### PR TITLE
HC-435: Upgrade Elasticsearch 7.9 -> 7.10

### DIFF
--- a/configs/logstash/event_status.template
+++ b/configs/logstash/event_status.template
@@ -39,6 +39,15 @@
           "text_fields"
         ]
       },
+      "id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "tags": {
         "type": "text",
         "fields": {

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -34,6 +34,16 @@ filter {
       rename => { "[event][local_received_new]" => "local_received" }
     }
   }
+
+  if [resource] in ["event", "job", "task"] {
+    mutate {
+      add_field => { "id" => "%{uuid}" }
+    }
+  } else if [resource] == "worker" {
+    mutate {
+      add_field => { "id" => "%{celery_hostname}" }
+    }
+  }
 }
 
 output {

--- a/configs/logstash/job_status.template
+++ b/configs/logstash/job_status.template
@@ -548,6 +548,15 @@
           "text_fields"
         ]
       },
+      "id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "job_id": {
         "type": "keyword",
         "ignore_above": 256,

--- a/configs/logstash/task_status.template
+++ b/configs/logstash/task_status.template
@@ -43,6 +43,15 @@
           "text_fields"
         ]
       },
+      "id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "event": {
         "properties": {
           "sw_sys": {

--- a/configs/logstash/worker_status.template
+++ b/configs/logstash/worker_status.template
@@ -43,6 +43,15 @@
           "text_fields"
         ]
       },
+      "id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "event": {
         "properties": {
           "sw_sys": {

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.1.9"
+__version__ = "1.1.10"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"


### PR DESCRIPTION
related ticket(s):
- https://hysds-core.atlassian.net/browse/HC-435
- https://jira.jpl.nasa.gov/browse/NSDS-2302

related PR(s):
- https://github.com/hysds/hysds_commons/pull/48

change(s):
- added `id` field to templates (`job_status`, `event_status`, `worker_status`, `task_status`)
- changed logstash indexer to add `id` field during indexing
- bump version