### PR TITLE
HC-242: Resolved file name too long issue

### DIFF
--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -969,12 +969,3 @@ def validate_checksum_files(job, cxt):
     else:
         logger.info("checksum preprocessing completed successfully")
     return True
-
-if __name__ == '__main__':
-    with open("_job.json", "r") as f:
-        job = json.load(f)
-
-    with open("_context.json", "r") as f:
-        ctx = json.load(f)
-
-    triage(job, ctx)

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -696,34 +696,20 @@ def triage(job, ctx):
     else:
         triage_id_format = default_triage_id_format
 
-    if "_triage_id_regex" in ctx:
-        triage_id_regex = ctx["_triage_id_regex"]
-    else:
-        triage_id_regex = default_triage_id_regex
-
     # get job info
     job_dir = job["job_info"]["job_dir"]
     job_id = job["job_info"]["id"]
     logger.info("job id: {}".format(job_id))
 
     # Check if the job_id is a triaged dataset. If so, let's parse out the job_id
-    logger.info("Checking to see if the job_id matches the triage dataset regex: {}".format(triage_id_regex))
-    try:
-        match = re.search(triage_id_regex, job_id)
-    except Exception as e:
-        logger.warning(
-            "Failed to apply custom triage id regex because of {}: {}. Falling back to default triage regex".format(
-                e.__class__.__name__, e
-            )
-        )
-        match = re.search(default_triage_id_regex, job_id)
-
+    logger.info("Checking to see if the job_id matches the regex: {}".format(default_triage_id_regex))
+    match = re.search(default_triage_id_regex, job_id)
     if match:
         logger.info("job_id matches the triage dataset regex. Parsing out job_id")
         parsed_job_id = match.groupdict()["job_id"]
         logger.info("extracted job_id: {}".format(parsed_job_id))
     else:
-        logger.info("job_id does not match the triage dataset regex: {}".format(triage_id_regex))
+        logger.info("job_id does not match the triage dataset regex: {}".format(default_triage_id_regex))
         parsed_job_id = job_id
 
     # create triage dataset

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -704,12 +704,26 @@ def triage(job, ctx):
     # get job info
     job_dir = job["job_info"]["job_dir"]
     job_id = job["job_info"]["id"]
+    logger.info("job id: {}".format(job_id))
 
     # Check if the job_id is a triaged dataset. If so, let's parse out the job_id
-    match = re.search(triage_id_regex, job_id)
+    logger.info("Checking to see if the job_id matches the triage dataset regex: {}".format(triage_id_regex))
+    try:
+        match = re.search(triage_id_regex, job_id)
+    except Exception as e:
+        logger.warning(
+            "Failed to apply custom triage id regex because of {}: {}. Falling back to default triage regex".format(
+                e.__class__.__name__, e
+            )
+        )
+        match = re.search(default_triage_id_regex, job_id)
+
     if match:
+        logger.info("job_id matches the triage dataset regex. Parsing out job_id")
         parsed_job_id = match.groupdict()["job_id"]
+        logger.info("extracted job_id: {}".format(parsed_job_id))
     else:
+        logger.info("job_id does not match the triage dataset regex: {}".format(triage_id_regex))
         parsed_job_id = job_id
 
     # create triage dataset
@@ -969,3 +983,12 @@ def validate_checksum_files(job, cxt):
     else:
         logger.info("checksum preprocessing completed successfully")
     return True
+
+if __name__ == '__main__':
+    with open("_job.json", "r") as f:
+        job = json.load(f)
+
+    with open("_context.json", "r") as f:
+        ctx = json.load(f)
+
+    triage(job, ctx)

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -676,8 +676,8 @@ def triage(job, ctx):
         job["job_info"]["time_start"] = "{}Z".format(datetime.utcnow().isoformat("T"))
 
     # default triage id
-    default_triage_id_format = "triaged_job-{job_id}-task-{job[task_id]}"
-    default_triage_id_regex = "triaged_job-(?P<job_id>.+)-task-(?P<task_id>[-\\w])"
+    default_triage_id_format = "triaged_job-{job_id}_task-{job[task_id]}"
+    default_triage_id_regex = "triaged_job-(?P<job_id>.+)_task-(?P<task_id>[-\\w])"
 
     # if exit code of job command is zero, don't triage anything
     exit_code = job["job_info"]["status"]

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -72,11 +72,11 @@ class TestTriage(unittest.TestCase):
         # Expectations
         expected_triage_dataset_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
+            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
         )
         expected_triage_met_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
+            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
         )
         expected_triage_json_filename = self.job_dir + "/_triaged.json"
 
@@ -220,11 +220,11 @@ class TestTriage(unittest.TestCase):
         # Expectations
         expected_triage_dataset_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
+            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
         )
         expected_triage_met_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
+            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
         )
         expected_triage_json_filename = self.job_dir + "/_triaged.json"
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -374,6 +374,53 @@ class TestTriage(unittest.TestCase):
             len(glob.glob("{}/test.log*".format(expected_triage_dataset))) == 2
         )
 
