### PR TITLE
HC-302: Add capability to propagate info messages up to the UI for successful jobs

### DIFF
--- a/configs/logstash/job_status.template
+++ b/configs/logstash/job_status.template
@@ -29,6 +29,20 @@
         "type": "object",
         "enabled": false
       },
+      "msg": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
+      "msg_details": {
+        "type": "keyword",
+        "ignore_above": 256,
+        "copy_to": [
+          "text_fields"
+        ]
+      },
       "job": {
         "properties": {
           "command": {

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1451,6 +1451,7 @@ def run_job(job, queue_when_finished=True):
         job_status_json["msg"] = msg
 
     # overwrite msg_details if _alt_msg_details.txt was dumped
+    msg_details = None
     alt_msg_details_file = os.path.join(job_dir, "_alt_msg_details.txt")
     if os.path.exists(alt_msg_details_file):
         with open(alt_msg_details_file) as f:

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1438,6 +1438,22 @@ def run_job(job, queue_when_finished=True):
             "celery_hostname": run_job.request.hostname,
         }
 
+    # overwrite message if _alt_msg.txt was dumped
+    alt_msg_file = os.path.join(job_dir, "_alt_msg.txt")
+    if os.path.exists(alt_msg_file):
+        with open(alt_msg_file) as f:
+            msg = f.read()
+            logger.info("Got alternate info message: %s" % msg)
+        job_status_json["msg"] = msg
+
+    # overwrite msg_details if _alt_msg_details.txt was dumped
+    alt_msg_details_file = os.path.join(job_dir, "_alt_msg_details.txt")
+    if os.path.exists(alt_msg_details_file):
+        with open(alt_msg_details_file) as f:
+            msg_details = f.read()
+            logger.info("Got alternate message details: %s" % msg_details)
+        job_status_json["msg_details"] = msg_details
+
     # store usage stats
     for usage_stats_file in find_usage_stats(job_dir):
         usage_stats = {}
@@ -1487,6 +1503,11 @@ def run_job(job, queue_when_finished=True):
             "traceback": traceback.format_exc(),
             "celery_hostname": run_job.request.hostname,
         }
+        if msg:
+            job_status_json["msg"] = msg
+        if msg_details:
+            job_status_json["msg_details"] = msg_details
+
         fail_job(job_status_json, jd_file)
 
     # raise worker execution error

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1445,8 +1445,8 @@ def run_job(job, queue_when_finished=True):
         with open(alt_msg_file) as f:
             msgs = f.readlines()
             logger.info("Got alternate info message: %s" % msgs)
-        for m in msgs:
-            msg.append(get_short_error(m))
+            for m in msgs:
+                msg.append(get_short_error(m))
 
         job_status_json["msg"] = msg
 

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1444,7 +1444,7 @@ def run_job(job, queue_when_finished=True):
         with open(alt_msg_file) as f:
             msg = f.read()
             logger.info("Got alternate info message: %s" % msg)
-        job_status_json["msg"] = msg
+        job_status_json["msg"] = get_short_error(msg)
 
     # overwrite msg_details if _alt_msg_details.txt was dumped
     alt_msg_details_file = os.path.join(job_dir, "_alt_msg_details.txt")
@@ -1504,7 +1504,7 @@ def run_job(job, queue_when_finished=True):
             "celery_hostname": run_job.request.hostname,
         }
         if msg:
-            job_status_json["msg"] = msg
+            job_status_json["msg"] = get_short_error(msg)
         if msg_details:
             job_status_json["msg_details"] = msg_details
 

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1439,12 +1439,16 @@ def run_job(job, queue_when_finished=True):
         }
 
     # overwrite message if _alt_msg.txt was dumped
+    msg = list()
     alt_msg_file = os.path.join(job_dir, "_alt_msg.txt")
     if os.path.exists(alt_msg_file):
         with open(alt_msg_file) as f:
-            msg = f.read()
-            logger.info("Got alternate info message: %s" % msg)
-        job_status_json["msg"] = get_short_error(msg)
+            msgs = f.readlines()
+            logger.info("Got alternate info message: %s" % msgs)
+        for m in msgs:
+            msg.append(get_short_error(m))
+
+        job_status_json["msg"] = msg
 
     # overwrite msg_details if _alt_msg_details.txt was dumped
     alt_msg_details_file = os.path.join(job_dir, "_alt_msg_details.txt")
@@ -1504,7 +1508,7 @@ def run_job(job, queue_when_finished=True):
             "celery_hostname": run_job.request.hostname,
         }
         if msg:
-            job_status_json["msg"] = get_short_error(msg)
+            job_status_json["msg"] = msg
         if msg_details:
             job_status_json["msg_details"] = msg_details
 


### PR DESCRIPTION
This PR adds the capability such that informational messages can get propagated up to the UI. This is useful for successful jobs that do not produce any output. 2 new fields are added to the job_status json:

- msg: Intended for short messages much like the error field. Can be a string or an array of strings.
- msg_details: Contains a detailed informational message.

If the worker finds an `_alt_msg.txt` file, it will add it to the `msg` field in the job_status. Additionally, if the `_alt_msg_details.txt` file is found, then it will add the string value to the `msg_details` in the job_status.
