### PR TITLE
HC-380, HC-383, HC-384: update to celery v5.1.2, accept json content to receive revokes, mitigate autoscaling API throttling

### DIFF
--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -3,7 +3,7 @@ result_backend = "redis://:{{ MOZART_REDIS_PASSWORD }}@{{ MOZART_REDIS_PVT_IP }}
 
 task_serializer = "msgpack"
 result_serializer = "msgpack"
-accept_content = ["msgpack"]
+accept_content = ["msgpack", "json"]
 
 task_acks_late = True
 result_expires = 86400

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/scripts/harikiri_sqs.py
+++ b/scripts/harikiri_sqs.py
@@ -283,12 +283,12 @@ def graceful_shutdown(id, logger=None):
         with open("/home/ops/verdi/etc/settings.yaml") as f:
             yml = yaml.safe_load(f)
         venue = yml["VENUE"]
-        queue_name = venue + ("-harikiri-queue.fifo")
+        queue_name = venue + ("-queue")
         # Get the queue. This returns an SQS.Queue instance
         queue = sqs.get_queue_by_name(QueueName=queue_name)
 
         # Create a new message, message body is the instance id
-        response = queue.send_message(MessageBody=id, MessageGroupId="harikiri")
+        response = queue.send_message(MessageBody=id)
         logging.info("SQS Queue Message Response: {}".format(json.dumps(response)))
     except Exception as e:
         logging.error("Got exception in calling queue: {}\n{}".format(str(e), traceback.format_exc()))

--- a/scripts/harikiri_sqs.py
+++ b/scripts/harikiri_sqs.py
@@ -285,10 +285,10 @@ def graceful_shutdown(id, logger=None):
         venue = yml["VENUE"]
         queue_name = venue + ("-harikiri-queue.fifo")
         # Get the queue. This returns an SQS.Queue instance
-        queue = sqs.get_queue_by_name(QueueName=queue_name, MessageGroupId="harikiri")
+        queue = sqs.get_queue_by_name(QueueName=queue_name)
 
         # Create a new message, message body is the instance id
-        response = queue.send_message(MessageBody=id)
+        response = queue.send_message(MessageBody=id, MessageGroupId="harikiri")
         logging.info("SQS Queue Message Response: {}".format(json.dumps(response)))
     except Exception as e:
         logging.error("Got exception in calling queue: {}\n{}".format(str(e), traceback.format_exc()))

--- a/scripts/harikiri_sqs.py
+++ b/scripts/harikiri_sqs.py
@@ -283,12 +283,12 @@ def graceful_shutdown(id, logger=None):
         with open("/home/ops/verdi/etc/settings.yaml") as f:
             yml = yaml.safe_load(f)
         venue = yml["VENUE"]
-        queue_name = venue + ("-queue")
+        queue_name = venue + ("-harikiri-queue.fifo")
         # Get the queue. This returns an SQS.Queue instance
         queue = sqs.get_queue_by_name(QueueName=queue_name)
 
         # Create a new message, message body is the instance id
-        response = queue.send_message(MessageBody=id)
+        response = queue.send_message(MessageBody=id, MessageGroupId="harikiri")
         logging.info("SQS Queue Message Response: {}".format(json.dumps(response)))
     except Exception as e:
         logging.error("Got exception in calling queue: {}\n{}".format(str(e), traceback.format_exc()))

--- a/scripts/harikiri_sqs.py
+++ b/scripts/harikiri_sqs.py
@@ -283,9 +283,9 @@ def graceful_shutdown(id, logger=None):
         with open("/home/ops/verdi/etc/settings.yaml") as f:
             yml = yaml.safe_load(f)
         venue = yml["VENUE"]
-        queue_name = venue + ("-harikiri-queue")
+        queue_name = venue + ("-harikiri-queue.fifo")
         # Get the queue. This returns an SQS.Queue instance
-        queue = sqs.get_queue_by_name(QueueName=queue_name)
+        queue = sqs.get_queue_by_name(QueueName=queue_name, MessageGroupId="harikiri")
 
         # Create a new message, message body is the instance id
         response = queue.send_message(MessageBody=id)

--- a/scripts/harikiri_sqs.py
+++ b/scripts/harikiri_sqs.py
@@ -283,12 +283,12 @@ def graceful_shutdown(id, logger=None):
         with open("/home/ops/verdi/etc/settings.yaml") as f:
             yml = yaml.safe_load(f)
         venue = yml["VENUE"]
-        queue_name = venue + ("-harikiri-queue.fifo")
+        queue_name = venue + ("-harikiri-queue")
         # Get the queue. This returns an SQS.Queue instance
         queue = sqs.get_queue_by_name(QueueName=queue_name)
 
         # Create a new message, message body is the instance id
-        response = queue.send_message(MessageBody=id, MessageGroupId="harikiri")
+        response = queue.send_message(MessageBody=id)
         logging.info("SQS Queue Message Response: {}".format(json.dumps(response)))
     except Exception as e:
         logging.error("Got exception in calling queue: {}\n{}".format(str(e), traceback.format_exc()))

