### PR TITLE
HC-425 - propagate Elasticsearch errors encountered during dataset indexing in grq2

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.1.8"
+__version__ = "1.1.9"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/dataset_ingest.py
+++ b/hysds/dataset_ingest.py
@@ -76,7 +76,6 @@ def index_dataset(grq_update_url, update_json):
         grq_update_url, verify=False, data={"dataset_info": json.dumps(update_json)}
     )
     if not 200 <= r.status_code < 300:
-        logger.error(r.text)
         raise RuntimeError(r.text)
     return r.json()
 

--- a/hysds/dataset_ingest.py
+++ b/hysds/dataset_ingest.py
@@ -75,6 +75,7 @@ def index_dataset(grq_update_url, update_json):
     r = requests.post(
         grq_update_url, verify=False, data={"dataset_info": json.dumps(update_json)}
     )
+    logger.info(r.text)
     r.raise_for_status()
     return r.json()
 

--- a/hysds/dataset_ingest.py
+++ b/hysds/dataset_ingest.py
@@ -65,7 +65,7 @@ def verify_dataset(dataset):
 
 @backoff.on_exception(
     backoff.expo,
-    requests.RequestException,
+    RuntimeError,
     max_tries=backoff_max_tries,
     max_value=backoff_max_value,
 )
@@ -75,8 +75,9 @@ def index_dataset(grq_update_url, update_json):
     r = requests.post(
         grq_update_url, verify=False, data={"dataset_info": json.dumps(update_json)}
     )
-    logger.info(r.text)
-    r.raise_for_status()
+    if not 200 <= r.status_code < 300:
+        logger.error(r.text)
+        raise RuntimeError(r.text)
     return r.json()
 
 

--- a/hysds/dataset_ingest.py
+++ b/hysds/dataset_ingest.py
@@ -65,7 +65,7 @@ def verify_dataset(dataset):
 
 @backoff.on_exception(
     backoff.expo,
-    RuntimeError,
+    (RuntimeError, requests.RequestException),
     max_tries=backoff_max_tries,
     max_value=backoff_max_value,
 )

--- a/hysds/dataset_ingest_bulk.py
+++ b/hysds/dataset_ingest_bulk.py
@@ -734,7 +734,7 @@ def ingest_to_object_store(
 
 @backoff.on_exception(
     backoff.expo,
-    NotAllProductsIngested,
+    (NotAllProductsIngested, requests.RequestException),
     max_tries=backoff_max_tries,
     max_value=backoff_max_value,
 )

--- a/hysds/dataset_ingest_bulk.py
+++ b/hysds/dataset_ingest_bulk.py
@@ -747,7 +747,6 @@ def bulk_index_dataset(grq_update_url, update_jsons):
     """
     r = requests.post(grq_update_url, verify=False, json=json.dumps(update_jsons))
     if not 200 <= r.status_code < 300:
-        logger.error("grq2 index error: %s" % r.text)
         raise NotAllProductsIngested(r.text)
     return r.json()
 


### PR DESCRIPTION
change(s):
- `r.raise_for_status()` doesn't propagate the error to grq2's error to the Figaro UI, raising the error manually instead
- bumped version

related PR: https://github.com/hysds/grq2/pull/55

related ticket: https://hysds-core.atlassian.net/browse/HC-425

```
[2022-08-24 18:46:23,148: INFO/ForkPoolWorker-1] Backing off bulk_index_dataset(...) for 0.5s (hysds.dataset_ingest_bulk.NotAllProductsIngested: {"success": false, "message": "Error: <class 'NameError'>:name 'fsjdkfshdkjfsdhkfjs' is not defined\nTraceback (most recent call last):\n  File \"/export/home/hysdsops/sciflo/ops/grq2/grq2/services/api_v02/datasets.py\", line 127, in post\n    print(fsjdkfshdkjfsdhkfjs)\nNameError: name 'fsjdkfshdkjfsdhkfjs' is not defined\n", "objectid": null, "index": null})
```

<img width="1024" alt="Screen Shot 2022-08-24 at 11 48 40 AM" src="https://user-images.githubusercontent.com/13371881/186500361-a1b0d4eb-2d3c-4659-b409-3ecc634a2fe1.png">

