### PR TITLE
HC-215: handle datestring conversions without microseconds (backport to develop-es1)

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -2,6 +2,6 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-__version__ = "0.3.9"
+__version__ = "0.3.10"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -311,7 +311,10 @@ def pprintXml(et):
 def parse_iso8601(t):
     """Return datetime from ISO8601 string."""
 
-    return datetime.strptime(t, '%Y-%m-%dT%H:%M:%S.%fZ')
+    try:
+        return datetime.strptime(t, '%Y-%m-%dT%H:%M:%S.%fZ')
+    except ValueError:
+        return datetime.strptime(t, '%Y-%m-%dT%H:%M:%SZ')
 
 
 def get_short_error(e):
@@ -529,7 +532,7 @@ def publish_dataset(prod_dir, dataset_file, job, ctx):
     datasets_cfg_file = job['job_info']['datasets_cfg_file']
 
     # time start
-    time_start = datetime.strptime(time_start_iso, '%Y-%m-%dT%H:%M:%S.%fZ')
+    time_start = parse_iso8601(time_start_iso)
 
     # check for PROV-ES JSON from PGE; if exists, append related PROV-ES info;
     # also overwrite merged PROV-ES JSON file

--- a/requirements.txt
+++ b/requirements.txt
@@ -115,7 +115,7 @@ SQLObject==3.8.0
 supervisor==4.1.0
 tabulate==0.8.6
 tornado==5.1.1
-Twisted==19.10.0
+Twisted==20.3.0
 vine==1.3.0
 wcwidth==0.1.8
 webassets==2.0


### PR DESCRIPTION
- handle no microseconds
- mitigate CVE-2020-10108 and CVE-2020-10109
- bump version