--- a/scripts/sync_ec2_target_tracking_metric.py
+++ b/scripts/sync_ec2_target_tracking_metric.py
@@ -49,6 +49,8 @@ def get_waiting_job_count(queue, user="guest", password="guest"):
     backoff.expo, botocore.exceptions.ClientError, max_tries=8, max_value=64
 )
 def describe_asg(client, asg):
+    """Backoff wrapper for describe_auto_scaling_groups()."""
+
     return client.describe_auto_scaling_groups(AutoScalingGroupNames=[asg])
 
 
@@ -67,6 +69,8 @@ def get_desired_capacity_max(asg):
     backoff.expo, botocore.exceptions.ClientError, max_tries=8, max_value=64
 )
 def set_desired_capacity(client, asg, desired):
+    """Backoff wrapper for set_desired_capacity()."""
+
     return client.set_desired_capacity(AutoScalingGroupName=asg, DesiredCapacity=int(desired))
 
 
@@ -82,6 +86,8 @@ def bootstrap_asg(asg, desired):
     backoff.expo, botocore.exceptions.ClientError, max_tries=8, max_value=64
 )
 def put_metric_data(client, metric_name, metric_ns, asg, queue, metric):
+    """Backoff wrapper for put_metric_data()."""
+
     client.put_metric_data(
         Namespace=metric_ns,
         MetricData=[

--- a/scripts/sync_ec2_target_tracking_metric.py
+++ b/scripts/sync_ec2_target_tracking_metric.py
@@ -14,7 +14,9 @@ import traceback
 import logging
 import argparse
 import boto3
+import botocore
 import requests
+import backoff
 
 from hysds.celery import app
 
@@ -43,30 +45,43 @@ def get_waiting_job_count(queue, user="guest", password="guest"):
         return 0
 
 
+@backoff.on_exception(
+    backoff.expo, botocore.exceptions.ClientError, max_tries=8, max_value=64
+)
+def describe_asg(client, asg):
+    return client.describe_auto_scaling_groups(AutoScalingGroupNames=[asg])
+
+
 def get_desired_capacity_max(asg):
     """Get current value of ASG's desired capacity and max size."""
 
     c = boto3.client("autoscaling")
-    r = c.describe_auto_scaling_groups(AutoScalingGroupNames=[asg])
+    r = describe_asg(c, asg)
     groups = r["AutoScalingGroups"]
     if len(groups) == 0:
         raise RuntimeError("Autoscaling group {} not found.".format(asg))
     return groups[0]["DesiredCapacity"], groups[0]["MaxSize"]
 
 
+@backoff.on_exception(
+    backoff.expo, botocore.exceptions.ClientError, max_tries=8, max_value=64
+)
+def set_desired_capacity(client, asg, desired):
+    return client.set_desired_capacity(AutoScalingGroupName=asg, DesiredCapacity=int(desired))
+
+
 def bootstrap_asg(asg, desired):
     """Bootstrap ASG's desired capacity."""
 
     c = boto3.client("autoscaling")
-    r = c.set_desired_capacity(AutoScalingGroupName=asg, DesiredCapacity=int(desired))
+    r = set_desired_capacity(c, asg, desired)
     return desired
 
 
-def submit_metric(queue, asg, metric, metric_ns):
-    """Submit EC2 custom metric data."""
-
-    metric_name = "JobsWaitingPerInstance-%s" % (asg)
-    client = boto3.client("cloudwatch")
+@backoff.on_exception(
+    backoff.expo, botocore.exceptions.ClientError, max_tries=8, max_value=64
+)
+def put_metric_data(client, metric_name, metric_ns, asg, queue, metric):
     client.put_metric_data(
         Namespace=metric_ns,
         MetricData=[
@@ -80,6 +95,14 @@ def submit_metric(queue, asg, metric, metric_ns):
             }
         ],
     )
+
+
+def submit_metric(queue, asg, metric, metric_ns):
+    """Submit EC2 custom metric data."""
+
+    metric_name = "JobsWaitingPerInstance-%s" % (asg)
+    client = boto3.client("cloudwatch")
+    put_metric_data(client, metric_name, metric_ns, asg, queue, metric)
     logging.info(
         "updated target tracking metric for %s queue and ASG %s as metric %s:%s: %s"
         % (queue, asg, metric_ns, metric_name, metric)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "redis>=3.2.1",
-        "celery>=5.0.5,<6.0.0",
+        "celery>=5.1.2,<6.0.0",
         "requests>=2.20.0",
         "flower>=0.8.2",
         "eventlet>=0.17.2",


### PR DESCRIPTION
This PR updates HySDS core to use celery v5.1.2 and additionally updates the `celeryconfig.py.tmpl` template to include `json` as acceptable content, which is the format of broadcasted revoke payloads.
This was tested in NISAR using the NASA demo pipeline (dev-e2e + ALOS L0B processed to RSLC, GSLC and GCOV).