### PR TITLE
locked celery version for hysds v3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "redis>=3.2.1",
-        "celery>=4.4.0",
+        "celery>=4.4.0,<5.0.0",
         "requests>=2.20.0",
         "flower>=0.8.2",
         "eventlet>=0.17.2",


### PR DESCRIPTION
the `dev-e2e` nightly for hysds v3 is failing, i suspect its because of changes to celery

https://nisar-pcm-ci.jpl.nasa.gov/job/nightlies/job/v3/job/develop-es1/job/E2E-nisar-pcm-develop-baseline-pge/358/display/redirect