### PR TITLE
Hc 199

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/event_processors.py
+++ b/hysds/event_processors.py
@@ -81,7 +81,7 @@ def offline_jobs(event):
     uuids = []
 
     try:
-        job_status_jsons = mozart_es.query("job_status-current", query)
+        job_status_jsons = mozart_es.query(index="job_status-current", body=query)
         logger.info("Got {} jobs for {}.".format(len(job_status_jsons), event["hostname"]))
 
         for job_status in job_status_jsons:

--- a/hysds/user_rules_dataset.py
+++ b/hysds/user_rules_dataset.py
@@ -42,10 +42,10 @@ def ensure_dataset_indexed(objectid, system_version, alias):
         }
       }
     }
-    logger.info("ensure_dataset_indexed query: %s" % json.dumps(query, indent=2))
+    logger.info("ensure_dataset_indexed query: %s" % json.dumps(query))
 
     try:
-        count = grq_es.get_count(alias, query)
+        count = grq_es.get_count(index=alias, body=query)
         if count == 0:
             error_message = "Failed to find indexed dataset: %s (%s)" % (objectid, system_version)
             logger.error(error_message)
@@ -108,7 +108,7 @@ def evaluate_user_rules_dataset(objectid, system_version, alias=DATASET_ALIAS, j
             }
         }
     }
-    rules = mozart_es.query(USER_RULES_DATASET_INDEX, query)
+    rules = mozart_es.query(index=USER_RULES_DATASET_INDEX, body=query)
     logger.info("Total %d enabled rules to check." % len(rules))
 
     for document in rules:
@@ -139,7 +139,7 @@ def evaluate_user_rules_dataset(objectid, system_version, alias=DATASET_ALIAS, j
                 continue
             doc_res = result['hits']['hits'][0]
             logger.info("Rule '%s' successfully matched for %s (%s)" % (rule_name, objectid, system_version))
-        except ElasticsearchException as e:
+        except (ElasticsearchException, Exception) as e:
             logger.error("Failed to query ES")
             logger.error(e)
             continue

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -31,9 +31,16 @@ mozart_es = get_mozart_es()
 @backoff.on_exception(backoff.expo, Exception, max_tries=backoff_max_tries, max_value=backoff_max_value)
 def ensure_job_indexed(job_id, alias):
     """Ensure job is indexed."""
-    logger.info("ensure_job_indexed: %s" % job_id)
-    job = mozart_es.get_by_id(index=alias, id=job_id)
-    if job['found'] is False:
+    query = {
+        "query": {
+            "term": {
+                "_id": job_id
+            }
+        }
+    }
+    logger.info("ensure_job_indexed: %s" % json.dumps(query))
+    count = mozart_es.get_count(index=alias, body=query)
+    if count == 0:
         raise RuntimeError("Failed to find indexed job: {}".format(job_id))
 
 

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -31,17 +31,9 @@ mozart_es = get_mozart_es()
 @backoff.on_exception(backoff.expo, Exception, max_tries=backoff_max_tries, max_value=backoff_max_value)
 def ensure_job_indexed(job_id, alias):
     """Ensure job is indexed."""
-    query = {
-        "query": {
-            'term': {
-                '_id': job_id
-             }
-        }
-    }
-    logger.info("ensure_job_indexed query: %s" % json.dumps(query, indent=2))
-
-    total = mozart_es.get_count(alias, query)
-    if total == 0:
+    logger.info("ensure_job_indexed: %s" % job_id)
+    job = mozart_es.get_by_id(index=alias, id=job_id)
+    if job['found'] is False:
         raise RuntimeError("Failed to find indexed job: {}".format(job_id))
 
 
@@ -105,7 +97,7 @@ def evaluate_user_rules_job(job_id, alias=STATUS_ALIAS):
             }
         }
     }
-    rules = mozart_es.query(USER_RULES_JOB_INDEX, query)
+    rules = mozart_es.query(index=USER_RULES_JOB_INDEX, body=query)
     logger.info("Total %d enabled rules to check." % len(rules))
 
     for rule in rules:


### PR DESCRIPTION
https://hysds-core.atlassian.net/browse/HC-199
- refactoring `hysds_common`'s `ElasticsearchUtility` to allow for more flexibility
- re-using hysds core's elasticsearch connection because it allows us to read/write to AWS elasticsearch (defined in `.sds/config` and `celeryconfig.py`)
- `lightweight-jobs` will use hysds-core's ES connection

https://github.com/hysds/hysds_commons/pull/26/files#diff-0177d5302571ecb822b51229be69453d

tested `on-demand` and `user_rules` processing in both tosca and figaro