### PR TITLE
HC-273: provision SDSWatch client on PCM components: mozart, metrics, and grq

### DIFF
--- a/configs/logstash/sdswatch_client-pcm.conf
+++ b/configs/logstash/sdswatch_client-pcm.conf
@@ -1,0 +1,61 @@
+input {
+  file {
+    path => ["/sdswatch/log/*.sdswatch.log"]
+    start_position => "beginning"
+    type => "pcm"
+  }
+}
+
+
+
+filter {
+  if [type] == "pcm" { # [type] returns the value of field "type"
+    csv {
+      source => "message" # parse csv format in [message]
+      separator => "," 
+      columns => ["sdswatch_timestamp", "host", "source_type", "source_id", "metric_key", "metric_value"]
+      quote_char => "'" # allow comma within token
+    } 
+    mutate {
+      strip => ["sdswatch_timestamp", "host", "source_type", "source_id", "metric_key", "metric_value"]
+    }
+  }
+  
+  mutate {
+    add_field => { "log_path" => "%{path}" }
+    remove_field => ["@timestamp", "path", "type"]
+  }
+
+  date { # match sdswatch_timestamp with the following patterns
+    match => ["sdswatch_timestamp", "yyyy-MM-dd HH:mm:ss.SSS", "yyyy-MM-dd HH:mm:ss,SSS", "yyyy-MM-dd'T'HH:mm:ssZ" ] 
+    timezone => "UTC"
+    target => "sdswatch_timestamp"
+  }
+
+  ruby {
+    code => '
+      key = event.get("metric_key")
+      value = event.get("metric_value").chomp()
+      if value.to_f.to_s == value || value.to_i.to_s == value
+         numeric_value = value.to_f
+         event.set("metric_value_float", numeric_value)
+      end
+    '
+  }
+
+  mutate {
+    rename => ["metric_value", "metric_value_string"]
+  }
+}
+
+
+output { # send data to SDSWatch server
+  #stdout { codec => rubydebug }
+
+  redis {
+    host => "{{ METRICS_REDIS_PVT_IP }}"
+    {% if METRICS_REDIS_PASSWORD != "" %}password => "{{ METRICS_REDIS_PASSWORD }}"{% endif %}
+    data_type => "list"
+    key => "sdswatch"
+  }
+}

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.13"
+__version__ = "1.0.14"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"


### PR DESCRIPTION
This PR adds an SDSWatch client configuration file for use on the mozart, metrics, and grq PCM components. See https://hysds-core.atlassian.net/browse/HC-273 for end-to-end test results.