### PR TITLE
HC-277: hotfix to explicitly set rotating indexes by date

### DIFF
--- a/configs/logstash/indexer.conf.metrics
+++ b/configs/logstash/indexer.conf.metrics
@@ -12,7 +12,7 @@ input {
 
     # add field to distinguish from sdswatch
     add_field => {
-      "@index" => "logstash"
+      "@index" => "logstash-%{+yyyy.MM.dd}"
     }
   }
 


### PR DESCRIPTION
Previous PR which added sdswatch indexer disabled auto rotating of indexes by date. Now we need to explicitly specify this.