### PR TITLE
HC-266: remove syncer script bootstrap mechanism

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/scripts/sync_ec2_target_tracking_metric.py
+++ b/scripts/sync_ec2_target_tracking_metric.py
@@ -54,14 +54,6 @@ def get_desired_capacity(asg):
     return groups[0]["DesiredCapacity"]
 
 
-def bootstrap_asg(asg):
-    """Bootstrap ASG's desired to 1."""
-
-    c = boto3.client("autoscaling")
-    r = c.set_desired_capacity(AutoScalingGroupName=asg, DesiredCapacity=1)
-    return 1
-
-
 def submit_metric(queue, asg, metric, metric_ns):
     """Submit EC2 custom metric data."""
 
@@ -104,13 +96,7 @@ def daemon(queue, asg, interval, namespace, user="guest", password="guest"):
             logging.info("jobs_waiting for %s queue: %s" % (queue, job_count))
             desired_capacity = float(get_desired_capacity(asg))
             if desired_capacity == 0:
-                if job_count > 0:
-                    desired_capacity = float(bootstrap_asg(asg))
-                    logging.info(
-                        "bootstrapped ASG %s to desired=%s" % (asg, desired_capacity)
-                    )
-                else:
-                    desired_capacity = 1.0
+                desired_capacity = 1.0
             metric = job_count / desired_capacity
             submit_metric(queue, asg, metric, namespace)
         except Exception as e:


### PR DESCRIPTION
Currently, the ec2 syncer script that updates CloudWatch metrics has to manually bootstrap the ASG because previously the target tracking capability needed at least one instance up in the ASG to scale up.

This PR removes that bootstrap mechanism so that the ASG can scale up immediately.

This PR was tested and verified on a NISAR dev cluster.