### PR TITLE
HC-205: add revoked task check

### DIFF
--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -32,7 +32,8 @@ from celery.signals import task_revoked
 import hysds
 from hysds.celery import app
 from hysds.log_utils import (logger, log_job_status, log_job_info, get_job_status,
-                             log_task_worker, get_task_worker, get_worker_status, log_custom_event)
+                             log_task_worker, get_task_worker, get_worker_status,
+                             log_custom_event, is_revoked)
 
 from hysds.utils import (disk_space_info, get_threshold, get_disk_usage, get_func,
                          get_short_error, query_dedup_job, makedirs, find_dataset_json, find_cache_dir)
@@ -439,6 +440,10 @@ def fail_job(job_status_json, jd_file):
 @app.task
 def run_job(job, queue_when_finished=True):
     """Function to execute a job."""
+
+    # if revoked?
+    if is_revoked(run_job.request.id):
+        app.control.revoke(run_job.request.id, terminate=True)
 
     # get payload id
     payload_id = job['job_info']['job_payload']['payload_task_id']


### PR DESCRIPTION
In conjunction with the updates to `lightweight-jobs` (https://github.com/hysds/lightweight-jobs/pull/17), this PR update the `run_job()` function to check redis if its task id was marked as revoked. If it is marked as revoked, it fires the `revoke()` function so that the appropriate signal handler is executed.