### PR TITLE
cleaner way to Ignore SSL warnings

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/es_util.py
+++ b/hysds/es_util.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 from elasticsearch import RequestsHttpConnection
-import urllib3
 
 from hysds.celery import app
 from hysds.log_utils import logger
@@ -14,8 +13,6 @@ try:
     from hysds_commons.elasticsearch_utils import ElasticsearchUtility
 except (ImportError, ModuleNotFoundError):
     logger.error('Cannot import hysds_commons.elasticsearch_utils')
-
-urllib3.disable_warnings()
 
 MOZART_ES = None
 GRQ_ES = None
@@ -46,6 +43,7 @@ def get_grq_es():
                 connection_class=RequestsHttpConnection,
                 use_ssl=True,
                 verify_certs=False,
+                ssl_show_warn=False
             )
         else:
             GRQ_ES = ElasticsearchUtility(es_url, logger)


### PR DESCRIPTION
https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch
```
es = Elasticsearch(
    ['localhost:443', 'other_host:443'],
    # turn on SSL
    use_ssl=True,
    # no verify SSL certificates
    verify_certs=False,
    # don't show warnings about ssl certs verification
    ssl_show_warn=False
)
```