### PR TITLE
pin celery until issue fixed: https://github.com/celery/celery/pull/7…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,10 @@ setup(
     zip_safe=False,
     install_requires=[
         "redis>=3.2.1",
-        "celery>=5.1.2,<6.0.0",
+        # TODO: undo this pin once this issues is resolved:
+        # https://github.com/celery/celery/pull/7194#issuecomment-100298885
+        #"celery>=5.1.2,<6.0.0",
+        "celery==5.2.2",
         "requests>=2.20.0",
         "flower>=0.8.2",
         "eventlet>=0.17.2",


### PR DESCRIPTION
…194#issuecomment-1002988857

was able to run `hysds-framework`'s `install.sh` when using this `hysds` branch
```
Cloning into 'hysds'...
remote: Enumerating objects: 2998, done.
remote: Counting objects: 100% (209/209), done.
remote: Compressing objects: 100% (150/150), done.
remote: Total 2998 (delta 131), reused 98 (delta 57), pack-reused 2789
Receiving objects: 100% (2998/2998), 4.09 MiB | 2.89 MiB/s, done.
Resolving deltas: 100% (1604/1604), done.
Branch hotfix-celery-setuptools set up to track remote branch hotfix-celery-setuptools from origin.
Switched to a new branch 'hotfix-celery-setuptools'
Obtaining file:///home/ops/mozart/ops/hysds
  Preparing metadata (setup.py) ... done
Collecting redis>=3.2.1
  Downloading redis-4.1.0-py3-none-any.whl (171 kB)
     |████████████████████████████████| 171 kB 2.7 MB/s            
Collecting celery==5.2.2
  Downloading celery-5.2.2-py3-none-any.whl (405 kB)
     |████████████████████████████████| 405 kB 16.4 MB/s            
Requirement already satisfied: requests>=2.20.0 in /opt/conda/lib/python3.9/site-packages (from hysds==1.1.4) (2.26.0)
Collecting flower>=0.8.2
  Downloading flower-1.0.0-py2.py3-none-any.whl (457 kB)
     |████████████████████████████████| 457 kB 23.4 MB/s            
Collecting eventlet>=0.17.2
  Downloading eventlet-0.33.0-py2.py3-none-any.whl (226 kB)
     |████████████████████████████████| 226 kB 20.2 MB/s            
Requirement already satisfied: easywebdav>=1.2.0 in /home/ops/mozart/lib/python3.9/site-packages (from hysds==1.1.4) (1.2.0)
Requirement already satisfied: lxml>=3.4.0 in /home/ops/mozart/lib/python3.9/site-packages (from hysds==1.1.4) (4.7.1)
Collecting httplib2>=0.9
  Downloading httplib2-0.20.2-py3-none-any.whl (96 kB)
     |████████████████████████████████| 96 kB 9.6 MB/s             
Collecting gevent>=1.0.1
  Downloading gevent-21.12.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (6.2 MB)
     |████████████████████████████████| 6.2 MB 28.3 MB/s            
Collecting psutil>=5.8.0
  Downloading psutil-5.9.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (280 kB)
     |████████████████████████████████| 280 kB 13.8 MB/s            
Requirement already satisfied: filechunkio>=1.6.0 in /home/ops/mozart/lib/python3.9/site-packages (from hysds==1.1.4) (1.6)
Collecting boto>=2.38.0
  Downloading boto-2.49.0-py2.py3-none-any.whl (1.4 MB)
     |████████████████████████████████| 1.4 MB 13.4 MB/s            
Collecting msgpack>=1.0.0
  Downloading msgpack-1.0.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (322 kB)
     |████████████████████████████████| 322 kB 8.8 MB/s            
Requirement already satisfied: awscli>=1.17.1 in /home/ops/mozart/lib/python3.9/site-packages (from hysds==1.1.4) (1.22.26)
Requirement already satisfied: boto3>=1.11.1 in /home/ops/mozart/lib/python3.9/site-packages (from hysds==1.1.4) (1.20.26)
Requirement already satisfied: backoff>=1.3.1 in /home/ops/mozart/lib/python3.9/site-packages (from hysds==1.1.4) (1.11.1)
Requirement already satisfied: protobuf>=3.1.0.post1 in /home/ops/mozart/lib/python3.9/site-packages (from hysds==1.1.4) (3.19.1)
Collecting google-cloud>=0.22.0
  Downloading google_cloud-0.34.0-py2.py3-none-any.whl (1.8 kB)
Collecting google-cloud-monitoring>=0.22.0
  Downloading google_cloud_monitoring-2.8.0-py2.py3-none-any.whl (270 kB)
     |████████████████████████████████| 270 kB 12.0 MB/s            
Requirement already satisfied: osaka>=0.0.1 in /home/ops/mozart/ops/osaka (from hysds==1.1.4) (1.0.6)
Requirement already satisfied: prov_es>=0.2.0 in /home/ops/mozart/ops/prov_es (from hysds==1.1.4) (0.2.2)
Requirement already satisfied: hysds_commons>=0.1 in /home/ops/mozart/ops/hysds_commons (from hysds==1.1.4) (1.0.9)
Collecting atomicwrites>=1.1.5
  Downloading atomicwrites-1.4.0-py2.py3-none-any.whl (6.8 kB)
Requirement already satisfied: future>=0.17.1 in /opt/conda/lib/python3.9/site-packages (from hysds==1.1.4) (0.18.2)
Collecting greenlet>=0.4.15
  Downloading greenlet-1.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (153 kB)
     |████████████████████████████████| 153 kB 26.5 MB/s            
Collecting fabric3
  Downloading Fabric3-1.14.post1-py3-none-any.whl (92 kB)
     |████████████████████████████████| 92 kB 1.0 MB/s             
Requirement already satisfied: pytz in /home/ops/mozart/lib/python3.9/site-packages (from hysds==1.1.4) (2021.3)
Collecting pytest
  Downloading pytest-6.2.5-py3-none-any.whl (280 kB)
     |████████████████████████████████| 280 kB 21.1 MB/s            
Collecting tabulate>=0.8.6
  Downloading tabulate-0.8.9-py3-none-any.whl (25 kB)
Collecting aws-requests-auth<1.0.0,>=0.4.3
  Downloading aws_requests_auth-0.4.3-py2.py3-none-any.whl (6.8 kB)
Requirement already satisfied: pyyaml in /opt/conda/lib/python3.9/site-packages (from hysds==1.1.4) (5.4.1)
Collecting vine<6.0,>=5.0.0
  Downloading vine-5.0.0-py2.py3-none-any.whl (9.4 kB)
Collecting click<9.0,>=8.0
  Downloading click-8.0.3-py3-none-any.whl (97 kB)
     |████████████████████████████████| 97 kB 8.1 MB/s             
Collecting click-repl>=0.2.0
  Downloading click_repl-0.2.0-py3-none-any.whl (5.2 kB)
Collecting billiard<4.0,>=3.6.4.0
  Downloading billiard-3.6.4.0-py3-none-any.whl (89 kB)
     |████████████████████████████████| 89 kB 9.0 MB/s             
Collecting click-didyoumean>=0.0.3
  Downloading click_didyoumean-0.3.0-py3-none-any.whl (2.7 kB)
Collecting click-plugins>=1.1.1
  Downloading click_plugins-1.1.1-py2.py3-none-any.whl (7.5 kB)
Collecting kombu<6.0,>=5.2.2
  Downloading kombu-5.2.3-py3-none-any.whl (189 kB)
     |████████████████████████████████| 189 kB 18.5 MB/s            
Requirement already satisfied: setuptools in /home/ops/mozart/lib/python3.9/site-packages (from celery==5.2.2->hysds==1.1.4) (60.2.0)
Requirement already satisfied: botocore==1.23.26 in /home/ops/mozart/lib/python3.9/site-packages (from awscli>=1.17.1->hysds==1.1.4) (1.23.26)
Requirement already satisfied: s3transfer<0.6.0,>=0.5.0 in /home/ops/mozart/lib/python3.9/site-packages (from awscli>=1.17.1->hysds==1.1.4) (0.5.0)
Requirement already satisfied: rsa<4.8,>=3.1.2 in /home/ops/mozart/lib/python3.9/site-packages (from awscli>=1.17.1->hysds==1.1.4) (4.7.2)
Requirement already satisfied: colorama<0.4.4,>=0.2.5 in /home/ops/mozart/lib/python3.9/site-packages (from awscli>=1.17.1->hysds==1.1.4) (0.4.3)
Requirement already satisfied: docutils<0.16,>=0.10 in /home/ops/mozart/lib/python3.9/site-packages (from awscli>=1.17.1->hysds==1.1.4) (0.15.2)
Requirement already satisfied: python-dateutil<3.0.0,>=2.1 in /opt/conda/lib/python3.9/site-packages (from botocore==1.23.26->awscli>=1.17.1->hysds==1.1.4) (2.8.2)
Requirement already satisfied: urllib3<1.27,>=1.25.4 in /opt/conda/lib/python3.9/site-packages (from botocore==1.23.26->awscli>=1.17.1->hysds==1.1.4) (1.26.7)
Requirement already satisfied: jmespath<1.0.0,>=0.7.1 in /home/ops/mozart/lib/python3.9/site-packages (from botocore==1.23.26->awscli>=1.17.1->hysds==1.1.4) (0.10.0)
Collecting dnspython>=1.15.0
  Downloading dnspython-2.1.0-py3-none-any.whl (241 kB)
     |████████████████████████████████| 241 kB 15.5 MB/s            
Requirement already satisfied: six>=1.10.0 in /opt/conda/lib/python3.9/site-packages (from eventlet>=0.17.2->hysds==1.1.4) (1.16.0)
Collecting prometheus-client>=0.8.0
  Downloading prometheus_client-0.12.0-py2.py3-none-any.whl (57 kB)
     |████████████████████████████████| 57 kB 5.1 MB/s             
Collecting tornado<7.0.0,>=5.0.0
  Downloading tornado-6.1-cp39-cp39-manylinux2010_x86_64.whl (427 kB)
     |████████████████████████████████| 427 kB 10.2 MB/s            
Collecting humanize
  Downloading humanize-3.13.1-py3-none-any.whl (98 kB)
     |████████████████████████████████| 98 kB 12.1 MB/s            
Collecting zope.interface
  Downloading zope.interface-5.4.0-cp39-cp39-manylinux2010_x86_64.whl (255 kB)
     |████████████████████████████████| 255 kB 18.8 MB/s            
Collecting zope.event
  Downloading zope.event-4.5.0-py2.py3-none-any.whl (6.8 kB)
Collecting proto-plus>=1.15.0
  Downloading proto_plus-1.19.8-py3-none-any.whl (45 kB)
     |████████████████████████████████| 45 kB 6.6 MB/s             
Requirement already satisfied: google-api-core[grpc]<3.0.0dev,>=1.28.0 in /home/ops/mozart/lib/python3.9/site-packages (from google-cloud-monitoring>=0.22.0->hysds==1.1.4) (2.3.2)
Requirement already satisfied: pyparsing!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3,<4,>=2.4.2 in /opt/conda/lib/python3.9/site-packages (from httplib2>=0.9->hysds==1.1.4) (3.0.4)
Requirement already satisfied: elasticsearch<7.14.0,>=7.0.0 in /home/ops/mozart/lib/python3.9/site-packages (from hysds_commons>=0.1->hysds==1.1.4) (7.13.4)
Requirement already satisfied: jsonschema>=3.0.1 in /opt/conda/lib/python3.9/site-packages (from hysds_commons>=0.1->hysds==1.1.4) (3.2.0)
Requirement already satisfied: azure-storage-blob==1.4.0 in /home/ops/mozart/lib/python3.9/site-packages (from osaka>=0.0.1->hysds==1.1.4) (1.4.0)
Requirement already satisfied: google-cloud-storage>=0.22.0 in /home/ops/mozart/lib/python3.9/site-packages (from osaka>=0.0.1->hysds==1.1.4) (1.43.0)
Requirement already satisfied: configparser>=3.5.0 in /home/ops/mozart/lib/python3.9/site-packages (from osaka>=0.0.1->hysds==1.1.4) (5.2.0)
Requirement already satisfied: mock>=4.0.3 in /home/ops/mozart/lib/python3.9/site-packages (from osaka>=0.0.1->hysds==1.1.4) (4.0.3)
Requirement already satisfied: moto>=2.0.6 in /home/ops/mozart/lib/python3.9/site-packages (from osaka>=0.0.1->hysds==1.1.4) (2.3.0)
Requirement already satisfied: azure-storage-common~=1.4 in /home/ops/mozart/lib/python3.9/site-packages (from azure-storage-blob==1.4.0->osaka>=0.0.1->hysds==1.1.4) (1.4.2)
Requirement already satisfied: azure-common>=1.1.5 in /home/ops/mozart/lib/python3.9/site-packages (from azure-storage-blob==1.4.0->osaka>=0.0.1->hysds==1.1.4) (1.1.27)
Requirement already satisfied: prov==1.3.1 in /home/ops/mozart/lib/python3.9/site-packages (from prov_es>=0.2.0->hysds==1.1.4) (1.3.1)
Requirement already satisfied: networkx in /home/ops/mozart/lib/python3.9/site-packages (from prov==1.3.1->prov_es>=0.2.0->hysds==1.1.4) (2.6.3)
Collecting deprecated>=1.2.3
  Downloading Deprecated-1.2.13-py2.py3-none-any.whl (9.6 kB)
Requirement already satisfied: packaging>=21.3 in /opt/conda/lib/python3.9/site-packages (from redis>=3.2.1->hysds==1.1.4) (21.3)
Requirement already satisfied: certifi>=2017.4.17 in /opt/conda/lib/python3.9/site-packages (from requests>=2.20.0->hysds==1.1.4) (2021.10.8)
Requirement already satisfied: idna<4,>=2.5 in /opt/conda/lib/python3.9/site-packages (from requests>=2.20.0->hysds==1.1.4) (3.3)
Requirement already satisfied: charset-normalizer~=2.0.0 in /opt/conda/lib/python3.9/site-packages (from requests>=2.20.0->hysds==1.1.4) (2.0.4)
Requirement already satisfied: paramiko<3.0,>=2.0 in /opt/conda/lib/python3.9/site-packages (from fabric3->hysds==1.1.4) (2.8.1)
Collecting py>=1.8.2
  Downloading py-1.11.0-py2.py3-none-any.whl (98 kB)
     |████████████████████████████████| 98 kB 7.6 MB/s             
Requirement already satisfied: attrs>=19.2.0 in /opt/conda/lib/python3.9/site-packages (from pytest->hysds==1.1.4) (21.2.0)
Collecting iniconfig
  Downloading iniconfig-1.1.1-py2.py3-none-any.whl (5.0 kB)
Collecting toml
  Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting pluggy<2.0,>=0.12
  Downloading pluggy-1.0.0-py2.py3-none-any.whl (13 kB)
Collecting prompt-toolkit
  Downloading prompt_toolkit-3.0.24-py3-none-any.whl (374 kB)
     |████████████████████████████████| 374 kB 16.5 MB/s            
Collecting wrapt<2,>=1.10
  Downloading wrapt-1.13.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (81 kB)
     |████████████████████████████████| 81 kB 6.1 MB/s             
Requirement already satisfied: googleapis-common-protos<2.0dev,>=1.52.0 in /home/ops/mozart/lib/python3.9/site-packages (from google-api-core[grpc]<3.0.0dev,>=1.28.0->google-cloud-monitoring>=0.22.0->hysds==1.1.4) (1.54.0)
Requirement already satisfied: google-auth<3.0dev,>=1.25.0 in /home/ops/mozart/lib/python3.9/site-packages (from google-api-core[grpc]<3.0.0dev,>=1.28.0->google-cloud-monitoring>=0.22.0->hysds==1.1.4) (2.3.3)
Collecting grpcio<2.0dev,>=1.33.2
  Downloading grpcio-1.43.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.1 MB)
     |████████████████████████████████| 4.1 MB 11.8 MB/s            
Collecting grpcio-status<2.0dev,>=1.33.2
  Downloading grpcio_status-1.43.0-py3-none-any.whl (10.0 kB)
Requirement already satisfied: google-cloud-core<3.0dev,>=1.6.0 in /home/ops/mozart/lib/python3.9/site-packages (from google-cloud-storage>=0.22.0->osaka>=0.0.1->hysds==1.1.4) (2.2.1)
Requirement already satisfied: google-resumable-media<3.0dev,>=1.3.0 in /home/ops/mozart/lib/python3.9/site-packages (from google-cloud-storage>=0.22.0->osaka>=0.0.1->hysds==1.1.4) (2.1.0)
Requirement already satisfied: pyrsistent>=0.14.0 in /opt/conda/lib/python3.9/site-packages (from jsonschema>=3.0.1->hysds_commons>=0.1->hysds==1.1.4) (0.18.0)
Collecting amqp<6.0.0,>=5.0.9
  Downloading amqp-5.0.9-py3-none-any.whl (50 kB)
     |████████████████████████████████| 50 kB 6.7 MB/s             
Requirement already satisfied: responses>=0.9.0 in /home/ops/mozart/lib/python3.9/site-packages (from moto>=2.0.6->osaka>=0.0.1->hysds==1.1.4) (0.16.0)
Requirement already satisfied: werkzeug in /home/ops/mozart/lib/python3.9/site-packages (from moto>=2.0.6->osaka>=0.0.1->hysds==1.1.4) (2.0.2)
Requirement already satisfied: xmltodict in /home/ops/mozart/lib/python3.9/site-packages (from moto>=2.0.6->osaka>=0.0.1->hysds==1.1.4) (0.12.0)
Requirement already satisfied: cryptography>=3.3.1 in /opt/conda/lib/python3.9/site-packages (from moto>=2.0.6->osaka>=0.0.1->hysds==1.1.4) (35.0.0)
Requirement already satisfied: Jinja2>=2.10.1 in /home/ops/mozart/lib/python3.9/site-packages (from moto>=2.0.6->osaka>=0.0.1->hysds==1.1.4) (3.0.3)
Requirement already satisfied: MarkupSafe!=2.0.0a1 in /home/ops/mozart/lib/python3.9/site-packages (from moto>=2.0.6->osaka>=0.0.1->hysds==1.1.4) (2.0.1)
Requirement already satisfied: pynacl>=1.0.1 in /opt/conda/lib/python3.9/site-packages (from paramiko<3.0,>=2.0->fabric3->hysds==1.1.4) (1.4.0)
Requirement already satisfied: bcrypt>=3.1.3 in /opt/conda/lib/python3.9/site-packages (from paramiko<3.0,>=2.0->fabric3->hysds==1.1.4) (3.2.0)
Requirement already satisfied: pyasn1>=0.1.3 in /home/ops/mozart/lib/python3.9/site-packages (from rsa<4.8,>=3.1.2->awscli>=1.17.1->hysds==1.1.4) (0.4.8)
Requirement already satisfied: cffi>=1.1 in /opt/conda/lib/python3.9/site-packages (from bcrypt>=3.1.3->paramiko<3.0,>=2.0->fabric3->hysds==1.1.4) (1.14.6)
Requirement already satisfied: cachetools<5.0,>=2.0.0 in /home/ops/mozart/lib/python3.9/site-packages (from google-auth<3.0dev,>=1.25.0->google-api-core[grpc]<3.0.0dev,>=1.28.0->google-cloud-monitoring>=0.22.0->hysds==1.1.4) (4.2.4)
Requirement already satisfied: pyasn1-modules>=0.2.1 in /home/ops/mozart/lib/python3.9/site-packages (from google-auth<3.0dev,>=1.25.0->google-api-core[grpc]<3.0.0dev,>=1.28.0->google-cloud-monitoring>=0.22.0->hysds==1.1.4) (0.2.8)
Requirement already satisfied: google-crc32c<2.0dev,>=1.0 in /home/ops/mozart/lib/python3.9/site-packages (from google-resumable-media<3.0dev,>=1.3.0->google-cloud-storage>=0.22.0->osaka>=0.0.1->hysds==1.1.4) (1.3.0)
Collecting wcwidth
  Downloading wcwidth-0.2.5-py2.py3-none-any.whl (30 kB)
Requirement already satisfied: pycparser in /opt/conda/lib/python3.9/site-packages (from cffi>=1.1->bcrypt>=3.1.3->paramiko<3.0,>=2.0->fabric3->hysds==1.1.4) (2.21)
Installing collected packages: wcwidth, vine, prompt-toolkit, grpcio, click, amqp, wrapt, kombu, grpcio-status, click-repl, click-plugins, click-didyoumean, billiard, zope.interface, zope.event, tornado, toml, py, proto-plus, prometheus-client, pluggy, iniconfig, humanize, greenlet, dnspython, deprecated, celery, tabulate, redis, pytest, psutil, msgpack, httplib2, google-cloud-monitoring, google-cloud, gevent, flower, fabric3, eventlet, boto, aws-requests-auth, atomicwrites, hysds
  Running setup.py develop for hysds
Successfully installed amqp-5.0.9 atomicwrites-1.4.0 aws-requests-auth-0.4.3 billiard-3.6.4.0 boto-2.49.0 celery-5.2.2 click-8.0.3 click-didyoumean-0.3.0 click-plugins-1.1.1 click-repl-0.2.0 deprecated-1.2.13 dnspython-2.1.0 eventlet-0.33.0 fabric3-1.14.post1 flower-1.0.0 gevent-21.12.0 google-cloud-0.34.0 google-cloud-monitoring-2.8.0 greenlet-1.1.2 grpcio-1.43.0 grpcio-status-1.43.0 httplib2-0.20.2 humanize-3.13.1 hysds iniconfig-1.1.1 kombu-5.2.3 msgpack-1.0.3 pluggy-1.0.0 prometheus-client-0.12.0 prompt-toolkit-3.0.24 proto-plus-1.19.8 psutil-5.9.0 py-1.11.0 pytest-6.2.5 redis-4.1.0 tabulate-0.8.9 toml-0.10.2 tornado-6.1 vine-5.0.0 wcwidth-0.2.5 wrapt-1.13.3 zope.event-4.5.0 zope.interface-5.4.0
```