### PR TITLE
HC-447 (update): Update Mozart clean up scripts to properly remove job_status indices

### DIFF
--- a/scripts/clean_job_status_indexes.py
+++ b/scripts/clean_job_status_indexes.py
@@ -30,7 +30,7 @@ def delete_job_status(es_url):
     r = requests.get(f"{es_url}/_alias/{alias}")
     r.raise_for_status()
     scan_result = r.json()
-    print(json.dumps(scan_result, indent=2))
+    logging.info(f"Found indices associated with alias {alias}:\n{json.dumps(scan_result, indent=2)}")
     for index in scan_result.keys():
         logging.info(f"Deleting from Mozart ES: {index}")
         r = requests.delete("f{es_url}/{index}")

--- a/scripts/clean_job_status_indexes.py
+++ b/scripts/clean_job_status_indexes.py
@@ -17,9 +17,10 @@ logging.basicConfig(format=log_format, level=logging.INFO)
 
 
 def delete_job_status(es_url):
-    """Remove any started jobs from ES job_status index if
-    the start_time for the task is earlier than the passed
-    in start_time."""
+    """
+    Finds the indices associated with the job_status-current alias.
+    For each one found, delete it.
+    """
 
     alias = "job_status-current"
     r = requests.get(f"{es_url}/_alias/{alias}")

--- a/scripts/clean_job_status_indexes.py
+++ b/scripts/clean_job_status_indexes.py
@@ -6,15 +6,10 @@ from __future__ import absolute_import
 from future import standard_library
 
 standard_library.install_aliases()
-import os
 import sys
 import requests
 import json
 import logging
-from subprocess import Popen, PIPE
-from pprint import pprint
-
-from hysds.celery import app
 
 
 log_format = "[%(asctime)s: %(levelname)s/%(funcName)s] %(message)s"

--- a/scripts/clean_job_status_indexes.py
+++ b/scripts/clean_job_status_indexes.py
@@ -28,7 +28,7 @@ def delete_job_status(es_url):
     logging.info(f"Found indices associated with alias {alias}:\n{json.dumps(scan_result, indent=2)}")
     for index in scan_result.keys():
         logging.info(f"Deleting from Mozart ES: {index}")
-        r = requests.delete("f{es_url}/{index}")
+        r = requests.delete(f"{es_url}/{index}")
         r.raise_for_status()
 
 

--- a/scripts/clean_job_status_indexes.py
+++ b/scripts/clean_job_status_indexes.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+
+standard_library.install_aliases()
+import os
+import sys
+import requests
+import json
+import logging
+from subprocess import Popen, PIPE
+from pprint import pprint
+
+from hysds.celery import app
+
+
+log_format = "[%(asctime)s: %(levelname)s/%(funcName)s] %(message)s"
+logging.basicConfig(format=log_format, level=logging.INFO)
+
+
+def delete_job_status(es_url):
+    """Remove any started jobs from ES job_status index if
+    the start_time for the task is earlier than the passed
+    in start_time."""
+
+    alias = "job_status-current"
+    r = requests.get(f"{es_url}/_alias/{alias}")
+    r.raise_for_status()
+    scan_result = r.json()
+    print(json.dumps(scan_result, indent=2))
+    for index in scan_result.keys():
+        logging.info(f"Deleting from Mozart ES: {index}")
+        r = requests.delete("f{es_url}/{index}")
+        r.raise_for_status()
+
+
+if __name__ == "__main__":
+    mozart_es_url = sys.argv[1]
+    delete_job_status(mozart_es_url)

--- a/scripts/clean_job_status_indexes.sh
+++ b/scripts/clean_job_status_indexes.sh
@@ -2,4 +2,3 @@
 ES_URL=$1
 
 python ${MOZART_DIR}/ops/hysds/scripts/clean_job_status_indexes.py ${ES_URL}
-

--- a/scripts/clean_job_status_indexes.sh
+++ b/scripts/clean_job_status_indexes.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 ES_URL=$1
 
