### PR TITLE
pin redis-py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "redis>=3.2.1",
+        "redis>=3.2.1,!=4.5.2",  # https://github.com/redis/redis-py/issues/2629
         "celery>=5.2.2,<6.0.0,!=5.2.3",
         "requests>=2.20.0",
         "flower>=1.0.0",


### PR DESCRIPTION
related issue: https://github.com/redis/redis-py/issues/2629

```
[2023-03-20 22:28:46,583: WARNING/process_events] Received method (60, 60) during closing channel 1. This method will be ignored
Traceback (most recent call last):
  File "/export/home/hysdsops/mozart/ops/hysds/scripts/process_events.py", line 256, in <module>
    event_monitor(app)
  File "/export/home/hysdsops/mozart/ops/hysds/scripts/process_events.py", line 252, in event_monitor
    recv.capture(limit=None, timeout=None, wakeup=True)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/celery/events/receiver.py", line 91, in capture
    for _ in self.consume(limit=limit, timeout=timeout, wakeup=wakeup):
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/kombu/mixins.py", line 193, in consume
    conn.drain_events(timeout=safety_interval)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/kombu/connection.py", line 316, in drain_events
    return self.transport.drain_events(self.connection, **kwargs)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/kombu/transport/pyamqp.py", line 169, in drain_events
    return connection.drain_events(**kwargs)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/amqp/connection.py", line 525, in drain_events
    while not self.blocking_read(timeout):
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/amqp/connection.py", line 531, in blocking_read
    return self.on_inbound_frame(frame)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/amqp/method_framing.py", line 77, in on_frame
    callback(channel, msg.frame_method, msg.frame_args, msg)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/amqp/connection.py", line 537, in on_inbound_method
    return self.channels[channel_id].dispatch_method(
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/amqp/abstract_channel.py", line 156, in dispatch_method
    listener(*args)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/amqp/channel.py", line 1629, in _on_basic_deliver
    fun(msg)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/kombu/messaging.py", line 626, in _receive_callback
    return on_m(message) if on_m else self.receive(decoded, message)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/kombu/messaging.py", line 592, in receive
    [callback(body, message) for callback in callbacks]
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/kombu/messaging.py", line 592, in <listcomp>
    [callback(body, message) for callback in callbacks]
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/celery/events/receiver.py", line 131, in _receive
    self.process(*self.event_from_message(body))
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/celery/events/receiver.py", line 69, in process
    handler and handler(event)
  File "/export/home/hysdsops/mozart/ops/hysds/scripts/process_events.py", line 228, in worker_heartbeat
    log_worker_status(event["hostname"], event["type"])
  File "/export/home/hysdsops/mozart/ops/hysds/scripts/process_events.py", line 145, in log_worker_status
    r.setex(WORKER_STATUS_KEY_TMPL % worker, 60, status)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/redis/commands/core.py", line 2327, in setex
    return self.execute_command("SETEX", name, time, value)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/redis/client.py", line 1255, in execute_command
    conn = self.connection or pool.get_connection(command_name, **options)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/redis/connection.py", line 1441, in get_connection
    connection.connect()
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/redis/connection.py", line 698, in connect
    sock = self.retry.call_with_retry(
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/redis/retry.py", line 46, in call_with_retry
    return do()
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/redis/connection.py", line 699, in <lambda>
    lambda: self._connect(), lambda error: self.disconnect(error)
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/redis/connection.py", line 1171, in _connect
    sock.settimeout(self.socket_timeout)
AttributeError: 'UnixDomainSocketConnection' object has no attribute 'socket_timeout'
```