### PR TITLE
add PYTHONHTTPSVERIFY environment variable in supervisor.conf.mozart

### DIFF
--- a/configs/supervisor/supervisord.conf.mozart
+++ b/configs/supervisor/supervisord.conf.mozart
@@ -135,6 +135,7 @@ startsecs=10
 
 [program:watchdog_job_timeouts]
 directory={{ OPS_HOME }}/mozart/ops/hysds/scripts
+environment=PYTHONHTTPSVERIFY=0
 command={{ OPS_HOME }}/mozart/ops/hysds/scripts/watchdog_job_timeouts.py
 process_name=%(program_name)s
 priority=1


### PR DESCRIPTION
will return an error when trying to connect to jenkins
```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:1125)
```

https://opendev.org/jjb/python-jenkins/src/branch/master/jenkins/__init__.py#L345-L350 says to set environment variable `PYTHONHTTPSVERIFY=0`