### PR TITLE
HC-334: Improve dedup detection

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.0.13"
+__version__ = "1.0.14"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/orchestrator.py
+++ b/hysds/orchestrator.py
@@ -39,6 +39,7 @@ from hysds.utils import (
     get_short_error,
     get_payload_hash,
     query_dedup_job,
+    NoDedupJobFoundException
 )
 from hysds.user_rules_dataset import queue_dataset_evaluation
 
@@ -284,7 +285,11 @@ def submit_job(j):
 
     # do dedup
     if dedup is True:
-        dj = query_dedup_job(payload_hash)
+        try:
+            dj = query_dedup_job(payload_hash)
+        except NoDedupJobFoundException as e:
+            logger.info(str(e))
+            dj = None
         if isinstance(dj, dict):
             dedup_msg = "orchestrator found duplicate job %s with status %s" % (
                 dj["_id"],

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -343,7 +343,7 @@ def get_payload_hash(payload):
     ).hexdigest()
 
 
-def no_dedup_job():
+def no_dedup_job(e):
     return None
 
 

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -361,6 +361,10 @@ def query_dedup_job(dedup_key, filter_id=None, states=None):
     """
 
     hash_exists_in_redis = payload_hash_exists(dedup_key)
+    if hash_exists_in_redis is True:
+        logger.info("Payload hash already exists in REDIS: {}".format(dedup_key))
+    elif hash_exists_in_redis is False:
+        logger.info("Payload hash does not exist in REDIS: {}".format(dedup_key))
 
     # get states
     if states is None:

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -343,8 +343,8 @@ def get_payload_hash(payload):
     ).hexdigest()
 
 
-def no_dedup_job(e):
-    logger.info("Giving up: {}".format(str(e)))
+def no_dedup_job(details):
+    logger.info("Giving up: {}".format(json.dumps(details, indent=2)))
     return None
 
 
@@ -352,7 +352,7 @@ def no_dedup_job(e):
     backoff.expo, requests.exceptions.RequestException, max_tries=8, max_value=32
 )
 @backoff.on_exception(
-    backoff.expo, ValueError, max_tries=8, max_value=32, giveup=no_dedup_job
+    backoff.expo, ValueError, max_tries=8, max_value=32, on_giveup=no_dedup_job
 )
 def query_dedup_job(dedup_key, filter_id=None, states=None):
     """
@@ -407,8 +407,8 @@ def query_dedup_job(dedup_key, filter_id=None, states=None):
     logger.info("result: %s" % r.text)
     if j["hits"]["total"]["value"] == 0:
         if hash_exists_in_redis is True:
-            raise ValueError("Could not find any jobs with the following query: {}".format(json.dumps(query,
-                                                                                                      indent=2)))
+            raise ValueError("Could not find any dedup jobs with the following query: {}".format(
+                json.dumps(query, indent=2)))
         elif hash_exists_in_redis is False:
             return None
         else:

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -344,7 +344,7 @@ def get_payload_hash(payload):
 
 
 def no_dedup_job(details):
-    logger.info("Giving up: {}".format(json.dumps(details, indent=2)))
+    logger.info("Giving up querying for dedup jobs with args {args} and kwargs {kwargs}".format(**details))
     return None
 
 

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -344,6 +344,7 @@ def get_payload_hash(payload):
 
 
 def no_dedup_job(e):
+    logger.info("Giving up: {}".format(str(e)))
     return None
 
 


### PR DESCRIPTION
This PR provides better support for detecting dedup jobs in the system. When the `query_dedup_job` function is called, it will first try to store the payload hash in REDIS. If it detects that it already exists, we will perform exponential backoff when trying to find the dedup job. This allows us to try and catch jobs with the same payload that may have been submitted at the same time. On the caller side, specifically at the orchestrator and job_worker levels, the calling of the `query_dedup_job` function is now surrounded by a try/except block to catch `NoDedupJobFoundException` exceptions so we can set the result to None if the hash key exists in REDIS and we cannot find the dedup job at the end of the exponential backoff.

This feature was tested on a local cluster, where this change was checked out onto Factotum and jobs were submitted to there for testing purposes. This screenshot shows that we are now able to properly catch the dedup even though the SCIFLO jobs were submitted at roughly the same time:

![image](https://user-images.githubusercontent.com/42812746/108941928-d4fc7f00-760a-11eb-9f4e-2171f358e656.png)

As an additional sanity check, this feature is being run through an end-to-end test on the SWOT side, where this issue initially appeared: https://swot-pcm-ci.jpl.nasa.gov/job/force-branches/job/ci-E2E_NIGHTLY-swot-pcm_develop-force-branch/308/