### PR TITLE
HC-300 Patch: Add logging messages wherever exceptions are caught

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.12"
+__version__ = "1.0.13"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/scripts/harikiri.py
+++ b/scripts/harikiri.py
@@ -88,7 +88,8 @@ def is_jobless(root_work, inactivity_secs, logger=None):
             if logger is not None:
                 try:
                     print((log_event(logger, "harikiri", "keep_alive_set", {}, [])))
-                except:
+                except Exception as e:
+                    logging.warning("Exception occurred while logging harikiri keep_alive_set: {}".format(str(e)))
                     pass
         logging.info("Keep-alive exists.")
         return
@@ -98,7 +99,8 @@ def is_jobless(root_work, inactivity_secs, logger=None):
             if logger is not None:
                 try:
                     print((log_event(logger, "harikiri", "keep_alive_unset", {}, [])))
-                except Exception:
+                except Exception as e:
+                    logging.warning("Exception occurred while logging harikiri keep_alive_unset: {}".format(str(e)))
                     pass
             logging.info("Keep-alive removed.")
 
@@ -283,14 +285,16 @@ def graceful_shutdown(as_group, spot_fleet, id, logger=None):
     try:
         logging.info("Stopping all docker containers.")
         os.system("/usr/bin/docker stop --time=30 $(/usr/bin/docker ps -aq)")
-    except Exception:
+    except Exception as e:
+        logging.warning("Exception occurred while stopping docker containers: {}".format(str(e)))
         pass
 
     # shutdown supervisord
     try:
         logging.info("Stopping supervisord.")
         call(["/usr/bin/sudo", "/usr/bin/systemctl", "stop", "supervisord"])
-    except Exception:
+    except Exception as e:
+        logging.warning("Exception occurred while stopping supervisord: {}".format(str(e)))
         pass
 
     # let supervisord shutdown its processes
@@ -317,7 +321,8 @@ def graceful_shutdown(as_group, spot_fleet, id, logger=None):
     if logger is not None:
         try:
             print((log_event(logger, "harikiri", "shutdown", {}, [])))
-        except Exception:
+        except Exception as e:
+            logging.warning("Exception occurred while logging harikiri shutdown: {}".format(str(e)))
             pass
     time.sleep(60)
 

--- a/scripts/harikiri_sqs.py
+++ b/scripts/harikiri_sqs.py
@@ -88,7 +88,8 @@ def is_jobless(root_work, inactivity_secs, logger=None):
             if logger is not None:
                 try:
                     print((log_event(logger, "harikiri", "keep_alive_set", {}, [])))
-                except:
+                except Exception as e:
+                    logging.warning("Exception occurred while logging harikiri keep_alive_set: {}".format(str(e)))
                     pass
         logging.info("Keep-alive exists.")
         return
@@ -98,7 +99,8 @@ def is_jobless(root_work, inactivity_secs, logger=None):
             if logger is not None:
                 try:
                     print((log_event(logger, "harikiri", "keep_alive_unset", {}, [])))
-                except:
+                except Exception as e:
+                    logging.warning("Exception occurred while logging harikiri keep_alive_unset: {}".format(str(e)))
                     pass
             logging.info("Keep-alive removed.")
 
@@ -253,14 +255,16 @@ def graceful_shutdown(id, logger=None):
     try:
         logging.info("Stopping all docker containers.")
         os.system("/usr/bin/docker stop --time=30 $(/usr/bin/docker ps -aq)")
-    except Exception:
+    except Exception as e:
+        logging.warning("Exception occurred while stopping docker containers: {}".format(str(e)))
         pass
 
     # shutdown supervisord
     try:
         logging.info("Stopping supervisord.")
         call(["/usr/bin/sudo", "/usr/bin/systemctl", "stop", "supervisord"])
-    except Exception:
+    except Exception as e:
+        logging.warning("Exception occurred while stopping supervisord: {}".format(str(e)))
         pass
 
     # let supervisord shutdown its processes
@@ -293,7 +297,8 @@ def graceful_shutdown(id, logger=None):
     if logger is not None:
         try:
             print((log_event(logger, "harikiri", "shutdown", {}, [])))
-        except Exception:
+        except Exception as e:
+            logging.warning("Exception occurred while logging harikiri shutdown: {}".format(str(e)))
             pass
 
     time.sleep(3600)

--- a/scripts/spot_termination_detector.py
+++ b/scripts/spot_termination_detector.py
@@ -81,31 +81,34 @@ def graceful_shutdown(url, term_time):
             )
         )
         logging.info("Finished logging a 'marked_for_termination' event. Termination time: {}".format(term_time))
-    except Exception:
+    except Exception as e:
+        logging.warning("Exception occurred while logging the 'marked_for_termination' event: {}".format(str(e)))
         pass
 
     # stop docker containers
     try:
         logging.info("Stopping all docker containers.")
         os.system("/usr/bin/docker stop --time=30 $(/usr/bin/docker ps -aq)")
-    except Exception:
+    except Exception as e:
+        logging.warning("Exception occurred while stopping docker containers: {}".format(str(e)))
         pass
 
     # shutdown supervisord
     try:
         logging.info("Stopping supervisord.")
         call(["/usr/bin/sudo", "/usr/bin/systemctl", "stop", "supervisord"])
-    except Exception:
+    except Exception as e:
+        logging.warning("Exception occurred while stopping supervisord: {}".format(str(e)))
         pass
 
     # die
     sys.exit(0)
 
 
-def daemon(url, check_interval):
+def spot_termination_detector(url, check_interval):
     """Check for spot termination notice."""
 
-    logging.info("configuration:")
+    logging.info("spot_termination_detector configuration:")
     logging.info("mozart_rest_url=%s" % url)
     logging.info("check=%d" % check_interval)
 
@@ -159,4 +162,4 @@ if __name__ == "__main__":
     if check is None:
         check = 60
 
-    daemon(mozart_rest_url, check)
+    spot_termination_detector(mozart_rest_url, check)

--- a/scripts/spot_termination_detector.py
+++ b/scripts/spot_termination_detector.py
@@ -55,7 +55,7 @@ def check_spot_termination():
     """Check if instance is marked for spot termination."""
 
     r = requests.get("http://169.254.169.254/latest/meta-data/spot/termination-time")
-    # logging.info("got status code: %d" % r.status_code)
+    logging.info("check_spot_termination response status code: %d" % r.status_code)
     if r.status_code == 200:
         return r.content.decode()
     else:


### PR DESCRIPTION
This PR will add logging messages wherever exceptions are being caught,
but proceeding onward. This will help us in the future in case issues
arise.

Also updated the function name from `daemon` to `spot_termination_detector` for better readability in the logs. Right
now it shows it like this:

```
Feb  5 00:03:30 ip-172-31-27-171 bash: [2021-02-05 00:03:30,216:
INFO/daemon] configuration:

Feb  5 00:03:30 ip-172-31-27-171 bash: [2021-02-05 00:03:30,216:
INFO/daemon] mozart_rest_url=https://100.64.122.239/mozart/api/v0.1

Feb  5 00:03:30 ip-172-31-27-171 bash: [2021-02-05 00:03:30,216:
INFO/daemon] check=30
```