+    def test_triage_on_triage_dataset(self):
+        import hysds.utils
+
+        # Test case data
+        job = {
+            "task_id": "2a9be25e-e281-4d3c-a7d8-e3c0c8342971",
+            "job_info": {
+                "id": "triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972",
+                "status": 1,
+                "job_dir": self.job_dir,
+                "time_start": "0001-01-01T00:00:00.000Z",
+                "context_file": "electric",
+                "datasets_cfg_file": "more/configuration",
+                "metrics": {"product_provenance": dict(), "products_staged": list()},
+            },
+        }
+
+        job_context = {"_triage_disabled": False}
+
+        # Mocked data
+        open_mock = umock.patch("hysds.utils.open", umock.mock_open()).start()
+        makedirs_mock = umock.patch("os.makedirs").start()
+        shutil_copy_mock = umock.patch("shutil.copy").start()
+        publish_dataset_mock = umock.patch("hysds.utils.publish_dataset").start()
+        publish_dataset_mock.return_value = {}
+
+        # Expectations
+        expected_triage_dataset_filename = (
+            self.job_dir
+            + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-2a9be25e-e281-4d3c-a7d8-e3c0c8342971.dataset.json"
+        )
+        expected_triage_met_filename = (
+            self.job_dir
+            + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-2a9be25e-e281-4d3c-a7d8-e3c0c8342971.met.json"
+        )
+        expected_triage_json_filename = self.job_dir + "/_triaged.json"
+
+        # Test execution
+        result = hysds.utils.triage(job, job_context)
+
+        # Assertions
+        self.assertTrue(result)
+
+        open_mock.assert_any_call(expected_triage_dataset_filename, umock.ANY)
+        open_mock.assert_any_call(expected_triage_met_filename, umock.ANY)
+        open_mock.assert_any_call(expected_triage_json_filename, umock.ANY)
+
 
 class TestUtils(unittest.TestCase):
     def setUp(self):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -278,11 +278,11 @@ class TestTriage(unittest.TestCase):
         # Expectations
         expected_triage_dataset_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
+            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
         )
         expected_triage_met_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
+            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
         )
         expected_triage_json_filename = self.job_dir + "/_triaged.json"
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -220,11 +220,11 @@ class TestTriage(unittest.TestCase):
         # Expectations
         expected_triage_dataset_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
+            + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
         )
         expected_triage_met_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
+            + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
         )
         expected_triage_json_filename = self.job_dir + "/_triaged.json"
 
@@ -278,11 +278,11 @@ class TestTriage(unittest.TestCase):
         # Expectations
         expected_triage_dataset_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
+            + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
         )
         expected_triage_met_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
+            + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
         )
         expected_triage_json_filename = self.job_dir + "/_triaged.json"
 
@@ -346,15 +346,15 @@ class TestTriage(unittest.TestCase):
 
         # Expectations
         expected_triage_dataset = (
-            self.job_dir + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972"
+            self.job_dir + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972"
         )
         expected_triage_dataset_filename = (
             expected_triage_dataset
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
+            + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
         )
         expected_triage_met_filename = (
             expected_triage_dataset
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
+            + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
         )
         expected_triage_json_filename = self.job_dir + "/_triaged.json"
         expected_triage_log_file1 = expected_triage_dataset + "/test.log"

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -72,11 +72,11 @@ class TestTriage(unittest.TestCase):
         # Expectations
         expected_triage_dataset_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
+            + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
         )
         expected_triage_met_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
+            + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
         )
         expected_triage_json_filename = self.job_dir + "/_triaged.json"
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -122,11 +122,11 @@ class TestTriage(unittest.TestCase):
         # Expectations
         expected_triage_dataset_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
+            + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.dataset.json"
         )
         expected_triage_met_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
+            + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972.met.json"
         )
         expected_triage_json_filename = self.job_dir + "/_triaged.json"
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -403,11 +403,11 @@ class TestTriage(unittest.TestCase):
         # Expectations
         expected_triage_dataset_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-2a9be25e-e281-4d3c-a7d8-e3c0c8342971.dataset.json"
+            + "/triaged_job-boogaloo_task-2a9be25e-e281-4d3c-a7d8-e3c0c8342971/triaged_job-boogaloo_task-2a9be25e-e281-4d3c-a7d8-e3c0c8342971.dataset.json"
         )
         expected_triage_met_filename = (
             self.job_dir
-            + "/triaged_job-boogaloo_task-da9be25e-e281-4d3c-a7d8-e3c0c8342972/triaged_job-boogaloo_task-2a9be25e-e281-4d3c-a7d8-e3c0c8342971.met.json"
+            + "/triaged_job-boogaloo_task-2a9be25e-e281-4d3c-a7d8-e3c0c8342971/triaged_job-boogaloo_task-2a9be25e-e281-4d3c-a7d8-e3c0c8342971.met.json"
         )
         expected_triage_json_filename = self.job_dir + "/_triaged.json"
 


### PR DESCRIPTION
This PR fixes an issue where essentially if you keep re-running a job on a triage dataset, you'll eventually get a `[Errno 36] File name too long` as the triage dataset name will keep getting longer for each run. This PR addresses the issue by adding a `task` identifier to the default triage dataset name: 

`triaged_job-{job_id}_task-{job[task_id]}`

Then, in the triage function, logic was added to check for a triage dataset name using the following regex:

`triaged_job-(?P<job_id>.+)_task-(?P<task_id>[-\\w])`

If we get a match, then the `job_id` is used as the job identifier instead of using the default `job["job_info"]["id"]`

The following screenshot shows the result of running a job on a triaged dataset. This demonstrates that all we're doing is updating the task id in the triaged dataset name:

![triaged-datasets-created](https://user-images.githubusercontent.com/42812746/92179046-ca4df380-edf8-11ea-8927-f7af70c1bdc5.png)

A unit test was also added to test this feature.

