### PR TITLE
HC-447-update-2: Update handling of non-existent aliases

### DIFF
--- a/scripts/clean_job_status_indexes.py
+++ b/scripts/clean_job_status_indexes.py
@@ -24,13 +24,19 @@ def delete_job_status(es_url):
 
     alias = "job_status-current"
     r = requests.get(f"{es_url}/_alias/{alias}")
-    r.raise_for_status()
-    scan_result = r.json()
-    logging.info(f"Found indices associated with alias {alias}:\n{json.dumps(scan_result, indent=2)}")
-    for index in scan_result.keys():
-        logging.info(f"Deleting from Mozart ES: {index}")
-        r = requests.delete(f"{es_url}/{index}")
-        r.raise_for_status()
+    if r.status_code == 404:
+        # If we get a 404, its safe to assume this is a fresh install
+        # and we don’t have to proceed with any subsequent request calls
+        logging.info(f"404 Client Error: Not Found for url: {es_url}/_alias/{alias}")
+    else:
+        scan_result = r.json()
+        logging.info(
+            f"Found indices associated with alias {alias}:\n{json.dumps(scan_result, indent=2)}"
+        )
+        for index in scan_result.keys():
+            logging.info(f"Deleting from Mozart ES: {index}")
+            r = requests.delete(f"{es_url}/{index}")
+            r.raise_for_status()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Overview

- This PR updates the handling of non-existent aliases within the `delete_job_status()` function.
- This PR is related to https://github.jpl.nasa.gov/IEMS-SDS/swot-pcm/pull/502 (Add mechanism for rolling off old ES indices in Metrics ES).

## Testing

- This branch was used in a  SWOT PCM end-to-end smoke test, linked below.
- forward-using-MOE: [![Build Status](https://swot-pcm-ci.jpl.nasa.gov/buildStatus/icon?job=force-branches%2Falgermis-force_branch-E2E-test&build=572)](https://swot-pcm-ci.jpl.nasa.gov/job/force-branches/job/algermis-force_branch-E2E-test/572/)
