### PR TITLE
hotfix: handle race condition between job_worker cleanup and harikiri scripts

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.1.6"
+__version__ = "1.1.7"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/scripts/harikiri.py
+++ b/scripts/harikiri.py
@@ -115,6 +115,7 @@ def is_jobless(root_work, inactivity_secs, logger=None):
             done_file = os.path.join(job_dir, ".done")
             if not os.path.exists(done_file):
                 logging.info("%s: no .done file found. Not jobless yet." % job_dir)
+                NO_JOBS_TIMER = None
                 return False
             t = os.path.getmtime(done_file)
             done_dt = datetime.utcfromtimestamp(t)

--- a/scripts/harikiri_sqs.py
+++ b/scripts/harikiri_sqs.py
@@ -115,6 +115,7 @@ def is_jobless(root_work, inactivity_secs, logger=None):
             done_file = os.path.join(job_dir, ".done")
             if not os.path.exists(done_file):
                 logging.info("%s: no .done file found. Not jobless yet." % job_dir)
+                NO_JOBS_TIMER = None
                 return False
             t = os.path.getmtime(done_file)
             done_dt = datetime.utcfromtimestamp(t)


### PR DESCRIPTION
This hotfix addresses a race condition that can result in the harikiri*.py script running on a worker to terminate the instance it's running on. The specific scenario where this happens is this:

1. Upon instance startup, the harikiri*.py script starts up via systemd.
2. Since no jobs have been run yet, the `NO_JOBS_TIMER` will have been set to a recorded timestamp: https://github.com/hysds/hysds/blob/2fb20d85e4af9ce653185e5e811503ed61369069/scripts/harikiri_sqs.py#L128
3. The celery worker running `run_job` picks up jobs to run and has not yet exercised any cleanup of old work directories via https://github.com/hysds/hysds/blob/2fb20d85e4af9ce653185e5e811503ed61369069/hysds/job_worker.py#L276-L317.
4. A subsequent job is picked up that triggers the cleanup of **ALL** old work directories **RIGHT BEFORE** the harikiri*.py script is evaluating if there are any work directories to loop over to detect if jobs are still running. At this point in the harikiri*.py script, it will have found no work directories and thus jump to this check: https://github.com/hysds/hysds/blob/2fb20d85e4af9ce653185e5e811503ed61369069/scripts/harikiri_sqs.py#L130
5. Because the value of `NO_JOBS_TIMER` was recorded with a timestamp at the initial startup, the function will exit with `True` and initiate instance termination if the difference between the current time and the `NO_JOBS_TIMER` timestamp is greater than the inactivity threshold.

To handle this scenario, the fix is to reset the `NO_JOBS_TIMER` back to a value of `None` whenever a job is detected to still be running: https://github.com/hysds/hysds/blob/2fb20d85e4af9ce653185e5e811503ed61369069/scripts/harikiri_sqs.py#L118

This hotfix was tested and verified in the NISAR dev-int cluster during the joint load test.