### PR TITLE
restore ASG bootstrap but modify for immediate scale-up

### DIFF
--- a/scripts/sync_ec2_target_tracking_metric.py
+++ b/scripts/sync_ec2_target_tracking_metric.py
@@ -58,10 +58,12 @@ def bootstrap_asg(asg, desired):
     """Bootstrap ASG's desired capacity."""
 
     c = boto3.client("autoscaling")
-    asgs = c.describe_auto_scaling_groups(AutoScalingGroupNames=[asg])['AutoScalingGroups']
+    asgs = c.describe_auto_scaling_groups(AutoScalingGroupNames=[asg])[
+        "AutoScalingGroups"
+    ]
     if len(asgs) == 0:
         raise RuntimeError("Failed to find ASG %s." % asg)
-    max_size = asgs[0]['MaxSize']
+    max_size = asgs[0]["MaxSize"]
     actual_desired = max_size if desired > max_size else desired
     r = c.set_desired_capacity(AutoScalingGroupName=asg, DesiredCapacity=actual_desired)
     return actual_desired
@@ -78,14 +80,8 @@ def submit_metric(queue, asg, metric, metric_ns):
             {
                 "MetricName": metric_name,
                 "Dimensions": [
-                    {
-                        "Name": "AutoScalingGroupName",
-                        "Value": asg,
-                    },
-                    {
-                        "Name": "Queue",
-                        "Value": queue,
-                    },
+                    {"Name": "AutoScalingGroupName", "Value": asg},
+                    {"Name": "Queue", "Value": queue},
                 ],
                 "Value": metric,
             }

--- a/scripts/sync_ec2_target_tracking_metric.py
+++ b/scripts/sync_ec2_target_tracking_metric.py
@@ -54,6 +54,14 @@ def get_desired_capacity(asg):
     return groups[0]["DesiredCapacity"]
 
 
+def bootstrap_asg(asg, desired):
+    """Bootstrap ASG's desired capacity."""
+
+    c = boto3.client("autoscaling")
+    r = c.set_desired_capacity(AutoScalingGroupName=asg, DesiredCapacity=desired)
+    return desired
+
+
 def submit_metric(queue, asg, metric, metric_ns):
     """Submit EC2 custom metric data."""
 
@@ -96,7 +104,13 @@ def daemon(queue, asg, interval, namespace, user="guest", password="guest"):
             logging.info("jobs_waiting for %s queue: %s" % (queue, job_count))
             desired_capacity = float(get_desired_capacity(asg))
             if desired_capacity == 0:
-                desired_capacity = 1.0
+                if job_count > 0:
+                    desired_capacity = float(bootstrap_asg(asg, job_count))
+                    logging.info(
+                        "bootstrapped ASG %s to desired=%s" % (asg, desired_capacity)
+                    )
+                else:
+                    desired_capacity = 1.0
             metric = job_count / desired_capacity
             submit_metric(queue, asg, metric, namespace)
         except Exception as e:


### PR DESCRIPTION
Previous update remove bootstrapping the ASG to 1 and relied on target tracking for initial scale up. However target tracking takes a few minutes to kick in on that initial scale up and adds latency to job execution. This hotfix restores the bootstrap functionality but bootstraps the ASG's `desired capacity == jobs waiting`.