### PR TITLE
fixed aws es_url

### DIFF
--- a/hysds/es_util.py
+++ b/hysds/es_util.py
@@ -40,7 +40,7 @@ def get_grq_es():
         if aws_es is True:
             aws_auth = BotoAWSRequestsAuth(aws_host=es_host, aws_region=region, aws_service='es')
             GRQ_ES = ElasticsearchUtility(
-                es_url=es_host,
+                es_url=es_url,
                 logger=logger,
                 http_auth=aws_auth,
                 connection_class=RequestsHttpConnection,


### PR DESCRIPTION
```
>>> from hysds.es_util import get_grq_es
>>> grq_es = get_grq_es()
/export/home/hysdsops/mozart/lib/python3.7/site-packages/elasticsearch/connection/http_requests.py:116: UserWarning: Connecting to https://vpce-#######-######.vpce-svc-#######.us-west-#.vpce.amazonaws.com:443 using SSL with verify_certs=False is insecure.
  % self.host
>>> grq_es.es.info()
{'name': '6a085e466b8afaf71ef350492e7e03cd', 'cluster_name': '271039147104:nisar-dev', 'cluster_uuid': 't_nlyhQDRNqvEu5GHBC8ng', 'version': {'number': '7.1.1', 'build_flavor': 'oss', 'build_type': 'tar', 'build_hash': '7a013de', 'build_date': '2019-09-05T07:25:23.525600Z', 'build_snapshot': False, 'lucene_version': '8.0.0', 'minimum_wire_compatibility_version': '6.8.0', 'minimum_index_compatibility_version': '6.0.0-beta1'}, 'tagline': 'You Know, for Search'}
```