### PR TITLE
HC-313: extend product publishing metrics from manual ingests within the job

### DIFF
--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1250,6 +1250,11 @@ def run_job(job, queue_when_finished=True):
                 pge_metrics.get("download", [])
             )
 
+            # append product staging metrics
+            job["job_info"]["metrics"]["products_staged"].extend(
+                pge_metrics.get("upload", [])
+            )
+
         # add prov associations
         if len(job["job_info"]["metrics"]["inputs_localized"]) > 0:
             context["_prov"]["wasDerivedFrom"] = [


### PR DESCRIPTION
This PR enables the propagation of data publishing metrics from a manual call to `publish_datasets()` within the job docker container through to the job status JSON payload. Test and development is being performed internally on NISAR dev.