### PR TITLE
Develop es7 (#52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.idea

--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -67,7 +67,7 @@ JOBS_ES_URL = "http://{{ MOZART_ES_PVT_IP }}:9200"
 JOBS_PROCESSED_QUEUE = "jobs_processed"
 USER_RULES_JOB_QUEUE = "user_rules_job"
 ON_DEMAND_JOB_QUEUE = "on_demand_job"
-USER_RULES_JOB_INDEX = "user_rules"
+USER_RULES_JOB_INDEX = "user_rules-mozart"
 STATUS_ALIAS = "job_status"
 
 TOSCA_URL = "https://{{ GRQ_PVT_IP }}/search/"
@@ -75,11 +75,15 @@ GRQ_URL = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}"
 GRQ_REST_URL = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.1"
 GRQ_UPDATE_URL = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.1/grq/dataset/index"
 GRQ_ES_URL = "http://{{ GRQ_ES_PVT_IP }}:9200"
+
 DATASET_PROCESSED_QUEUE = "dataset_processed"
 USER_RULES_DATASET_QUEUE = "user_rules_dataset"
 ON_DEMAND_DATASET_QUEUE = "on_demand_dataset"
-USER_RULES_DATASET_INDEX = "user_rules"
+USER_RULES_DATASET_INDEX = "user_rules-grq"
 DATASET_ALIAS = "grq"
+
+HYSDS_IOS_MOZART = "hysds_ios-mozart"
+HYSDS_IOS_GRQ = "hysds_ios-grq"
 
 USER_RULES_TRIGGER_QUEUE = "user_rules_trigger"
 

--- a/configs/logstash/event_status.template
+++ b/configs/logstash/event_status.template
@@ -1,61 +1,83 @@
 {
   "mappings": {
-    "event": {
-      "properties": {
-        "resource": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "type": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "status": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "timestamp": {
-          "type": "date", 
-          "format": "YYYY-MM-dd HH:mm:ss,SSS"
-        }, 
-        "hostname": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "uuid": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "tags": {
-          "type": "multi_field",
-          "fields": {
-            "tags": { "type": "string", "index": "analyzed" },
-            "untouched": { "type": "string", "index": "not_analyzed" }
+    "properties": {
+      "resource": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "type": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "status": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "timestamp": {
+        "type": "date"
+      },
+      "hostname": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "uuid": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "tags": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
         },
-        "event" : {
-          "type" : "object",
-          "enabled" : false
-        }
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "event": {
+        "type": "object",
+        "enabled": false
+      },
+      "text_fields": {
+        "type": "text"
       }
     }
-  }, 
-  "template": "event_status*",
+  },
+  "index_patterns": [
+    "event_status*"
+  ],
   "settings": {
+    "index.refresh_interval": "5s",
     "analysis": {
       "analyzer": {
         "default": {
           "filter": [
-            "standard", 
-            "lowercase", 
+            "lowercase",
             "word_delimiter"
-          ], 
+          ],
           "tokenizer": "keyword"
         }
       }
     }
   },
-  "aliases" : {
-    "job_status" : {}
+  "aliases": {
+    "job_status": {}
   }
 }

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -12,57 +12,64 @@ input {
   }
 }
 
+filter {
+  if [resource] in ["worker", "task"] {
+    mutate {
+      convert => {
+        "[event][timestamp]" => "string"
+        "[event][local_received]" => "string"
+      }
+
+      split => ["[event][timestamp]", "."]
+      split => ["[event][local_received]", "."]
+
+      add_field => [ "[event][timestamp_new]" , "%{[event][timestamp][0]}" ]
+      add_field => [ "[event][local_received_new]" , "%{[event][local_received][0]}" ]
+
+      remove_field => ["[event][timestamp]", "[event][local_received]"]
+    }
+
+    mutate {
+      rename => { "[event][timestamp_new]" => "timestamp" }
+      rename => { "[event][local_received_new]" => "local_received" }
+    }
+  }
+}
+
 output {
   #stdout { codec => rubydebug }
 
   if [resource] == "job" {
     elasticsearch {
-      protocol => "transport"
-      host => "{{ MOZART_ES_PVT_IP }}"
-      cluster => "{{ cluster_jobs }}"
+      hosts => ["{{ MOZART_ES_PVT_IP }}:9200"]
       index => "job_status-current"
       document_id => "%{payload_id}"
-      document_type => "%{resource}"
       template => "{{ OPS_HOME }}/mozart/etc/job_status.template"
       template_name => "job_status"
-      flush_size => 1
     }
   } else if [resource] == "worker" {
     elasticsearch {
-      protocol => "transport"
-      host => "{{ MOZART_ES_PVT_IP }}"
-      cluster => "{{ cluster_jobs }}"
+      hosts => ["{{ MOZART_ES_PVT_IP }}:9200"]
       index => "worker_status-current"
       document_id => "%{celery_hostname}"
-      document_type => "%{resource}"
       template => "{{ OPS_HOME }}/mozart/etc/worker_status.template"
       template_name => "worker_status"
-      flush_size => 1
     }
   } else if [resource] == "task" {
     elasticsearch {
-      protocol => "transport"
-      host => "{{ MOZART_ES_PVT_IP }}"
-      cluster => "{{ cluster_jobs }}"
+      hosts => ["{{ MOZART_ES_PVT_IP }}:9200"]
       index => "task_status-current"
       document_id => "%{uuid}"
-      document_type => "%{resource}"
       template => "{{ OPS_HOME }}/mozart/etc/task_status.template"
       template_name => "task_status"
-      flush_size => 1
     }
   } else if [resource] == "event" {
     elasticsearch {
-      protocol => "transport"
-      host => "{{ MOZART_ES_PVT_IP }}"
-      cluster => "{{ cluster_jobs }}"
+      hosts => ["{{ MOZART_ES_PVT_IP }}:9200"]
       index => "event_status-current"
       document_id => "%{uuid}"
-      document_type => "%{resource}"
       template => "{{ OPS_HOME }}/mozart/etc/event_status.template"
       template_name => "event_status"
-      flush_size => 1
     }
-  } else {
-  }
+  } else {}
 }

