### PR TITLE
HC-374: failed job not detected as done causing harikiri to leave worker instances up

### DIFF
--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1457,16 +1457,16 @@ def run_job(job, queue_when_finished=True):
 
     # close up job execution
     try:
+        # transition running file to done file
+        os.rename(job_running_file, job_done_file)
+        with open(job_done_file, "w") as f:
+            f.write("%sZ\n" % datetime.utcnow().isoformat())
+
         # log job info metrics
         log_job_info(job)
 
         # log final job status
         log_job_status(job_status_json)
-
-        # transition running file to done file and queue finished job
-        os.rename(job_running_file, job_done_file)
-        with open(job_done_file, "w") as f:
-            f.write("%sZ\n" % datetime.utcnow().isoformat())
 
         # queue job finished for user rules processing
         if queue_when_finished is True:


### PR DESCRIPTION
This PR fixes the issue where the `.running` signal file is not transitioned to `.done` because the remote services running on remote servers (e.g. ES, redis, or rabbitmq-server running on mozart) is not reachable. By transitioning the signal file upfront before these remote calls, the harikiri process on each verdi worker will be able to detect all jobs as being done and terminate the instance accordingly.