### PR TITLE
ping msgpack; version 1.0.0 introduces breaking changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 import hysds
 
 setup(
-    name='hysds',
+    name="hysds",
     version=hysds.__version__,
     long_description=hysds.__description__,
     url=hysds.__url__,
@@ -14,21 +14,38 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'redis>=3.2.1', 'celery>=4.4.0', 'requests>=2.20.0',
-        'flower>=0.8.2', 'eventlet>=0.17.2', 'easywebdav>=1.2.0',
-        'lxml>=3.4.0', 'httplib2>=0.9', 'gevent>=1.0.1', 
-        'psutil>=2.1.3', 'filechunkio>=1.6.0', 'boto>=2.38.0',
-        'msgpack>=0.6.1', 'awscli>=1.17.1', 'boto3>=1.11.1', 
-        'backoff>=1.3.1', 'protobuf>=3.1.0.post1', 'google-cloud>=0.22.0', 
-        'google-cloud-monitoring>=0.22.0', 'osaka>=0.0.1', 
-        'prov_es>=0.2.0', 'hysds_commons>=0.1', 'atomicwrites>=1.1.5',
-        'future>=0.17.1', 'greenlet>=0.4.15', 'fabric3', 'pytz',
-        'pytest', 'tabulate>=0.8.6'
+        "redis>=3.2.1",
+        "celery>=4.4.0",
+        "requests>=2.20.0",
+        "flower>=0.8.2",
+        "eventlet>=0.17.2",
+        "easywebdav>=1.2.0",
+        "lxml>=3.4.0",
+        "httplib2>=0.9",
+        "gevent>=1.0.1",
+        "psutil>=2.1.3",
+        "filechunkio>=1.6.0",
+        "boto>=2.38.0",
+        # TODO: remove msgpack pin once logstash is updated to 7.1.1
+        # https://hysds-core.atlassian.net/browse/HC-168
+        "msgpack==0.6.2",
+        "awscli>=1.17.1",
+        "boto3>=1.11.1",
+        "backoff>=1.3.1",
+        "protobuf>=3.1.0.post1",
+        "google-cloud>=0.22.0",
+        "google-cloud-monitoring>=0.22.0",
+        "osaka>=0.0.1",
+        "prov_es>=0.2.0",
+        "hysds_commons>=0.1",
+        "atomicwrites>=1.1.5",
+        "future>=0.17.1",
+        "greenlet>=0.4.15",
+        "fabric3",
+        "pytz",
+        "pytest",
+        "tabulate>=0.8.6",
     ],
-    setup_requires=[
-        'pytest-runner'
-    ],
-    tests_require=[
-        'pytest'
-    ]
+    setup_requires=["pytest-runner"],
+    tests_require=["pytest"],
 )


### PR DESCRIPTION
@DustinKLo: Please review. In order for development of HySDS core v3 to continue concurrent to HySDS core v4 development, we need to pin msgpack in `develop` since `develop` is technically still HySDS core v3 (logstash 1.5.5). This fix isn't needed in `develop-es7` branch but should be merged in from `develop` once this PR is merged so as to maintain the branch history (i.e. when we finally merge `develop-es7` into `develop` we won't have to worry about resolving this conflict).  