### PR TITLE
HC-393, HC-398: Fix UTC time handling in harikiri & add target tracking metric for autoscaling that allows for 1:1 scaling of jobs to workers

### DIFF
--- a/configs/supervisor/supervisord.conf.mozart
+++ b/configs/supervisor/supervisord.conf.mozart
@@ -176,9 +176,10 @@ startsecs=10
 # target tracking metrics
 {% for q in QUEUES %}
 {% set queue = q['QUEUE_NAME'] | trim -%}
+{% set use_job_total = q.get('TOTAL_JOBS_METRIC', False) -%}
 [program:sync_ec2_target_tracking_metric-{{ queue }}]
 directory={{ OPS_HOME }}/mozart/ops/hysds/scripts
-command={{ OPS_HOME }}/mozart/ops/hysds/scripts/sync_ec2_target_tracking_metric.py --interval 60 -u {{ MOZART_RABBIT_USER }} -p {{ MOZART_RABBIT_PASSWORD }} {{ queue }} {{ VENUE }}-{{ queue }}
+command={{ OPS_HOME }}/mozart/ops/hysds/scripts/sync_ec2_target_tracking_metric.py --interval 60 -u {{ MOZART_RABBIT_USER }} -p {{ MOZART_RABBIT_PASSWORD }} {% if use_job_total == True %}--total_jobs {% endif %}{{ queue }} {{ VENUE }}-{{ queue }}
 process_name=%(program_name)s
 priority=1
 numprocs=1

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -100,7 +100,7 @@ PyNaCl==1.3.0
 pyrsistent==0.15.7
 pytest==5.3.2
 python-editor==1.0.4
-python-ldap==3.2.0
+python-ldap==3.4.0
 python-magic==0.4.15
 PyYAML==5.4
 redis==3.3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ awscli==1.17.1
 azure-common==1.1.24
 azure-storage-blob==1.4.0
 azure-storage-common==1.4.2
-Babel==2.8.0
+Babel>=2.9.1
 backoff==1.10.0
 bcrypt==3.1.7
 billiard==3.6.1.0

--- a/scripts/harikiri.py
+++ b/scripts/harikiri.py
@@ -117,7 +117,7 @@ def is_jobless(root_work, inactivity_secs, logger=None):
                 logging.info("%s: no .done file found. Not jobless yet." % job_dir)
                 return False
             t = os.path.getmtime(done_file)
-            done_dt = datetime.fromtimestamp(t)
+            done_dt = datetime.utcfromtimestamp(t)
             age = (datetime.utcnow() - done_dt).total_seconds()
             if most_recent is None or age < most_recent:
                 most_recent = age

--- a/scripts/harikiri_sqs.py
+++ b/scripts/harikiri_sqs.py
@@ -117,7 +117,7 @@ def is_jobless(root_work, inactivity_secs, logger=None):
                 logging.info("%s: no .done file found. Not jobless yet." % job_dir)
                 return False
             t = os.path.getmtime(done_file)
-            done_dt = datetime.fromtimestamp(t)
+            done_dt = datetime.utcfromtimestamp(t)
             age = (datetime.utcnow() - done_dt).total_seconds()
             if most_recent is None or age < most_recent:
                 most_recent = age

--- a/scripts/sync_ec2_target_tracking_metric.py
+++ b/scripts/sync_ec2_target_tracking_metric.py
@@ -36,7 +36,7 @@ def get_job_count(queue, user="guest", password="guest", total_jobs=False):
         .get("hostname", "localhost")
     )
 
-    # get total number of jobs
+    # get number of jobs
     url = "http://%s:15672/api/queues/%%2f/%s" % (host, queue)
     r = requests.get(url, auth=(user, password))
     # r.raise_for_status()

--- a/scripts/sync_ec2_target_tracking_metric.py
+++ b/scripts/sync_ec2_target_tracking_metric.py
@@ -120,7 +120,7 @@ def submit_metric(queue, asg, metric, metric_ns, total_jobs=False):
 
 
 def daemon(queue, asg, interval, namespace, user="guest", password="guest", total_jobs=False):
-    """Submit EC2 custom metric for the ratio of jobs to workers."""
+    """Submit EC2 custom metric for an ASG's target tracking policy."""
 
     logging.info("queue: %s" % queue)
     logging.info("interval: %d" % interval)

