### PR TITLE
HC-363: catch errors copying additional paths for triage

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/dataset_ingest.py
+++ b/hysds/dataset_ingest.py
@@ -43,6 +43,7 @@ from hysds.log_utils import (
     log_custom_event,
 )
 from hysds.recognize import Recognizer
+from hysds.orchestrator import do_submit_job
 
 
 FILE_RE = re.compile(r"file://(.*?)(/.*)$")
@@ -80,7 +81,7 @@ def queue_dataset(dataset, update_json, queue_name):
     """Add dataset type and URL to queue."""
 
     payload = {"job_type": "dataset:%s" % dataset, "payload": update_json}
-    hysds.orchestrator.do_submit_job(payload, queue_name)
+    do_submit_job(payload, queue_name)
 
 
 def get_remote_dav(url):

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -809,7 +809,11 @@ def triage(job, ctx):
                     shutil.copy(f, dst)
             except Exception as e:
                 tb = traceback.format_exc()
-                logger.error("Skipping copying of {}. Got exception: {}\n{}".format(f, str(e), tb))
+                logger.error(
+                    "Skipping copying of {}. Got exception: {}\n{}".format(
+                        f, str(e), tb
+                    )
+                )
 
     # publish
     prod_json = publish_dataset(triage_dir, ds_file, job, ctx)

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -802,10 +802,14 @@ def triage(job, ctx):
             dst = os.path.join(triage_dir, os.path.basename(f))
             if os.path.exists(dst):
                 dst = "{}.{}Z".format(dst, datetime.utcnow().isoformat("T"))
-            if os.path.isdir(f):
-                shutil.copytree(f, dst)
-            else:
-                shutil.copy(f, dst)
+            try:
+                if os.path.isdir(f):
+                    shutil.copytree(f, dst)
+                else:
+                    shutil.copy(f, dst)
+            except Exception as e:
+                tb = traceback.format_exc()
+                logger.error("Skipping copying of {}. Got exception: {}\n{}".format(f, str(e), tb))
 
     # publish
     prod_json = publish_dataset(triage_dir, ds_file, job, ctx)


### PR DESCRIPTION
This PR adds more robust exception handling in the `triage` post-processor function and prevents jobs from failing when there are issues accessing additional file/directory globs. A new unit test was also added to test this feature.