--- a/configs/logstash/job_status.template
+++ b/configs/logstash/job_status.template
@@ -1,477 +1,668 @@
 {
   "mappings": {
-    "job": {
-      "properties": {
-        "resource": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "type": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "status": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "timestamp": {
-          "type": "date", 
-          "format": "YYYY-MM-dd HH:mm:ss,SSS"
-        }, 
-        "context" : {
-          "type" : "object",
-          "enabled" : false
-        },
-        "job": {
-          "properties": {
-            "container_image_name": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "container_image_url": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "context" : {
-              "type" : "object",
-              "enabled" : false
-            },
-            "priority": {
-              "type": "integer"
-            },
-            "delivery_info": {
-              "properties": {
-                "priority": {
-                  "type": "integer"
-                },
-                "routing_key": {
-                  "index": "not_analyzed", 
-                  "type": "string"
-                },
-                "exchange": {
-                  "index": "not_analyzed", 
-                  "type": "string"
-                },
-                "redelivered": {
-                  "type": "boolean"
-                }
+    "properties": {
+      "resource": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "type": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "status": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "timestamp": {
+        "type": "date"
+      },
+      "context": {
+        "type": "object",
+        "enabled": false
+      },
+      "job": {
+        "properties": {
+          "container_image_name": {
+            "type": "keyword",
+            "ignore_above": 256,
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "container_image_url": {
+            "type": "keyword",
+            "ignore_above": 256,
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "context": {
+            "type": "object",
+            "enabled": false
+          },
+          "priority": {
+            "type": "integer"
+          },
+          "delivery_info": {
+            "properties": {
+              "priority": {
+                "type": "integer"
+              },
+              "routing_key": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "copy_to": [
+                  "text_fields"
+                ]
+              },
+              "exchange": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "copy_to": [
+                  "text_fields"
+                ]
+              },
+              "redelivered": {
+                "type": "boolean"
               }
-            },
-            "job_info": {
-              "properties": {
-                "context" : {
-                  "type" : "object",
-                  "enabled" : false
-                },
-                "payload" : {
-                  "type" : "object",
-                  "enabled" : false
-                },
-                "payload_hash": {
-                  "index": "not_analyzed", 
-                  "type": "string"
-                },
-                "dedup": {
-                  "type": "boolean"
-                },
-                "dedup_job": {
-                  "index": "not_analyzed", 
-                  "type": "string"
-                },
-                "job_queue": {
-                  "index": "not_analyzed", 
-                  "type": "string"
-                }, 
-                "status": {
-                  "type": "integer"
-                }, 
-                "time_start": {
-                  "type": "date", 
-                  "format": "dateOptionalTime"
-                }, 
-                "error_queue": {
-                  "index": "not_analyzed", 
-                  "type": "string"
-                }, 
-                "completed_queue": {
-                  "index": "not_analyzed", 
-                  "type": "string"
-                }, 
-                "execute_node": {
-                  "index": "not_analyzed", 
-                  "type": "string"
-                }, 
-                "time_queued": {
-                  "type": "date", 
-                  "format": "dateOptionalTime"
-                }, 
-                "job_status_exchange": {
-                  "index": "not_analyzed", 
-                  "type": "string"
-                }, 
-                "job_dir": {
-                  "index": "not_analyzed", 
-                  "type": "string"
-                }, 
-                "time_end": {
-                  "type": "date", 
-                  "format": "dateOptionalTime"
-                }, 
-                "cmd_start": {
-                  "type": "date", 
-                  "format": "dateOptionalTime"
-                }, 
-                "cmd_end": {
-                  "type": "date", 
-                  "format": "dateOptionalTime"
-                }, 
-                "cmd_duration": {
-                  "type": "double"
-                }, 
-                "public_ip": {
-                  "index": "not_analyzed", 
-                  "type": "string"
-                }, 
-                "facts": {
-                  "properties": {
-                    "swapsize": {
-                      "index": "not_analyzed", 
-                      "type": "string"
-                    }, 
-                    "ec2_instance_type": {
-                      "index": "not_analyzed", 
-                      "type": "string"
-                    }, 
-                    "is_virtual": {
-                      "index": "not_analyzed", 
-                      "type": "string"
-                    }, 
-                    "architecture": {
-                      "index": "not_analyzed", 
-                      "type": "string"
-                    }, 
-                    "ec2_placement_availability_zone": {
-                      "index": "not_analyzed", 
-                      "type": "string"
-                    }, 
-                    "memorytotal": {
-                      "index": "not_analyzed", 
-                      "type": "string"
-                    }, 
-                    "virtual": {
-                      "index": "not_analyzed", 
-                      "type": "string"
-                    }, 
-                    "physicalprocessorcount": {
-                      "index": "not_analyzed", 
-                      "type": "string"
-                    }, 
-                    "ec2_ami_id": {
-                      "index": "not_analyzed", 
-                      "type": "string"
-                    }, 
-                    "processorcount": {
-                      "index": "not_analyzed", 
-                      "type": "string"
-                    }
-                  }
-                }, 
-                "host": {
-                  "index": "not_analyzed", 
-                  "type": "string"
-                }, 
-                "job_url": {
-                  "index": "not_analyzed", 
-                  "type": "string"
-                }, 
-                "metrics": {
-                  "properties": {
-                    "inputs_localized": {
-                      "properties": {
-                        "disk_usage": {
-                          "index": "not_analyzed", 
-                          "type": "string"
-                        }, 
-                        "time_start": {
-                          "type": "date", 
-                          "format": "dateOptionalTime"
-                        }, 
-                        "url": {
-                          "index": "not_analyzed", 
-                          "type": "string"
-                        }, 
-                        "time_end": {
-                          "type": "date", 
-                          "format": "dateOptionalTime"
-                        }, 
-                        "duration": {
-                          "type": "double"
-                        }, 
-                        "transfer_rate": {
-                          "type": "double"
-                        }, 
-                        "path": {
-                          "index": "not_analyzed", 
-                          "type": "string"
-                        }
-                      }
-                    }, 
-                    "products_staged": {
-                      "properties": {
-                        "path": {
-                          "index": "not_analyzed", 
-                          "type": "string"
-                        },
-                        "disk_usage": {
-                          "index": "not_analyzed", 
-                          "type": "string"
-                        }, 
-                        "time_start": {
-                          "type": "date", 
-                          "format": "dateOptionalTime"
-                        }, 
-                        "time_end": {
-                          "type": "date", 
-                          "format": "dateOptionalTime"
-                        }, 
-                        "duration": {
-                          "type": "double"
-                        }, 
-                        "transfer_rate": {
-                          "type": "double"
-                        }, 
-                        "id": {
-                          "index": "not_analyzed", 
-                          "type": "string"
-                        },
-                        "urls": {
-                          "index": "not_analyzed", 
-                          "type": "string"
-                        },
-                        "browse_urls": {
-                          "index": "not_analyzed", 
-                          "type": "string"
-                        },
-                        "dataset": {
-                          "index": "not_analyzed", 
-                          "type": "string"
-                        },
-                        "ipath": {
-                          "index": "not_analyzed", 
-                          "type": "string"
-                        },
-                        "system_version": {
-                          "index": "not_analyzed", 
-                          "type": "string"
-                        },
-                        "dataset_level": {
-                          "index": "not_analyzed", 
-                          "type": "string"
-                        },
-                        "dataset_type": {
-                          "index": "not_analyzed", 
-                          "type": "string"
-                        }
-                      }
-                    }, 
-                    "job_dir_size": {
-                      "index": "not_analyzed", 
-                      "type": "string"
-                    },
-                    "product_provenance": {
-                      "properties": {
-                        "product_type": {
-                          "index": "not_analyzed", 
-                          "type": "string"
-                        },
-                        "acquisition_start_time": {
-                          "type": "date", 
-                          "format": "dateOptionalTime"
-                        }, 
-                        "source_production_time": {
-                          "type": "date", 
-                          "format": "dateOptionalTime"
-                        }, 
-                        "availability_time": {
-                          "type": "date", 
-                          "format": "dateOptionalTime"
-                        }, 
-                        "processing_start_time": {
-                          "type": "date", 
-                          "format": "dateOptionalTime"
-                        }, 
-                        "ground_system_latency": {
-                          "type": "double"
-                        }, 
-                        "access_latency": {
-                          "type": "double"
-                        }, 
-                        "processing_latency": {
-                          "type": "double"
-                        }, 
-                        "total_latency": {
-                          "type": "double"
-                        }, 
-                        "location": {
-                          "tree": "quadtree",
-                          "type": "geo_shape",
-                          "precision": "1m"
-                        } 
-                      }
-                    }
-                  }
-                }, 
-                "duration": {
-                  "type": "double"
-                }, 
-                "id": {
-                  "index": "not_analyzed", 
-                  "type": "string"
-                }, 
-                "job_payload": {
-                  "properties": {
-                    "job_type": {
-                      "index": "not_analyzed", 
-                      "type": "string"
-                    },
-                    "payload_task_id": {
-                      "index": "not_analyzed", 
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }, 
-            "localize_urls" : {
-              "type" : "object",
-              "enabled" : false
-            },
-            "params" : {
-              "type" : "object",
-              "enabled" : false
-            },
-            "type": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "name": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "job_id": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "task_id": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "tag": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "username": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "job_hash": {
-              "index": "not_analyzed", 
-              "type": "string"
             }
-          }
-        }, 
-        "uuid": {
-          "index": "not_analyzed", 
-          "type": "string"
-        },
-        "job_id": {
-          "index": "not_analyzed", 
-          "type": "string"
-        },
-        "payload_id": {
-          "index": "not_analyzed", 
-          "type": "string"
-        },
-        "payload_hash": {
-          "index": "not_analyzed", 
-          "type": "string"
-        },
-        "dedup": {
-          "type": "boolean"
-        },
-        "dedup_job": {
-          "index": "not_analyzed", 
-          "type": "string"
-        },
-        "dedup_msg": {
-          "type": "string"
-        },
-        "error": {
-          "type": "multi_field",
-          "fields": {
-            "error": { "type": "string", "index": "analyzed" },
-            "untouched": { "type": "string", "index": "not_analyzed" }
-          }
-        },
-        "short_error": {
-          "type": "multi_field",
-          "fields": {
-            "short_error": { "type": "string", "index": "analyzed" },
-            "untouched": { "type": "string", "index": "not_analyzed" }
-          }
-        },
-        "traceback": {
-          "type": "string"
-        },
-        "signum": {
-          "type": "integer"
-        },
-        "celery_hostname": {
-          "index": "not_analyzed", 
-          "type": "string"
-        },
-        "celery_timestamp": {
-          "type": "date"
-        },
-        "celery_pid": {
-          "type": "integer"
-        },
-        "celery_runtime": {
-          "type": "double"
-        },
-        "tags": {
-          "type": "multi_field",
-          "fields": {
-            "tags": { "type": "string", "index": "analyzed" },
-            "untouched": { "type": "string", "index": "not_analyzed" }
-          }
-        },
-        "user_tags": {
-          "type": "multi_field",
-          "fields": {
-            "user_tags": { "type": "string", "index": "analyzed" },
-            "untouched": { "type": "string", "index": "not_analyzed" }
+          },
+          "job_info": {
+            "properties": {
+              "context": {
+                "type": "object",
+                "enabled": false
+              },
+              "payload": {
+                "type": "object",
+                "enabled": false
+              },
+              "payload_hash": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "copy_to": [
+                  "text_fields"
+                ]
+              },
+              "dedup": {
+                "type": "boolean"
+              },
+              "dedup_job": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "copy_to": [
+                  "text_fields"
+                ]
+              },
+              "job_queue": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "copy_to": [
+                  "text_fields"
+                ]
+              },
+              "status": {
+                "type": "integer"
+              },
+              "time_start": {
+                "type": "date"
+              },
+              "error_queue": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "copy_to": [
+                  "text_fields"
+                ]
+              },
+              "completed_queue": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "copy_to": [
+                  "text_fields"
+                ]
+              },
+              "execute_node": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "copy_to": [
+                  "text_fields"
+                ]
+              },
+              "time_queued": {
+                "type": "date"
+              },
+              "job_status_exchange": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "copy_to": [
+                  "text_fields"
+                ]
+              },
+              "job_dir": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "copy_to": [
+                  "text_fields"
+                ]
+              },
+              "time_end": {
+                "type": "date"
+              },
+              "cmd_start": {
+                "type": "date"
+              },
+              "cmd_end": {
+                "type": "date"
+              },
+              "cmd_duration": {
+                "type": "double"
+              },
+              "public_ip": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "copy_to": [
+                  "text_fields"
+                ]
+              },
+              "facts": {
+                "properties": {
+                  "swapsize": {
+                    "type": "keyword",
+                    "ignore_above": 256,
+                    "copy_to": [
+                      "text_fields"
+                    ]
+                  },
+                  "ec2_instance_type": {
+                    "type": "keyword",
+                    "ignore_above": 256,
+                    "copy_to": [
+                      "text_fields"
+                    ]
+                  },
+                  "is_virtual": {
+                    "type": "keyword",
+                    "ignore_above": 256,
+                    "copy_to": [
+                      "text_fields"
+                    ]
+                  },
+                  "architecture": {
+                    "type": "keyword",
+                    "ignore_above": 256,
+                    "copy_to": [
+                      "text_fields"
+                    ]
+                  },
+                  "ec2_placement_availability_zone": {
+                    "type": "keyword",
+                    "ignore_above": 256,
+                    "copy_to": [
+                      "text_fields"
+                    ]
+                  },
+                  "memorytotal": {
+                    "type": "keyword",
+                    "ignore_above": 256,
+                    "copy_to": [
+                      "text_fields"
+                    ]
+                  },
+                  "virtual": {
+                    "type": "keyword",
+                    "ignore_above": 256,
+                    "copy_to": [
+                      "text_fields"
+                    ]
+                  },
+                  "physicalprocessorcount": {
+                    "type": "keyword",
+                    "ignore_above": 256,
+                    "copy_to": [
+                      "text_fields"
+                    ]
+                  },
+                  "ec2_ami_id": {
+                    "type": "keyword",
+                    "ignore_above": 256,
+                    "copy_to": [
+                      "text_fields"
+                    ]
+                  },
+                  "processorcount": {
+                    "type": "keyword",
+                    "ignore_above": 256,
+                    "copy_to": [
+                      "text_fields"
+                    ]
+                  }
+                }
+              },
+              "host": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "copy_to": [
+                  "text_fields"
+                ]
+              },
+              "job_url": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "copy_to": [
+                  "text_fields"
+                ]
+              },
+              "metrics": {
+                "properties": {
+                  "inputs_localized": {
+                    "properties": {
+                      "disk_usage": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                        "copy_to": [
+                          "text_fields"
+                        ]
+                      },
+                      "time_start": {
+                        "type": "date"
+                      },
+                      "url": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                        "copy_to": [
+                          "text_fields"
+                        ]
+                      },
+                      "time_end": {
+                        "type": "date"
+                      },
+                      "duration": {
+                        "type": "double"
+                      },
+                      "transfer_rate": {
+                        "type": "double"
+                      },
+                      "path": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                        "copy_to": [
+                          "text_fields"
+                        ]
+                      }
+                    }
+                  },
+                  "products_staged": {
+                    "properties": {
+                      "path": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                        "copy_to": [
+                          "text_fields"
+                        ]
+                      },
+                      "disk_usage": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                        "copy_to": [
+                          "text_fields"
+                        ]
+                      },
+                      "time_start": {
+                        "type": "date"
+                      },
+                      "time_end": {
+                        "type": "date"
+                      },
+                      "duration": {
+                        "type": "double"
+                      },
+                      "transfer_rate": {
+                        "type": "double"
+                      },
+                      "id": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                        "copy_to": [
+                          "text_fields"
+                        ]
+                      },
+                      "urls": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                        "copy_to": [
+                          "text_fields"
+                        ]
+                      },
+                      "browse_urls": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                        "copy_to": [
+                          "text_fields"
+                        ]
+                      },
+                      "dataset": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                        "copy_to": [
+                          "text_fields"
+                        ]
+                      },
+                      "ipath": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                        "copy_to": [
+                          "text_fields"
+                        ]
+                      },
+                      "system_version": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                        "copy_to": [
+                          "text_fields"
+                        ]
+                      },
+                      "dataset_level": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                        "copy_to": [
+                          "text_fields"
+                        ]
+                      },
+                      "dataset_type": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                        "copy_to": [
+                          "text_fields"
+                        ]
+                      }
+                    }
+                  },
+                  "job_dir_size": {
+                    "type": "keyword",
+                    "ignore_above": 256,
+                    "copy_to": [
+                      "text_fields"
+                    ]
+                  },
+                  "product_provenance": {
+                    "properties": {
+                      "product_type": {
+                        "type": "keyword",
+                        "ignore_above": 256,
+                        "copy_to": [
+                          "text_fields"
+                        ]
+                      },
+                      "acquisition_start_time": {
+                        "type": "date"
+                      },
+                      "source_production_time": {
+                        "type": "date"
+                      },
+                      "availability_time": {
+                        "type": "date"
+                      },
+                      "processing_start_time": {
+                        "type": "date"
+                      },
+                      "ground_system_latency": {
+                        "type": "double"
+                      },
+                      "access_latency": {
+                        "type": "double"
+                      },
+                      "processing_latency": {
+                        "type": "double"
+                      },
+                      "total_latency": {
+                        "type": "double"
+                      },
+                      "location": {
+                        "type": "geo_shape",
+                        "strategy": "recursive"
+                      }
+                    }
+                  }
+                }
+              },
+              "duration": {
+                "type": "double"
+              },
+              "id": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "copy_to": [
+                  "text_fields"
+                ]
+              },
+              "job_payload": {
+                "properties": {
+                  "job_type": {
+                    "type": "keyword",
+                    "ignore_above": 256,
+                    "copy_to": [
+                      "text_fields"
+                    ]
+                  },
+                  "payload_task_id": {
+                    "type": "keyword",
+                    "ignore_above": 256,
+                    "copy_to": [
+                      "text_fields"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "localize_urls": {
+            "type": "object",
+            "enabled": false
+          },
+          "params": {
+            "type": "object",
+            "enabled": false
+          },
+          "type": {
+            "type": "keyword",
+            "ignore_above": 256,
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "name": {
+            "type": "keyword",
+            "ignore_above": 256,
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "job_id": {
+            "type": "keyword",
+            "ignore_above": 256,
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "task_id": {
+            "type": "keyword",
+            "ignore_above": 256,
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "tag": {
+            "type": "keyword",
+            "ignore_above": 256,
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "username": {
+            "type": "keyword",
+            "ignore_above": 256,
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "job_hash": {
+            "type": "keyword",
+            "ignore_above": 256,
+            "copy_to": [
+              "text_fields"
+            ]
           }
         }
+      },
+      "uuid": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "job_id": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "payload_id": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "payload_hash": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "dedup": {
+        "type": "boolean"
+      },
+      "dedup_job": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "dedup_msg": {
+        "type": "text",
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "error": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        },
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "short_error": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        },
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "traceback": {
+        "type": "text",
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "signum": {
+        "type": "integer"
+      },
+      "celery_hostname": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "celery_timestamp": {
+        "type": "date"
+      },
+      "celery_pid": {
+        "type": "integer"
+      },
+      "celery_runtime": {
+        "type": "double"
+      },
+      "tags": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        },
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "user_tags": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        },
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "text_fields": {
+        "type": "text"
       }
     }
-  }, 
-  "template": "job_status*",
+  },
+  "index_patterns": [
+    "job_status*"
+  ],
   "settings": {
+    "index.refresh_interval": "5s",
     "analysis": {
       "analyzer": {
         "default": {
           "filter": [
-            "standard", 
-            "lowercase", 
+            "lowercase",
             "word_delimiter"
-          ], 
+          ],
           "tokenizer": "keyword"
         }
       }
     }
   },
-  "aliases" : {
-    "job_status" : {}
+  "aliases": {
+    "job_status": {}
   }
 }

--- a/configs/logstash/task_status.template
+++ b/configs/logstash/task_status.template
@@ -1,107 +1,132 @@
 {
   "mappings": {
-    "task": {
-      "properties": {
-        "resource": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "type": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "status": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "tags": {
-          "type": "multi_field",
-          "fields": {
-            "tags": { "type": "string", "index": "analyzed" },
-            "untouched": { "type": "string", "index": "not_analyzed" }
-          }
-        },
-        "celery_hostname": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "uuid": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "event": {
-          "properties": {
-            "sw_sys": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "local_received": {
-              "type": "date", 
-              "format": "dateOptionalTime"
-            }, 
-            "clock": {
-              "type": "integer"
-            }, 
-            "timestamp": {
-              "type": "date", 
-              "format": "dateOptionalTime"
-            }, 
-            "hostname": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "pid": {
-              "type": "integer"
-            }, 
-            "sw_ver": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "utcoffset": {
-              "type": "integer"
-            }, 
-            "loadavg": {
-              "type": "double"
-            }, 
-            "processed": {
-              "type": "integer"
-            }, 
-            "active": {
-              "type": "integer"
-            }, 
-            "freq": {
-              "type": "double"
-            }, 
-            "type": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "sw_ident": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }
+    "properties": {
+      "resource": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "type": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "status": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "tags": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
         }
+      },
+      "celery_hostname": {
+        "type": "text",
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "uuid": {
+        "type": "text",
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "event": {
+        "properties": {
+          "sw_sys": {
+            "type": "text",
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "local_received": {
+            "type": "date"
+          },
+          "clock": {
+            "type": "integer"
+          },
+          "timestamp": {
+            "type": "date"
+          },
+          "hostname": {
+            "type": "text",
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "pid": {
+            "type": "integer"
+          },
+          "sw_ver": {
+            "type": "text",
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "utcoffset": {
+            "type": "integer"
+          },
+          "loadavg": {
+            "type": "double"
+          },
+          "processed": {
+            "type": "integer"
+          },
+          "active": {
+            "type": "integer"
+          },
+          "freq": {
+            "type": "double"
+          },
+          "type": {
+            "type": "text",
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "sw_ident": {
+            "type": "text",
+            "copy_to": [
+              "text_fields"
+            ]
+          }
+        }
+      },
+      "text_fields": {
+        "type": "text"
       }
     }
-  }, 
-  "template": "task_status*",
+  },
+  "index_patterns": [
+    "task_status*"
+  ],
   "settings": {
     "analysis": {
       "analyzer": {
         "default": {
           "filter": [
-            "standard", 
-            "lowercase", 
+            "lowercase",
             "word_delimiter"
-          ], 
+          ],
           "tokenizer": "keyword"
         }
       }
     }
   },
-  "aliases" : {
-    "task_status" : {},
-    "job_status" : {}
+  "aliases": {
+    "task_status": {},
+    "job_status": {}
   }
 }

--- a/configs/logstash/worker_status.template
+++ b/configs/logstash/worker_status.template
@@ -1,107 +1,132 @@
 {
   "mappings": {
-    "worker": {
-      "properties": {
-        "resource": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "type": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "status": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "tags": {
-          "type": "multi_field",
-          "fields": {
-            "tags": { "type": "string", "index": "analyzed" },
-            "untouched": { "type": "string", "index": "not_analyzed" }
-          }
-        },
-        "celery_hostname": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "uuid": {
-          "index": "not_analyzed", 
-          "type": "string"
-        }, 
-        "event": {
-          "properties": {
-            "sw_sys": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "local_received": {
-              "type": "date", 
-              "format": "dateOptionalTime"
-            }, 
-            "clock": {
-              "type": "integer"
-            }, 
-            "timestamp": {
-              "type": "date", 
-              "format": "dateOptionalTime"
-            }, 
-            "hostname": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "pid": {
-              "type": "integer"
-            }, 
-            "sw_ver": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "utcoffset": {
-              "type": "integer"
-            }, 
-            "loadavg": {
-              "type": "double"
-            }, 
-            "processed": {
-              "type": "integer"
-            }, 
-            "active": {
-              "type": "integer"
-            }, 
-            "freq": {
-              "type": "double"
-            }, 
-            "type": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }, 
-            "sw_ident": {
-              "index": "not_analyzed", 
-              "type": "string"
-            }
+    "properties": {
+      "resource": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "type": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "status": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "tags": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
           }
         }
+      },
+      "celery_hostname": {
+        "type": "text",
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "uuid": {
+        "type": "text",
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "event": {
+        "properties": {
+          "sw_sys": {
+            "type": "text",
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "local_received": {
+            "type": "date"
+          },
+          "clock": {
+            "type": "integer"
+          },
+          "timestamp": {
+            "type": "date"
+          },
+          "hostname": {
+            "type": "text",
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "pid": {
+            "type": "integer"
+          },
+          "sw_ver": {
+            "type": "text",
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "utcoffset": {
+            "type": "integer"
+          },
+          "loadavg": {
+            "type": "double"
+          },
+          "processed": {
+            "type": "integer"
+          },
+          "active": {
+            "type": "integer"
+          },
+          "freq": {
+            "type": "double"
+          },
+          "type": {
+            "type": "text",
+            "copy_to": [
+              "text_fields"
+            ]
+          },
+          "sw_ident": {
+            "type": "text",
+            "copy_to": [
+              "text_fields"
+            ]
+          }
+        }
+      },
+      "text_fields": {
+        "type": "text"
       }
     }
-  }, 
-  "template": "worker_status*",
+  },
+  "index_patterns": [
+    "worker_status*"
+  ],
   "settings": {
     "analysis": {
       "analyzer": {
         "default": {
           "filter": [
-            "standard", 
-            "lowercase", 
+            "lowercase",
             "word_delimiter"
-          ], 
+          ],
           "tokenizer": "keyword"
         }
       }
     }
   },
-  "aliases" : {
-    "worker_status" : {},
-    "job_status" : {}
+  "aliases": {
+    "worker_status": {},
+    "job_status": {}
   }
 }

--- a/configs/supervisor/supervisord.conf.mozart
+++ b/configs/supervisor/supervisord.conf.mozart
@@ -108,7 +108,7 @@ startsecs=10
 [program:logstash_indexer]
 directory={{ OPS_HOME }}/logstash/bin
 environment=LS_HEAP_SIZE="2048m"
-command={{ OPS_HOME }}/logstash/bin/logstash agent -f {{ OPS_HOME }}/mozart/etc/indexer.conf
+command={{ OPS_HOME }}/logstash/bin/logstash -f {{ OPS_HOME }}/mozart/etc/indexer.conf
 process_name=%(program_name)s
 priority=1
 numprocs=1

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-__version__ = "0.3.8"
+
+__version__ = "0.4.0"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/es_util.py
+++ b/hysds/es_util.py
@@ -1,0 +1,29 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+from hysds.celery import app
+from hysds.log_utils import logger
+
+try:
+    from hysds_commons.elasticsearch_utils import ElasticsearchUtility
+except (ImportError, ModuleNotFoundError):
+    logger.error('Cannot import hysds_commons.elasticsearch_utils')
+
+MOZART_ES = None
+GRQ_ES = None
+
+
+def get_mozart_es():
+    global MOZART_ES
+    if MOZART_ES is None:
+        MOZART_ES = ElasticsearchUtility(app.conf.JOBS_ES_URL, logger)
+    return MOZART_ES
+
+
+def get_grq_es():
+    global GRQ_ES
+    if GRQ_ES is None:
+        GRQ_ES = ElasticsearchUtility(app.conf.GRQ_ES_URL, logger)
+    return GRQ_ES

--- a/hysds/orchestrator.py
+++ b/hysds/orchestrator.py
@@ -2,12 +2,11 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-
-
 from builtins import open
 from builtins import super
 from future import standard_library
 standard_library.install_aliases()
+
 import os
 import sys
 import re
@@ -26,11 +25,9 @@ from inspect import getargspec
 from celery import uuid
 
 from hysds.celery import app
-from hysds.log_utils import (logger, log_job_status, backoff_max_tries,
-                             backoff_max_value, ensure_hard_time_limit_gap)
+from hysds.log_utils import (logger, log_job_status, backoff_max_tries, backoff_max_value, ensure_hard_time_limit_gap)
 from hysds.job_worker import run_job
-from hysds.utils import (error_handler, get_short_error, get_payload_hash,
-                         query_dedup_job)
+from hysds.utils import (error_handler, get_short_error, get_payload_hash, query_dedup_job)
 from hysds.user_rules_dataset import queue_dataset_evaluation
 
 
@@ -402,10 +399,7 @@ def submit_job(j):
     return results
 
 
-@backoff.on_exception(backoff.expo,
-                      socket.error,
-                      max_tries=backoff_max_tries,
-                      max_value=backoff_max_value)
+@backoff.on_exception(backoff.expo, socket.error, max_tries=backoff_max_tries, max_value=backoff_max_value)
 def do_submit_job(job_json, job_queue):
     """Submit job wrapper with exponential backoff and full jitter."""
 

--- a/hysds/user_rules_dataset.py
+++ b/hysds/user_rules_dataset.py
@@ -2,205 +2,162 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-
-
 from future import standard_library
 standard_library.install_aliases()
-import os
-import sys
+
 import json
-import requests
 import copy
 import time
-import types
 import backoff
 import socket
-import traceback
 
 import hysds
 from hysds.celery import app
 from hysds.log_utils import logger, backoff_max_tries, backoff_max_value
+from hysds.es_util import get_mozart_es, get_grq_es
+
+from elasticsearch import ElasticsearchException
+
+GRQ_ES_URL = app.conf.GRQ_ES_URL  # ES
+DATASET_ALIAS = app.conf.DATASET_ALIAS
+USER_RULES_DATASET_INDEX = app.conf.USER_RULES_DATASET_INDEX
+
+JOBS_PROCESSED_QUEUE = app.conf.JOBS_PROCESSED_QUEUE  # queue names
+USER_RULES_TRIGGER_QUEUE = app.conf.USER_RULES_TRIGGER_QUEUE
+USER_RULES_DATASET_QUEUE = app.conf.USER_RULES_DATASET_QUEUE
+
+mozart_es = get_mozart_es()
+grq_es = get_grq_es()
 
 
-@backoff.on_exception(backoff.expo,
-                      Exception,
-                      max_tries=backoff_max_tries,
-                      max_value=backoff_max_value)
-def ensure_dataset_indexed(objectid, system_version, es_url, alias):
+@backoff.on_exception(backoff.expo, Exception, max_tries=backoff_max_tries, max_value=backoff_max_value)
+def ensure_dataset_indexed(objectid, system_version, alias):
     """Ensure dataset is indexed."""
-
     query = {
-        "query": {
-            "bool": {
-                "must": [
-                    {'term': {'_id': objectid}},
-                    {'term': {'system_version.raw': system_version}}
-                ]
-            }
-        },
-        "fields": [],
+      "query": {
+        "bool": {
+          "must": [
+            {'term': {'_id': objectid}},
+            {'term': {'system_version.keyword': system_version}}
+          ]
+        }
+      }
     }
-    logger.info("ensure_dataset_indexed query: %s" %
-                json.dumps(query, indent=2))
-    if es_url.endswith('/'):
-        search_url = '%s%s/_search' % (es_url, alias)
-    else:
-        search_url = '%s/%s/_search' % (es_url, alias)
-    logger.info("ensure_dataset_indexed url: %s" % search_url)
-    r = requests.post(search_url, data=json.dumps(query))
-    logger.info("ensure_dataset_indexed status: %s" % r.status_code)
-    r.raise_for_status()
-    result = r.json()
-    logger.info("ensure_dataset_indexed result: %s" %
-                json.dumps(result, indent=2))
-    total = result['hits']['total']
-    if total == 0:
-        raise RuntimeError("Failed to find indexed dataset: {} ({})".format(
-            objectid, system_version))
+    logger.info("ensure_dataset_indexed query: %s" % json.dumps(query, indent=2))
+
+    try:
+        count = grq_es.get_count(alias, query)
+        if count == 0:
+            error_message = "Failed to find indexed dataset: %s (%s)" % (objectid, system_version)
+            logger.error(error_message)
+            raise RuntimeError(error_message)
+        logger.info("Found indexed dataset: %s (%s)" % (objectid, system_version))
+
+    except ElasticsearchException as e:
+        logger.error("Unable to execute query")
+        logger.error(e)
 
 
 def update_query(objectid, system_version, rule):
-    """Update final query."""
-
-    # build query
-    query = rule['query']
+    """
+    Update final query.
+    TLDR: takes the rule's query and adds system version and dataset's id to "filter" in "bool"
+    """
+    updated_query = copy.deepcopy(rule['query'])  # build query
 
     # filters
     filts = [
-        {'term': {'system_version.raw': system_version}}
+        {'term': {'system_version.keyword': system_version}}
     ]
 
-    # query all?
+    # query all? (will add _id if False)
     if rule.get('query_all', False) is False:
-        filts.append({'ids':  {'values': [objectid]}})
-
-    # build final query
-    if 'filtered' in query:
-        final_query = copy.deepcopy(query)
-        if 'and' in query['filtered']['filter']:
-            final_query['filtered']['filter']['and'].extend(filts)
-        else:
-            filts.append(final_query['filtered']['filter'])
-            final_query['filtered']['filter'] = {
-                'and': filts,
+        filts.append({
+            "term": {
+                "_id": objectid
             }
-    else:
-        final_query = {
-            'filtered': {
-                'query': query,
-                'filter': {
-                    'and': filts,
-                }
-            }
-        }
-    final_query = {"query": final_query}
-    logger.info("Final query: %s" % json.dumps(final_query, indent=2))
-    rule['query'] = final_query
-    rule['query_string'] = json.dumps(final_query)
+        })
+
+    updated_query['bool']['filter'] = filts
+    updated_query = {"query": updated_query}
+
+    logger.info("Final query: %s" % json.dumps(updated_query, indent=2))
+    rule['query'] = updated_query
+    rule['query_string'] = json.dumps(updated_query)
 
 
-def evaluate_user_rules_dataset(objectid, system_version,
-                                es_url=app.conf.GRQ_ES_URL,
-                                alias=app.conf.DATASET_ALIAS,
-                                user_rules_idx=app.conf.USER_RULES_DATASET_INDEX,
-                                job_queue=app.conf.JOBS_PROCESSED_QUEUE):
-    """Process all user rules in ES database and check if this objectid matches.
-       If so, submit jobs. Otherwise do nothing."""
+def evaluate_user_rules_dataset(objectid, system_version, alias=DATASET_ALIAS, job_queue=JOBS_PROCESSED_QUEUE):
+    """
+    Process all user rules in ES database and check if this objectid matches.
+    If so, submit jobs. Otherwise do nothing.
+    """
 
-    # sleep for 10 seconds; let any documents finish indexing in ES
-    time.sleep(10)
-
-    # ensure dataset is indexed
-    ensure_dataset_indexed(objectid, system_version, es_url, alias)
+    time.sleep(10)  # sleep for 10 seconds; let any documents finish indexing in ES
+    ensure_dataset_indexed(objectid, system_version, alias)  # ensure dataset is indexed
 
     # get all enabled user rules
-    query = {"query": {"term": {"enabled": True}}}
-    r = requests.post('%s/%s/.percolator/_search?search_type=scan&scroll=10m&size=100' %
-                      (es_url, user_rules_idx), data=json.dumps(query))
-    r.raise_for_status()
-    scan_result = r.json()
-    count = scan_result['hits']['total']
-    scroll_id = scan_result['_scroll_id']
-    rules = []
-    while True:
-        r = requests.post('%s/_search/scroll?scroll=10m' %
-                          es_url, data=scroll_id)
-        res = r.json()
-        scroll_id = res['_scroll_id']
-        if len(res['hits']['hits']) == 0:
-            break
-        for hit in res['hits']['hits']:
-            rules.append(hit['_source'])
-    logger.info("Got %d enabled rules to check." % len(rules))
+    query = {
+      "query": {
+        "term": {
+          "enabled": True
+        }
+      }
+    }
+    rules = mozart_es.query(USER_RULES_DATASET_INDEX, query)
 
-    # process rules
-    for rule in rules:
-        # sleep between queries
-        time.sleep(1)
+    for document in rules:
+        time.sleep(1)  # sleep between queries
+
+        rule = document['_source']
+        logger.info("rule: %s" % json.dumps(rule, indent=2))
+
+        update_query(objectid, system_version, rule)
+
+        rule_name = rule['rule_name']
+        job_type = rule['job_type']  # set clean descriptive job name
+        final_qs = rule['query_string']
+        logger.info("updated query: %s" % json.dumps(final_qs, indent=2))
 
         # check for matching rules
-        update_query(objectid, system_version, rule)
-        final_qs = rule['query_string']
         try:
-            r = requests.post('%s/%s/_search' % (es_url, alias), data=final_qs)
-            r.raise_for_status()
-        except:
-            logger.error("Failed to query ES. Got status code %d:\n%s" %
-                         (r.status_code, traceback.format_exc()))
-            continue
-        result = r.json()
-        if result['hits']['total'] == 0:
-            logger.info("Rule '%s' didn't match for %s (%s)" %
-                        (rule['rule_name'], objectid, system_version))
-            continue
-        else:
+            result = grq_es.es.search(index=alias, body=final_qs)
+            if result['hits']['total']['value'] == 0:
+                logger.info("Rule '%s' didn't match for %s (%s)" % (rule_name, objectid, system_version))
+                continue
             doc_res = result['hits']['hits'][0]
-        logger.info("Rule '%s' successfully matched for %s (%s)" %
-                    (rule['rule_name'], objectid, system_version))
-        #logger.info("doc_res: %s" % json.dumps(doc_res, indent=2))
+            logger.info("Rule '%s' successfully matched for %s (%s)" % (rule_name, objectid, system_version))
+        except ElasticsearchException as e:
+            logger.error("Failed to query ES")
+            logger.error(e)
+            continue
 
-        # set clean descriptive job name
-        job_type = rule['job_type']
         if job_type.startswith('hysds-io-'):
             job_type = job_type.replace('hysds-io-', '', 1)
         job_name = "%s-%s" % (job_type, objectid)
 
-        # submit trigger task
-        queue_dataset_trigger(doc_res, rule, es_url, job_name)
-        logger.info("Trigger task submitted for %s (%s): %s" %
-                    (objectid, system_version, rule['job_type']))
-
+        queue_dataset_trigger(doc_res, rule, job_name)  # submit trigger task
+        logger.info("Trigger task submitted for %s (%s): %s" % (objectid, system_version, job_type))
     return True
 
 
-@backoff.on_exception(backoff.expo,
-                      socket.error,
-                      max_tries=backoff_max_tries,
-                      max_value=backoff_max_value)
+@backoff.on_exception(backoff.expo, socket.error, max_tries=backoff_max_tries, max_value=backoff_max_value)
 def queue_dataset_evaluation(info):
     """Queue dataset id for user_rules_dataset evaluation."""
-
     payload = {
         'type': 'user_rules_dataset',
         'function': 'hysds.user_rules_dataset.evaluate_user_rules_dataset',
         'args': [info['id'], info['system_version']],
     }
-    hysds.task_worker.run_task.apply_async((payload,),
-                                           queue=app.conf.USER_RULES_DATASET_QUEUE)
+    hysds.task_worker.run_task.apply_async((payload,), queue=app.conf.USER_RULES_DATASET_QUEUE)
 
 
-@backoff.on_exception(backoff.expo,
-                      socket.error,
-                      max_tries=backoff_max_tries,
-                      max_value=backoff_max_value)
-def queue_dataset_trigger(doc_res, rule, es_url, job_name):
+@backoff.on_exception(backoff.expo, socket.error, max_tries=backoff_max_tries, max_value=backoff_max_value)
+def queue_dataset_trigger(doc_res, rule, job_name):
     """Trigger dataset rule execution."""
-
     payload = {
         'type': 'user_rules_trigger',
         'function': 'hysds_commons.job_utils.submit_mozart_job',
         'args': [doc_res, rule],
-        'kwargs': {'es_hysdsio_url': es_url, 'job_name': job_name},
+        'kwargs': {'job_name': job_name, 'component': 'grq'},
     }
-    hysds.task_worker.run_task.apply_async((payload,),
-                                           queue=app.conf.USER_RULES_TRIGGER_QUEUE)
+    hysds.task_worker.run_task.apply_async((payload,), queue=USER_RULES_TRIGGER_QUEUE)

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -2,60 +2,51 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-
-
 from future import standard_library
 standard_library.install_aliases()
-import os
-import sys
+
 import json
-import requests
 import time
 import backoff
 import socket
-import traceback
 
 import hysds
 from hysds.celery import app
 from hysds.log_utils import logger, backoff_max_tries, backoff_max_value
+from hysds.es_util import get_mozart_es
+
+from elasticsearch import ElasticsearchException
+
+JOBS_ES_URL = app.conf.JOBS_ES_URL  # ES
+STATUS_ALIAS = app.conf.STATUS_ALIAS
+USER_RULES_JOB_INDEX = app.conf.USER_RULES_JOB_INDEX
+
+JOBS_PROCESSED_QUEUE = app.conf.JOBS_PROCESSED_QUEUE  # queue names
+USER_RULES_TRIGGER_QUEUE = app.conf.USER_RULES_TRIGGER_QUEUE
+USER_RULES_JOB_QUEUE = app.conf.USER_RULES_JOB_QUEUE
+
+mozart_es = get_mozart_es()
 
 
-@backoff.on_exception(backoff.expo,
-                      Exception,
-                      max_tries=backoff_max_tries,
-                      max_value=backoff_max_value)
-def ensure_job_indexed(job_id, es_url, alias):
+@backoff.on_exception(backoff.expo, Exception, max_tries=backoff_max_tries, max_value=backoff_max_value)
+def ensure_job_indexed(job_id, alias):
     """Ensure job is indexed."""
-
     query = {
         "query": {
-            "bool": {
-                "must": [
-                    {'term': {'_id': job_id}}
-                ]
-            }
-        },
-        "fields": [],
+            'term': {
+                '_id': job_id
+             }
+        }
     }
     logger.info("ensure_job_indexed query: %s" % json.dumps(query, indent=2))
-    if es_url.endswith('/'):
-        search_url = '%s%s/_search' % (es_url, alias)
-    else:
-        search_url = '%s/%s/_search' % (es_url, alias)
-    logger.info("ensure_job_indexed url: %s" % search_url)
-    r = requests.post(search_url, data=json.dumps(query))
-    logger.info("ensure_job_indexed status: %s" % r.status_code)
-    r.raise_for_status()
-    result = r.json()
-    logger.info("ensure_job_indexed result: %s" % json.dumps(result, indent=2))
-    total = result['hits']['total']
+
+    total = mozart_es.get_count(alias, query)
     if total == 0:
         raise RuntimeError("Failed to find indexed job: {}".format(job_id))
 
 
 def get_job(job_id, rule, result):
     """Return generic json job configuration."""
-
     priority = rule.get('priority', 0)
     return {
         "job_type": "job:%s" % rule['job_type'],
@@ -69,139 +60,92 @@ def get_job(job_id, rule, result):
 
 
 def update_query(job_id, rule):
-    """Update final query."""
+    """
+    Update final query.
+    TLDR: takes the rule's query and adds system version and job's id to "filter" in "bool"
+    """
+    query = rule['query']  # build query
 
-    # build query
-    query = rule['query']
+    filts = []  # filters
 
-    # filters
-    filts = []
-
-    # query all?
     if rule.get('query_all', False) is False:
-        filts.append({'ids':  {'values': [job_id]}})
-
-    # build final query
-    if 'filtered' in query:
-        final_query = copy.deepcopy(query)
-        if 'and' in query['filtered']['filter']:
-            final_query['filtered']['filter']['and'].extend(filts)
-        else:
-            filts.append(final_query['filtered']['filter'])
-            final_query['filtered']['filter'] = {
-                'and': filts,
+        filts.append({
+            "term": {
+                "_id": job_id
             }
-    else:
-        final_query = {
-            'filtered': {
-                'query': query,
-                'filter': {
-                    'and': filts,
-                }
-            }
-        }
-    final_query = {"query": final_query}
-    logger.info("Final query: %s" % json.dumps(final_query, indent=2))
-    rule['query'] = final_query
-    rule['query_string'] = json.dumps(final_query)
+        })
+
+    query['bool']['filter'] = filts
+    query = {"query": query}
+
+    logger.info("Final query: %s" % json.dumps(query, indent=2))
+    rule['query'] = query
+    rule['query_string'] = json.dumps(query)
 
 
-def evaluate_user_rules_job(job_id, es_url=app.conf.JOBS_ES_URL,
-                            alias=app.conf.STATUS_ALIAS,
-                            user_rules_idx=app.conf.USER_RULES_JOB_INDEX,
-                            job_queue=app.conf.JOBS_PROCESSED_QUEUE):
+def evaluate_user_rules_job(job_id, alias=STATUS_ALIAS):
     """Process all user rules in ES database and check if this job ID matches.
        If so, submit jobs. Otherwise do nothing."""
 
-    # sleep 10 seconds to allow ES documents to be indexed
-    time.sleep(10)
-
-    # ensure job is indexed
-    ensure_job_indexed(job_id, es_url, alias)
+    time.sleep(10)  # sleep 10 seconds to allow ES documents to be indexed
+    ensure_job_indexed(job_id, alias)  # ensure job is indexed
 
     # get all enabled user rules
-    query = {"query": {"term": {"enabled": True}}}
-    r = requests.post('%s/%s/.percolator/_search?search_type=scan&scroll=10m&size=100' %
-                      (es_url, user_rules_idx), data=json.dumps(query))
-    r.raise_for_status()
-    scan_result = r.json()
-    count = scan_result['hits']['total']
-    scroll_id = scan_result['_scroll_id']
-    rules = []
-    while True:
-        r = requests.post('%s/_search/scroll?scroll=10m' %
-                          es_url, data=scroll_id)
-        res = r.json()
-        scroll_id = res['_scroll_id']
-        if len(res['hits']['hits']) == 0:
-            break
-        for hit in res['hits']['hits']:
-            rules.append(hit['_source'])
-    logger.info("Got %d enabled rules to check." % len(rules))
+    query = {
+        "query": {
+            "term": {"enabled": True}
+        }
+    }
 
-    # process rules
+    rules = mozart_es.query(USER_RULES_JOB_INDEX, query)
+    logger.info("Total %d enabled rules to check." % len(rules))
+
     for rule in rules:
-        # sleep between queries
-        time.sleep(1)
+        logger.info('rule: %s' % json.dumps(rule, indent=2))
+        rule = rule['_source']  # extracting _source from the rule itself
 
-        # check for matching rules
-        update_query(job_id, rule)
+        time.sleep(1)  # sleep between queries
+
+        update_query(job_id, rule)  # check for matching rules
         final_qs = rule['query_string']
+
         try:
-            r = requests.post('%s/job_status-current/job/_search' %
-                              es_url, data=final_qs)
-            r.raise_for_status()
-        except:
-            logger.error("Failed to query ES. Got status code %d:\n%s" %
-                         (r.status_code, traceback.format_exc()))
+            result = mozart_es.es.search(index=alias, body=final_qs)
+            if result['hits']['total']['value'] == 0:
+                logger.info("Rule '%s' didn't match for %s" % (rule['rule_name'], job_id))
+                continue
+        except ElasticsearchException as e:
+            logger.error("Failed to query ES")
+            logger.error(e)
             continue
-        result = r.json()
-        if result['hits']['total'] == 0:
-            logger.info("Rule '%s' didn't match for %s" %
-                        (rule['rule_name'], job_id))
-            continue
-        else:
-            doc_res = result['hits']['hits'][0]
-        logger.info("Rule '%s' successfully matched for %s" %
-                    (rule['rule_name'], job_id))
-        #logger.info("doc_res: %s" % json.dumps(doc_res, indent=2))
+
+        doc_res = result['hits']['hits'][0]
+        logger.info("Rule '%s' successfully matched for %s" % (rule['rule_name'], job_id))
 
         # submit trigger task
-        queue_job_trigger(doc_res, rule, es_url)
-        logger.info("Trigger task submitted for %s: %s" %
-                    (job_id, rule['job_type']))
-
+        queue_job_trigger(doc_res, rule)
+        logger.info("Trigger task submitted for %s: %s" % (job_id, rule['job_type']))
     return True
 
 
-@backoff.on_exception(backoff.expo,
-                      socket.error,
-                      max_tries=backoff_max_tries,
-                      max_value=backoff_max_value)
+@backoff.on_exception(backoff.expo, socket.error, max_tries=backoff_max_tries, max_value=backoff_max_value)
 def queue_finished_job(id):
     """Queue job id for user_rules_job evaluation."""
-
     payload = {
         'type': 'user_rules_job',
         'function': 'hysds.user_rules_job.evaluate_user_rules_job',
         'args': [id],
     }
-    hysds.task_worker.run_task.apply_async((payload,),
-                                           queue=app.conf.USER_RULES_JOB_QUEUE)
+    hysds.task_worker.run_task.apply_async((payload,), queue=USER_RULES_JOB_QUEUE)
 
 
-@backoff.on_exception(backoff.expo,
-                      socket.error,
-                      max_tries=backoff_max_tries,
-                      max_value=backoff_max_value)
-def queue_job_trigger(doc_res, rule, es_url):
+@backoff.on_exception(backoff.expo, socket.error, max_tries=backoff_max_tries, max_value=backoff_max_value)
+def queue_job_trigger(doc_res, rule):
     """Trigger job rule execution."""
-
     payload = {
         'type': 'user_rules_trigger',
         'function': 'hysds_commons.job_utils.submit_mozart_job',
         'args': [doc_res, rule],
-        'kwargs': {'es_hysdsio_url': es_url},
+        'kwargs': {'component': 'mozart'},
     }
-    hysds.task_worker.run_task.apply_async((payload,),
-                                           queue=app.conf.USER_RULES_TRIGGER_QUEUE)
+    hysds.task_worker.run_task.apply_async((payload,), queue=USER_RULES_TRIGGER_QUEUE)

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -335,8 +335,7 @@ def get_payload_hash(payload):
                                   ensure_ascii=True).encode()).hexdigest()
 
 
-@backoff.on_exception(backoff.expo, requests.exceptions.RequestException,
-                      max_tries=8, max_value=32)
+@backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=8, max_value=32)
 def query_dedup_job(dedup_key, filter_id=None, states=None):
     """
     Return job IDs with matching dedup key defined in states
@@ -351,51 +350,55 @@ def query_dedup_job(dedup_key, filter_id=None, states=None):
     query = {
         "sort": [{"job.job_info.time_queued": {"order": "asc"}}],
         "size": 1,
-        "fields": ["_id", "status"],
+        "_source": ["_id", "status"],
         "query": {
-            "filtered": {
-                "filter": {
-                    "bool": {
-                        "must": {
-                            "term": {
-                                "payload_hash": dedup_key
-                            }
+            "bool": {
+                "must": [
+                    {"term": {"payload_hash": dedup_key}},
+                    {
+                        "bool": {
+                            "should": [{
+                                "terms": {
+                                    "status": states  # should be an list
+                                }
+                            }]
                         }
                     }
-                }
+                ]
             }
         }
     }
-    for state in states:
-        query['query']['filtered']['filter']['bool'].setdefault('should', []).append({
-            "term": {
-                "status": state
-            }
-        })
+
     if filter_id is not None:
-        query['query']['filtered']['filter']['bool']['must_not'] = {
+        query['query']['bool']['must_not'] = {
             "term": {
                 "uuid": filter_id
             }
         }
+
+    logger.info("constructed query: %s" % json.dumps(query, indent=2))
     es_url = "%s/job_status-current/_search" % app.conf['JOBS_ES_URL']
-    r = requests.post(es_url, data=json.dumps(query))
+
+    headers = {'Content-Type': 'application/json'}
+    r = requests.post(es_url, data=json.dumps(query), headers=headers)
     if r.status_code != 200:
         if r.status_code == 404:
-            pass
+            logger.info("status_code 404, job_status-current index probably does not exist, returning None")
+            return None
         else:
             r.raise_for_status()
-    hits = []
     j = r.json()
-    if j.get('hits', {}).get('total', 0) == 0:
+    logger.info("result: %s" % r.text)
+    if j['hits']['total']['value'] == 0:
         return None
     else:
         hit = j['hits']['hits'][0]
-        logger.info("Found duplicate job: %s" %
-                    json.dumps(hit, indent=2, sort_keys=True))
-        return {'_id': hit['_id'],
-                'status': hit['fields']['status'][0],
-                'query_timestamp': datetime.utcnow().isoformat()}
+        logger.info("Found duplicate job: %s" % json.dumps(hit, indent=2, sort_keys=True))
+        return {
+            '_id': hit['_id'],
+            'status': hit['_source']['status'][0],
+            'query_timestamp': datetime.utcnow().isoformat()
+        }
 
 
 @backoff.on_exception(backoff.expo, requests.exceptions.RequestException,
@@ -411,8 +414,7 @@ def get_job_status(id):
     return result['fields']['status'][0] if result['found'] else None
 
 
-@backoff.on_exception(backoff.expo, requests.exceptions.RequestException,
-                      max_tries=8, max_value=32)
+@backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=8, max_value=32)
 def check_dataset(id, es_index="grq"):
     """Query for dataset with specified input ID."""
 
@@ -423,27 +425,27 @@ def check_dataset(id, es_index="grq"):
                     {"term": {"_id": id}},
                 ]
             }
-        },
-        "fields": [],
+        }
     }
     es_url = app.conf['GRQ_ES_URL']
     if es_url.endswith('/'):
-        search_url = '%s%s/_search' % (es_url, es_index)
+        search_url = '%s%s/_count' % (es_url, es_index)
     else:
-        search_url = '%s/%s/_search' % (es_url, es_index)
-    r = requests.post(search_url, data=json.dumps(query))
+        search_url = '%s/%s/_count' % (es_url, es_index)
+
+    headers = {'Content-Type': 'application/json'}
+    r = requests.post(search_url, data=json.dumps(query), headers=headers)
     if r.status_code == 200:
         result = r.json()
-        total = result['hits']['total']
+        return result['count']
     else:
         logger.warn("Failed to query %s:\n%s" % (es_url, r.text))
         logger.warn("query: %s" % json.dumps(query, indent=2))
         logger.warn("returned: %s" % r.text)
         if r.status_code == 404:
-            total = 0
+            return 0
         else:
             r.raise_for_status()
-    return total
 
 
 def dataset_exists(id, es_index="grq"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,8 +27,8 @@ decorator==4.4.1
 dnspython==1.16.0
 docutils==0.15.2
 easywebdav==1.2.0
-elasticsearch==1.9.0
-elasticsearch-dsl==0.0.11
+elasticsearch>=7.0.0,<8.0.0
+elasticsearch-dsl>=7.0.0,<8.0.0
 eventlet==0.25.1
 Fabric3==1.14.post1
 filechunkio==1.6


### PR DESCRIPTION
* Hc 142 user rules (#43)

* created deprecated folder to add older user rules py files

* removed .idea/

* edited gitignore

* refactored user_rules_dataset.py to use elasticsearch library

.raw -> .keyword
TODO: need to fix update_query function to be compatible with ES7

* fixed comment

* fixed update query in user_rule_dataset.py to be compatible with ES7

* added hysdsio argument in user_rules_job.queue_job_trigger

* removed 'hysdsio': '_doc' from user_rules_job.py

* extra space is bothering me

* Hc 153 logstash (#46)

* bump version

* edited indexer.conf.template

edited job_status.template

TODO: edit other index mapping templates

* removed unused parameters from indexer.conf.template

* edited template for event_status

* fixed mapping template for eventn and worker

* fixed indexer.conf and removed 'template' key from index templates

* edited indexer.conf with filter to parse timestamp and local_received to be compaitble with elasticsearch date fields

* added pip install -e . to .circleci/config.yml

* added index_template field to the logstash template mappings

* consolidated mapping types in task and worker so it will not break the frontend

* updated version in __init__.py to 0.4.0

Co-authored-by: Gerald Manipon <pymonger@gmail.com>

* Hc 159 user rules (#47)

* fixed evaluate_user_rules_job, job_dedup ot be compatible with es7

cosmetic changes to user_rules_dataset function

* moved states variable to query in query_dedup

* edited .circleci file

* edited .circleci file

* edited .circleci file

* edited .circleci file

* edited .circleci file

* edited .circleci file

* edited .circleci file

* edited .circleci file

* edited .circleci file

* edited .circleci file

* edited .circleci file

* edited .circleci file

* edited .circleci file

* edited .circleci file

* Hc 163 container builder (#48)

* edited user_rule index names for both GRQ and mozart

initialized ElasticsearchUtility (for mozart and GRQ) in hysds/__init__.py
refactored user_rules_dataset.py and user_rules_job.py to use ES wrapper class
code clean up
removed hysds/deprecated since we wont need legacy code anymore

* added notes on some TODOs

* refactored user_rules_dataset and user_rules_job to pass component=(mozart or grq) to submit_mozart_job in hysds_commons

* added mozart and grq HYSDS_IOS index in celery app config

* removed TODO from orcehstrator.py

* fixed circleci to run with HC-163 branch

* moved moved hysds_commons intall to top of circleci config

* moved source bash_profile to top

* added 'setters' for elasticsearch_utils so it wont force initialize, edited circleci

* safe import on hysds/__init__.py

* safe import on hysds/__init__.py

* safe import on hysds/__init__.py

* moved get_mozart_es and get_grq_es out of __init__.py and into es_util.py

* removed celery import app from __init__.py

* fixed import statement in user_rules_job and user_rules_dataset.py

* fixed import statement in user_rules_job and user_rules_dataset.py

* fixed url in get_grq_es()

* removed agent from logstash command in supervisord

* fixed check_datasets in utils

* additional logging

* fixed check_dataset

* query_dedup returns None is job_status-current index doesnt exist

* circleci fix

* removed circleci block

Co-authored-by: Gerald Manipon <pymonger@gmail.com>