--- a/scripts/sync_ec2_target_tracking_metric.py
+++ b/scripts/sync_ec2_target_tracking_metric.py
@@ -72,7 +72,9 @@ def get_desired_capacity_max(asg):
 def set_desired_capacity(client, asg, desired):
     """Backoff wrapper for set_desired_capacity()."""
 
-    return client.set_desired_capacity(AutoScalingGroupName=asg, DesiredCapacity=int(desired))
+    return client.set_desired_capacity(
+        AutoScalingGroupName=asg, DesiredCapacity=int(desired)
+    )
 
 
 def bootstrap_asg(asg, desired):
@@ -119,7 +121,9 @@ def submit_metric(queue, asg, metric, metric_ns, total_jobs=False):
     )
 
 
-def daemon(queue, asg, interval, namespace, user="guest", password="guest", total_jobs=False):
+def daemon(
+    queue, asg, interval, namespace, user="guest", password="guest", total_jobs=False
+):
     """Submit EC2 custom metric for an ASG's target tracking policy."""
 
     logging.info("queue: %s" % queue)
@@ -135,7 +139,11 @@ def daemon(queue, asg, interval, namespace, user="guest", password="guest", tota
             desired_capacity, max_size = map(float, get_desired_capacity_max(asg))
             if desired_capacity == 0:
                 if job_count > 0:
-                    desired_capacity = float(bootstrap_asg(asg, max_size if job_count > max_size else job_count))
+                    desired_capacity = float(
+                        bootstrap_asg(
+                            asg, max_size if job_count > max_size else job_count
+                        )
+                    )
                     logging.info(
                         "bootstrapped ASG %s to desired=%s" % (asg, desired_capacity)
                     )
@@ -162,9 +170,19 @@ if __name__ == "__main__":
     )
     parser.add_argument("-u", "--user", default="guest", help="rabbitmq user")
     parser.add_argument("-p", "--password", default="guest", help="rabbitmq password")
-    parser.add_argument("-t", "--total_jobs", action="store_true",
-                        help="use total job count instead of waiting job count (default)")
+    parser.add_argument(
+        "-t",
+        "--total_jobs",
+        action="store_true",
+        help="use total job count instead of waiting job count (default)",
+    )
     args = parser.parse_args()
     daemon(
-        args.queue, args.asg, args.interval, args.namespace, args.user, args.password, args.total_jobs
+        args.queue,
+        args.asg,
+        args.interval,
+        args.namespace,
+        args.user,
+        args.password,
+        args.total_jobs,
     )


### PR DESCRIPTION
This PR addresses both https://hysds-core.atlassian.net/browse/HC-393 and https://hysds-core.atlassian.net/browse/HC-398.

## HC-393
This PR updates the `sync_ec2_target_tracking_metric.py` script by adding a new option (`-t, --total_jobs`) that modifies the custom metric that is sent for an autoscaling group target tracking policy. The default when not specifying that option (to maintain backwards compatibility) is the current behavior to send the ratio of waiting/queued jobs to desired_count to the `JobsWaitingPerInstance-*` custom metric. When that option is specified, the ratio of total jobs to desired_count is sent to the `JobsPerInstance-*` custom metric instead.

To test backwards compatibility, this new script was run in NISAR against the `dev-e2e (fwd)`, `dev-e2e (reprocessing)`, `dev-e2e-pge`, `dev-e2e-baseline-pge` and `dev-e2e-event-misfire` tests:

![Screen Shot 2021-11-11 at 8 32 17 AM](https://user-images.githubusercontent.com/387300/141334117-ce0b407c-4a28-434b-bf7e-991c36e1782e.png)

To test the new feature, the following update was made to the terraform `modules/common/main.tf`:

```
diff --git a/cluster_provisioning/modules/common/main.tf b/cluster_provisioning/modules/common/main.tf
index a77eaf4f..c85cb99c 100644
--- a/cluster_provisioning/modules/common/main.tf
+++ b/cluster_provisioning/modules/common/main.tf
@@ -1126,6 +1126,23 @@ resource "aws_instance" "mozart" {
     ]
   }
 
+  # temporary kludge to test backwards-compatibility of 
+  # https://hysds-core.atlassian.net/browse/HC-393 and
+  # https://hysds-core.atlassian.net/browse/HC-398
+  provisioner "remote-exec" {
+    inline = [
+      "set -ex",
+      "source ~/.bash_profile",
+      "cd ~/mozart/ops/hysds/scripts",
+      "mv sync_ec2_target_tracking_metric.py sync_ec2_target_tracking_metric.py.orig",
+      "wget https://raw.githubusercontent.com/hysds/hysds/HC-393_HC-398/scripts/sync_ec2_target_tracking_metric.py",
+      "chmod 755 sync_ec2_target_tracking_metric.py",
+      "mv harikiri_sqs.py harikiri_sqs.py.orig",
+      "wget https://raw.githubusercontent.com/hysds/hysds/HC-393_HC-398/scripts/harikiri_sqs.py",
+      "chmod 755 harikiri_sqs.py"
+    ]
+  }
+
   provisioner "remote-exec" {
     inline = [
       "set -ex",
@@ -1410,7 +1427,8 @@ resource "aws_autoscaling_policy" "autoscaling_policy" {
         name  = "Queue"
         value = each.key
       }
-      metric_name = "JobsWaitingPerInstance-${var.project}-${var.venue}-${local.counter}-${each.key}"
+      #metric_name = "JobsWaitingPerInstance-${var.project}-${var.venue}-${local.counter}-${each.key}"
+      metric_name = "JobsPerInstance-${var.project}-${var.venue}-${local.counter}-${each.key}"
       unit        = "None"
       namespace   = "HySDS"
       statistic   = "Maximum"
```

and the following update to the `conf/sds/files/supervisord.conf.mozart`:

```
diff --git a/conf/sds/files/supervisord.conf.mozart b/conf/sds/files/supervisord.conf.mozart
index ebb5768f..20589a72 100644
--- a/conf/sds/files/supervisord.conf.mozart
+++ b/conf/sds/files/supervisord.conf.mozart
@@ -235,7 +235,8 @@ startsecs=10
 {% set queue = q['QUEUE_NAME'] | trim -%}
 [program:sync_ec2_target_tracking_metric-{{ queue }}]
 directory={{ OPS_HOME }}/mozart/ops/hysds/scripts
-command={{ OPS_HOME }}/mozart/ops/hysds/scripts/sync_ec2_target_tracking_metric.py --interval 60 -u {{ MOZART_RABBIT_USER }} -p {{ MOZART_RABBIT_PASSWORD }} {{ queue }} {{ VENUE }}-{{ queue }}
+#command={{ OPS_HOME }}/mozart/ops/hysds/scripts/sync_ec2_target_tracking_metric.py --interval 60 -u {{ MOZART_RABBIT_USER }} -p {{ MOZART_RABBIT_PASSWORD }} {{ queue }} {{ VENUE }}-{{ queue }}
+command={{ OPS_HOME }}/mozart/ops/hysds/scripts/sync_ec2_target_tracking_metric.py --interval 60 -u {{ MOZART_RABBIT_USER }} -p {{ MOZART_RABBIT_PASSWORD }} --total_jobs {{ queue }} {{ VENUE }}-{{ queue }}
 process_name=%(program_name)s
 priority=1
 numprocs=1
```

and NISAR ran the `dev-e2e (fwd)`, `dev-e2e (reprocessing)`, `dev-e2e-pge`, `dev-e2e-baseline-pge` and `dev-e2e-event-misfire` tests:

![Screen Shot 2021-11-12 at 4 47 38 AM](https://user-images.githubusercontent.com/387300/141469658-288eb4f6-94ea-4acd-8948-e9e55f3b372b.png)

## HC-398
This PR fixes an issue in `harikiri.py` and `harikiri_sqs.py` where the determination of how long a verdi instance has been inactive (time since last job was run) is incorrectly calculated if the system's default timezone is not set to UTC. For example in the case that the system's default timezone is PST, there will be at least a difference of 8 hours calculated and thus depending on the `inactivity` threshold configured in `harikiri.yml` the instance will shut itself down prematurely after the first job.

This fix was also tested in the above tests where the verdi AMI was configured for PST as the system timezone.