### PR TITLE
hot-fix: Make redis pin less than 4.5.2

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "redis>=3.2.1,!=4.5.2",  # https://github.com/redis/redis-py/issues/2629
+        "redis>=3.2.1,<4.5.2",  # https://github.com/redis/redis-py/issues/2629
         "celery>=5.2.2,<6.0.0,!=5.2.3",
         "requests>=2.20.0",
         "flower>=1.0.0",


### PR DESCRIPTION
With https://github.com/hysds/hysds/pull/155, the redis module was setup to not include 4.5.2. However, 4.5.3 was just released yesterday and unfortunately, it broke the cluster provisioners with the same Socket Timeout error:

![image](https://user-images.githubusercontent.com/42812746/227255245-185694af-a8e3-4dca-80c5-22bcd8772440.png)

Therefore, it's probably best to make the pin `<4.5.2` as opposed to `!=4.5.2` for the time being.