### PR TITLE
Hot fix bulk publish

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.1.7"
+__version__ = "1.1.8"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/dataset_ingest_bulk.py
+++ b/hysds/dataset_ingest_bulk.py
@@ -504,7 +504,6 @@ def ingest_to_object_store(
                             )
                         else:
                             raise
-                delete_from_object_store(prod_path)
                 write_to_object_store(
                     local_prod_path,
                     pub_path_url,
@@ -541,7 +540,6 @@ def ingest_to_object_store(
                             }
                         },
                     )
-                    delete_from_object_store(prod_path)
                     write_to_object_store(
                         local_prod_path,
                         pub_path_url,


### PR DESCRIPTION
thanks @mcayanan  for figuring this out :+1:

was able to replicate this issue on a test cluster

we were calling `delete_from_object_store(prod_path)`  after it encounters a NoClobber but osaka would “error” out because `prod_path` **was actually the location of the job path** so it wasnt deleting an s3 object at all

for some reason even though osaka would error an exception wouldn’t be properly raised and it would **publish to elasticsearch anyways**, not sure why
but after removing those 2 lines it was able to function as intended

before:
```
[2022-08-20 04:56:26,024: INFO/ForkPoolWorker-1] hysds.job_worker.run_job[6eee308f-d1f6-43eb-b685-9da7a476386e]: Browse publish is configured.
[2022-08-20 04:56:26,024: INFO/ForkPoolWorker-1] Removing s3://s3-us-west-2.amazonaws.com:80/nisar-dev-lts-fwd-dustinlo/products/AOI_Oregon/_publish.context.json
[2022-08-20 04:56:26,025: INFO/ForkPoolWorker-1] Removing URI s3://s3-us-west-2.amazonaws.com:80/nisar-dev-lts-fwd-dustinlo/products/AOI_Oregon/_publish.context.json
[2022-08-20 04:56:26,025: INFO/ForkPoolWorker-1] Making session with: {"region_name": "us-west-2", "profile_name": "default"}
[2022-08-20 04:56:26,183: INFO/ForkPoolWorker-1] Checking lock status of s3://s3-us-west-2.amazonaws.com:80/nisar-dev-lts-fwd-dustinlo/products/AOI_Oregon/_publish.context.json in s3://s3-us-west-2.amazonaws.com:80/nisar-dev-lts-fwd-dustinlo/products/AOI_Oregon/_publish.context.json.osaka.locked.json
du: cannot access '/data/work/jobs/2022/08/20/04/56/aoi_oregon__master-AOI_sacramento_valley-20220820T045621.965739Z/AOI_Oregon': No such file or directory  <------ ERROR HERE
[2022-08-20 04:56:26,445: INFO/ForkPoolWorker-1] hysds.job_worker.run_job[6eee308f-d1f6-43eb-b685-9da7a476386e]: publishing 1 dataset(s) to Elasticsearch
```

after:
```
[2022-08-20 05:26:57,647: INFO/ForkPoolWorker-1] Removing s3://s3-us-west-2.amazonaws.com:80/nisar-dev-lts-fwd-dustinlo/products/AOI_Oregon
[2022-08-20 05:26:57,647: INFO/ForkPoolWorker-1] Removing URI s3://s3-us-west-2.amazonaws.com:80/nisar-dev-lts-fwd-dustinlo/products/AOI_Oregon
.
.
.
[2022-08-20 05:26:59,778: INFO/ForkPoolWorker-1] hysds.job_worker.run_job[5d1f82b6-189e-441b-bad4-0c82b7a5cacd]: Browse publish is configured.
[2022-08-20 05:26:59,779: INFO/ForkPoolWorker-1] Removing s3://s3-us-west-2.amazonaws.com:80/nisar-dev-lts-fwd-dustinlo/products/AOI_Oregon/_publish.context.json
[2022-08-20 05:26:59,779: INFO/ForkPoolWorker-1] Removing URI s3://s3-us-west-2.amazonaws.com:80/nisar-dev-lts-fwd-dustinlo/products/AOI_Oregon/_publish.context.json
[2022-08-20 05:26:59,779: INFO/ForkPoolWorker-1] Making session with: {"region_name": "us-west-2", "profile_name": "default"}
[2022-08-20 05:26:59,850: INFO/ForkPoolWorker-1] Checking lock status of s3://s3-us-west-2.amazonaws.com:80/nisar-dev-lts-fwd-dustinlo/products/AOI_Oregon/_publish.context.json in s3://s3-us-west-2.amazonaws.com:80/nisar-dev-lts-fwd-dustinlo/products/AOI_Oregon/_publish.context.json.osaka.locked.json
[2022-08-20 05:27:00,084: INFO/ForkPoolWorker-1] hysds.job_worker.run_job[5d1f82b6-189e-441b-bad4-0c82b7a5cacd]: publishing 1 dataset(s) to Elasticsearch
```

those 2 lines were redundant because we would force ingest and it would clear out s3 anyways