### PR TITLE
locked celery version to >=4.4.0,<5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "redis>=3.2.1",
-        "celery>=4.4.0",
+        "celery>=4.4.0,<5.0.0",
         "requests>=2.20.0",
         "flower>=0.8.2",
         "eventlet>=0.17.2",


### PR DESCRIPTION
related ticket: https://hysds-core.atlassian.net/browse/HC-278

after locking the version, celery workers run as normal
```
$ supervisorctl status all
flower                                                                   RUNNING   pid 12810, uptime 0:00:23
instance_stats                                                           RUNNING   pid 12811, uptime 0:00:23
logstash_indexer                                                         RUNNING   pid 12812, uptime 0:00:23
mozart_job_management                                                    RUNNING   pid 12813, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-00                           RUNNING   pid 12814, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-01                           RUNNING   pid 12816, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-02                           RUNNING   pid 12818, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-03                           RUNNING   pid 12819, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-04                           RUNNING   pid 12820, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-05                           RUNNING   pid 12821, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-06                           RUNNING   pid 12823, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-07                           RUNNING   pid 12824, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-08                           RUNNING   pid 12826, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-09                           RUNNING   pid 12827, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-10                           RUNNING   pid 12828, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-11                           RUNNING   pid 12829, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-12                           RUNNING   pid 12830, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-13                           RUNNING   pid 12833, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-14                           RUNNING   pid 12834, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-15                           RUNNING   pid 12835, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-16                           RUNNING   pid 12836, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-17                           RUNNING   pid 12839, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-18                           RUNNING   pid 12840, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-19                           RUNNING   pid 12841, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-20                           RUNNING   pid 12842, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-21                           RUNNING   pid 12846, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-22                           RUNNING   pid 12847, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-23                           RUNNING   pid 12848, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-24                           RUNNING   pid 12849, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-25                           RUNNING   pid 12850, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-26                           RUNNING   pid 12856, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-27                           RUNNING   pid 12857, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-28                           RUNNING   pid 12858, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-29                           RUNNING   pid 12859, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-30                           RUNNING   pid 12860, uptime 0:00:23
orchestrator_datasets:orchestrator_datasets-31                           RUNNING   pid 12864, uptime 0:00:23
```