-curl -XDELETE "${ES_URL}/job_status-current"
+python clean_job_status_indexes.py ${ES_URL}
+

--- a/scripts/clean_job_status_indexes.sh
+++ b/scripts/clean_job_status_indexes.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 ES_URL=$1
-cwd=$(pwd)
 
-python ${cwd}/clean_job_status_indexes.py ${ES_URL}
+python ${MOZART_DIR}/ops/hysds/scripts/clean_job_status_indexes.py ${ES_URL}
 

--- a/scripts/clean_job_status_indexes.sh
+++ b/scripts/clean_job_status_indexes.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 ES_URL=$1
+cwd=$(pwd)
 
-python clean_job_status_indexes.py ${ES_URL}
+python ${cwd}/clean_job_status_indexes.py ${ES_URL}
 

--- a/scripts/clean_mozart_indexes.sh
+++ b/scripts/clean_mozart_indexes.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 ES_URL=$1
+cwd=$(pwd)
 
-python clean_job_status_indexes.py ${ES_URL}
+python ${cwd}/clean_job_status_indexes.py ${ES_URL}
 curl -XDELETE "${ES_URL}/worker_status-current"
 curl -XDELETE "${ES_URL}/task_status-current"
 curl -XDELETE "${ES_URL}/event_status-current"

--- a/scripts/clean_mozart_indexes.sh
+++ b/scripts/clean_mozart_indexes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ES_URL=$1
 
-curl -XDELETE "${ES_URL}/job_status-current"
+python clean_job_status_indexes.py ${ES_URL}
 curl -XDELETE "${ES_URL}/worker_status-current"
 curl -XDELETE "${ES_URL}/task_status-current"
 curl -XDELETE "${ES_URL}/event_status-current"

--- a/scripts/clean_mozart_indexes.sh
+++ b/scripts/clean_mozart_indexes.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 ES_URL=$1
-cwd=$(pwd)
 
-python ${cwd}/clean_job_status_indexes.py ${ES_URL}
+python ${MOZART_DIR}/ops/hysds/scripts/clean_job_status_indexes.py ${ES_URL}
 curl -XDELETE "${ES_URL}/worker_status-current"
 curl -XDELETE "${ES_URL}/task_status-current"
 curl -XDELETE "${ES_URL}/event_status-current"


### PR DESCRIPTION
### Overview

This PR updates the clean up scripts to properly clean out the job status indices. 

During testing, it was discovered that when running the `sds -d reset mozart` command, the following error message was appearing:

```
[100.104.10.166] run: ~/mozart/ops/hysds/scripts/clean_job_status_indexes.sh http://100.104.10.166:9200
[100.104.10.166] out: {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"The provided expression [job_status-current] matches an alias, specify the corresponding concrete indices instead."}],"type":"illegal_argument_exception","reason":"The provided expression [job_status-current] matches an alias, specify the corresponding concrete indices instead."},"status":400}
```

Therefore, the `cleanup_job_status_indexes.sh` script was updated such that we will call a script instead to:

- Find the indices associated with the job_status-current alias
- For each index found, delete it

### Testing

With this change, when you run `sds -d reset mozart`, I now see this:

```
[100.104.10.166] run: ~/mozart/ops/hysds/scripts/clean_job_status_indexes.sh http://100.104.10.166:9200
[100.104.10.166] out: [2023-02-06 20:49:39,798: INFO/delete_job_status] Found indices associated with alias job_status-current:
[100.104.10.166] out: {
[100.104.10.166] out:   "job_status-2023.02.06": {
[100.104.10.166] out:     "aliases": {
[100.104.10.166] out:       "job_status-current": {}
[100.104.10.166] out:     }
[100.104.10.166] out:   }
[100.104.10.166] out: }
[100.104.10.166] out: [2023-02-06 20:49:39,798: INFO/delete_job_status] Deleting from Mozart ES: job_status-2023.02.06
```