### PR TITLE
NSDS-2584 - Implement rollover of old task, worker, event ES docs on Mozart ES

### DIFF
--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -47,7 +47,7 @@ filter {
 }
 
 output {
-  stdout { codec => rubydebug }
+  #stdout { codec => rubydebug }
 
   if [resource] == "job" {
     elasticsearch {

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -47,7 +47,7 @@ filter {
 }
 
 output {
-  #stdout { codec => rubydebug }
+  stdout { codec => rubydebug }
 
   if [resource] == "job" {
     elasticsearch {
@@ -58,7 +58,7 @@ output {
   } else if [resource] == "worker" {
     elasticsearch {
       hosts => ["{{ MOZART_ES_PVT_IP }}:9200"]
-      index => "worker_status-current"
+      index => "worker_status-%{+YYYY.MM.dd}"
       document_id => "%{celery_hostname}"
     }
   } else if [resource] == "task" {
@@ -70,7 +70,7 @@ output {
   } else if [resource] == "event" {
     elasticsearch {
       hosts => ["{{ MOZART_ES_PVT_IP }}:9200"]
-      index => "event_status-current"
+      index => "event_status-%{+YYYY.MM.dd}"
       document_id => "%{uuid}"
     }
   } else {}

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -64,7 +64,7 @@ output {
   } else if [resource] == "task" {
     elasticsearch {
       hosts => ["{{ MOZART_ES_PVT_IP }}:9200"]
-      index => "task_status-current"
+      index => "%{index}"
       document_id => "%{uuid}"
     }
   } else if [resource] == "event" {

--- a/scripts/clean_indices_from_alias.py
+++ b/scripts/clean_indices_from_alias.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+
+standard_library.install_aliases()
+import sys
+import requests
+import json
+import logging
+
+
+log_format = "[%(asctime)s: %(levelname)s/%(funcName)s] %(message)s"
+logging.basicConfig(format=log_format, level=logging.INFO)
+
+
+def delete_job_status(es_url, alias):
+    """
+    Finds the indices associated with the job_status-current alias.
+    For each one found, delete it.
+    """
+
+    r = requests.get(f"{es_url}/_alias/{alias}")
+    if r.status_code == 404:
+        # If we get a 404, its safe to assume this is a fresh install
+        # and we don’t have to proceed with any subsequent request calls
+        logging.info(f"404 Client Error: Not Found for url: {es_url}/_alias/{alias}")
+    else:
+        scan_result = r.json()
+        logging.info(f"Found indices associated with alias {alias}:\n{json.dumps(scan_result, indent=2)}")
+        for index in scan_result.keys():
+            logging.info(f"Deleting from Mozart ES: {index}")
+            r = requests.delete(f"{es_url}/{index}")
+            r.raise_for_status()
+
+
+if __name__ == "__main__":
+    mozart_es_url = sys.argv[1]
+    alias_name = sys.argv[2]
+    delete_job_status(mozart_es_url, alias_name)

--- a/scripts/process_events.py
+++ b/scripts/process_events.py
@@ -113,6 +113,7 @@ def log_worker_event(event_type, event, uuid=[]):
     global POOL
     info = {
         "resource": "worker",
+        "index": event.get("index", f"task_status-{datetime.utcnow().strftime('%Y.%m.%d')}"),
         "type": parse_job_type(event),
         "status": event_type,
         "celery_hostname": event["hostname"],

--- a/scripts/process_events.py
+++ b/scripts/process_events.py
@@ -86,6 +86,7 @@ def log_task_event(event_type, event, uuid=[]):
     global POOL
     info = {
         "resource": "task",
+        "index": event.get("index", f"task_status-{datetime.utcnow().strftime('%Y.%m.%d')}"),
         "type": parse_job_type(event),
         "status": event_type,
         "celery_hostname": event.get("hostname", None),
@@ -113,7 +114,6 @@ def log_worker_event(event_type, event, uuid=[]):
     global POOL
     info = {
         "resource": "worker",
-        "index": event.get("index", f"task_status-{datetime.utcnow().strftime('%Y.%m.%d')}"),
         "type": parse_job_type(event),
         "status": event_type,
         "celery_hostname": event["hostname"],


### PR DESCRIPTION
https://jira.jpl.nasa.gov/browse/NSDS-2584

related PR: https://github.com/sdskit/sdscli/pull/99

change(s):
- created `clean_indices_from_alias.py` to delete index by alias passed by `argv`
- `worker` and `event` index name will have date time appended through logstash
- `task` index name now has date time through the `event` body; (for clobbering) similar to how its done for `job_status-*`

<img width="1003" alt="Screenshot 2023-03-08 at 10 50 21 AM" src="https://user-images.githubusercontent.com/13371881/223823731-e58cf83f-23df-4a86-982d-c5ca8a1ec226.png">
