### PR TITLE
HC-460: address performance of publishing products

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/dataset_ingest_bulk.py
+++ b/hysds/dataset_ingest_bulk.py
@@ -29,8 +29,8 @@ from importlib import import_module
 
 from tempfile import mkdtemp
 
-from billiard.managers import BaseManager as Manager
-from billiard.pool import Pool, cpu_count
+from billiard import Manager  # noqa
+from billiard.pool import Pool, cpu_count  # noqa
 
 from hysds.utils import get_disk_usage, makedirs, get_job_status, dataset_exists, find_dataset_json
 from hysds.log_utils import logger, log_prov_es, log_custom_event, log_publish_prov_es, backoff_max_value, \
@@ -778,9 +778,9 @@ def async_publish_files(job, ctx, prod_dir, event=None):
     try:
         # get job info
         job_dir = job["job_info"]["job_dir"]
-        time_start_iso = job["job_info"]["time_start"]  # TODO: these variables are used in publishing
-        context_file = job["job_info"]["context_file"]  # TODO: these variables are used in publishing
-        datasets_cfg_file = job["job_info"]["datasets_cfg_file"]  # TODO: these variables are used in publishing
+        time_start_iso = job["job_info"]["time_start"]
+        context_file = job["job_info"]["context_file"]
+        datasets_cfg_file = job["job_info"]["datasets_cfg_file"]
 
         time_start = parse_iso8601(time_start_iso)  # time start
 
@@ -913,7 +913,7 @@ def publish_datasets(job, ctx):
     published_prods = []  # find and publish
 
     async_tasks = []
-    num_procs = max(cpu_count() - 2, 1)  # TODO: create configuration in sdscli
+    num_procs = max(cpu_count() - 2, 1)  # TODO: create configuration in sdscli? (maybe)
 
     with Pool(num_procs) as pool, Manager() as manager:
         event = manager.Event()

--- a/hysds/dataset_ingest_bulk.py
+++ b/hysds/dataset_ingest_bulk.py
@@ -29,6 +29,9 @@ from importlib import import_module
 
 from tempfile import mkdtemp
 
+from billiard.managers import BaseManager as Manager
+from billiard.pool import Pool, cpu_count
+
 from hysds.utils import get_disk_usage, makedirs, get_job_status, dataset_exists, find_dataset_json
 from hysds.log_utils import logger, log_prov_es, log_custom_event, log_publish_prov_es, backoff_max_value, \
     backoff_max_tries
@@ -136,6 +139,7 @@ def delete_from_object_store(url, params=None):
     """
     Remove a dataset at (and below) the given url
     @param url - url to remove files (at and below)
+    @param params - osaka.main.rmall parameters - https://github.com/hysds/osaka/blob/develop/osaka/main.py#L151
     """
 
     # set osaka params
@@ -152,6 +156,7 @@ def write_to_object_store(
     Publish a dataset to the given url
     @param path - path of dataset to publish
     @param url - url to publish to
+    @param params - osaka.main.put params - https://github.com/hysds/osaka/blob/develop/osaka/main.py#L29
     @param force - unpublish dataset first if exists
     @param publ_ctx_file - publish context file
     @param publ_ctx_url - url to publish context file to
@@ -757,6 +762,133 @@ def queue_dataset(dataset, update_json, queue_name):
     do_submit_job(payload, queue_name)
 
 
+def async_publish_files(job, ctx, prod_dir, event=None):
+    """
+    publish single dataset given the product directory, can be used in both multiprocessing or synchronous
+    :param job [Dict] - job object
+    :param ctx [Dict] - job context
+    :param prod_dir [Str] - str; product directory
+    :param event [Event, Optional] - Event to halt tasks if previous failed, taken from multiprocessing Manager()
+    """
+
+    if event and event.is_set():
+        logger.warning("Previous task failed, skipping %s..." % prod_dir)
+        return
+
+    try:
+        # get job info
+        job_dir = job["job_info"]["job_dir"]
+        time_start_iso = job["job_info"]["time_start"]  # TODO: these variables are used in publishing
+        context_file = job["job_info"]["context_file"]  # TODO: these variables are used in publishing
+        datasets_cfg_file = job["job_info"]["datasets_cfg_file"]  # TODO: these variables are used in publishing
+
+        time_start = parse_iso8601(time_start_iso)  # time start
+
+        # check for PROV-ES JSON from PGE; if exists, append related PROV-ES info;
+        # also overwrite merged PROV-ES JSON file
+        prod_id = os.path.basename(prod_dir)
+        prov_es_file = os.path.join(prod_dir, "%s.prov_es.json" % prod_id)
+        prov_es_info = {}
+        if os.path.exists(prov_es_file):
+            with open(prov_es_file) as f:
+                try:
+                    prov_es_info = json.load(f)
+                except Exception as e:
+                    tb = traceback.format_exc()
+                    raise RuntimeError(
+                        "Failed to log PROV-ES from {}: {}\n{}".format(
+                            prov_es_file, str(e), tb
+                        )
+                    )
+            log_prov_es(job, prov_es_info, prov_es_file)
+
+        # copy _context.json
+        prod_context_file = os.path.join(prod_dir, "%s.context.json" % prod_id)
+        shutil.copy(context_file, prod_context_file)
+
+        # force ingest? (i.e. disable no-clobber)
+        ingest_kwargs = {"force": False}
+        if ctx.get("_force_ingest", False):
+            logger.info("Flag _force_ingest set to True.")
+            ingest_kwargs["force"] = True
+
+        # upload
+        tx_t1 = datetime.utcnow()
+        metrics, prod_json = ingest_to_object_store(
+            *(
+                prod_id,
+                datasets_cfg_file,
+                prod_dir,
+                job_dir,
+            ),
+            **ingest_kwargs
+        )
+
+        tx_t2 = datetime.utcnow()
+        tx_dur = (tx_t2 - tx_t1).total_seconds()
+        prod_dir_usage = get_disk_usage(prod_dir)
+
+        # set product provenance
+        prod_prov = {
+            "product_type": metrics["ipath"],
+            "processing_start_time": time_start.isoformat() + "Z",
+            "availability_time": tx_t2.isoformat() + "Z",
+            "processing_latency": (tx_t2 - time_start).total_seconds() / 60.0,
+            "total_latency": (tx_t2 - time_start).total_seconds() / 60.0,
+        }
+        prod_prov_file = os.path.join(prod_dir, "%s.prod_prov.json" % prod_id)
+        if os.path.exists(prod_prov_file):
+            with open(prod_prov_file) as f:
+                prod_prov.update(json.load(f))
+        if "acquisition_start_time" in prod_prov:
+            if "source_production_time" in prod_prov:
+                prod_prov["ground_system_latency"] = (
+                                                             parse_iso8601(prod_prov["source_production_time"])
+                                                             - parse_iso8601(prod_prov["acquisition_start_time"])
+                                                     ).total_seconds() / 60.0
+                prod_prov["total_latency"] += prod_prov["ground_system_latency"]
+                prod_prov["access_latency"] = (
+                                                      tx_t2 - parse_iso8601(prod_prov["source_production_time"])
+                                              ).total_seconds() / 60.0
+                prod_prov["total_latency"] += prod_prov["access_latency"]
+        # write product provenance of the last product; not writing to an array under the
+        # product because kibana table panel won't show them correctly:
+        # https://github.com/elasticsearch/kibana/issues/998
+        job["job_info"]["metrics"]["product_provenance"] = prod_prov
+
+        product_staged_metadata = {
+            "path": prod_dir,
+            "disk_usage": prod_dir_usage,
+            "time_start": tx_t1.isoformat() + "Z",
+            "time_end": tx_t2.isoformat() + "Z",
+            "duration": tx_dur,
+            "transfer_rate": prod_dir_usage / tx_dur,
+            "id": prod_json["id"],
+            "urls": prod_json["urls"],
+            "browse_urls": prod_json["browse_urls"],
+            "dataset": prod_json["dataset"],
+            "ipath": prod_json["ipath"],
+            "system_version": prod_json["system_version"],
+            "dataset_level": prod_json["dataset_level"],
+            "dataset_type": prod_json["dataset_type"],
+            "index": prod_json["grq_index_result"]["index"],
+        }
+
+        return prod_json, product_staged_metadata, metrics
+    except (Exception, ):
+        if event:
+            event.set()
+        logger.error("Publishing fialed on %s" % prod_dir)
+        logger.error(traceback.format_exc())
+
+
+def async_delete_files(metrics):
+    if "pub_path_url" in metrics:
+        delete_from_object_store(metrics["pub_path_url"])
+    if "browse_path" in metrics:
+        delete_from_object_store(metrics["browse_path"])
+
+
 def publish_datasets(job, ctx):
     """Publish a dataset. Track metrics."""
 
@@ -774,123 +906,45 @@ def publish_datasets(job, ctx):
         logger.info("Job command never ran. Bypassing dataset publishing.")
         return True
 
-    # get job info
     job_dir = job["job_info"]["job_dir"]
-    time_start_iso = job["job_info"]["time_start"]
-    context_file = job["job_info"]["context_file"]
-    datasets_cfg_file = job["job_info"]["datasets_cfg_file"]
-
     dataset_directories = list(find_dataset_json(job_dir))
-
-    time_start = parse_iso8601(time_start_iso)  # time start
 
     prods_ingested_to_obj_store = []
     published_prods = []  # find and publish
-    try:
+
+    async_tasks = []
+    num_procs = max(cpu_count() - 2, 1)  # TODO: create configuration in sdscli
+
+    with Pool(num_procs) as pool, Manager() as manager:
+        event = manager.Event()
         for _, prod_dir in dataset_directories:
             signal_file = os.path.join(prod_dir, ".localized")  # skip if marked as localized input
             if os.path.exists(signal_file):
                 logger.info("Skipping publish of %s. Marked as localized input." % prod_dir)
                 continue
+            async_task = pool.apply_async(async_publish_files, args=(job, ctx, prod_dir, ), kwds={"event": event})
+            async_tasks.append(async_task)
+        pool.close()
+        logger.info("Waiting for dataset publishing tasks to complete...")
+        pool.join()
 
-            # check for PROV-ES JSON from PGE; if exists, append related PROV-ES info;
-            # also overwrite merged PROV-ES JSON file
-            prod_id = os.path.basename(prod_dir)
-            prov_es_file = os.path.join(prod_dir, "%s.prov_es.json" % prod_id)
-            prov_es_info = {}
-            if os.path.exists(prov_es_file):
-                with open(prov_es_file) as f:
-                    try:
-                        prov_es_info = json.load(f)
-                    except Exception as e:
-                        tb = traceback.format_exc()
-                        raise RuntimeError(
-                            "Failed to log PROV-ES from {}: {}\n{}".format(
-                                prov_es_file, str(e), tb
-                            )
-                        )
-                log_prov_es(job, prov_es_info, prov_es_file)
+    has_error = False
+    for t in async_tasks:
+        if t.successful():
+            result = t.get()
+            if result:
+                prods_ingested_to_obj_store.append(result)
+        else:
+            has_error = True
+            logger.error(t._value)  # noqa
 
-            # copy _context.json
-            prod_context_file = os.path.join(prod_dir, "%s.context.json" % prod_id)
-            shutil.copy(context_file, prod_context_file)
-
-            # force ingest? (i.e. disable no-clobber)
-            ingest_kwargs = {"force": False}
-            if ctx.get("_force_ingest", False):
-                logger.info("Flag _force_ingest set to True.")
-                ingest_kwargs["force"] = True
-
-            # upload
-            tx_t1 = datetime.utcnow()
-            metrics, prod_json = ingest_to_object_store(
-                *(
-                    prod_id,
-                    datasets_cfg_file,
-                    prod_dir,
-                    job_dir,
-                ),
-                **ingest_kwargs
-            )
-
-            tx_t2 = datetime.utcnow()
-            tx_dur = (tx_t2 - tx_t1).total_seconds()
-            prod_dir_usage = get_disk_usage(prod_dir)
-
-            # set product provenance
-            prod_prov = {
-                "product_type": metrics["ipath"],
-                "processing_start_time": time_start.isoformat() + "Z",
-                "availability_time": tx_t2.isoformat() + "Z",
-                "processing_latency": (tx_t2 - time_start).total_seconds() / 60.0,
-                "total_latency": (tx_t2 - time_start).total_seconds() / 60.0,
-            }
-            prod_prov_file = os.path.join(prod_dir, "%s.prod_prov.json" % prod_id)
-            if os.path.exists(prod_prov_file):
-                with open(prod_prov_file) as f:
-                    prod_prov.update(json.load(f))
-            if "acquisition_start_time" in prod_prov:
-                if "source_production_time" in prod_prov:
-                    prod_prov["ground_system_latency"] = (
-                        parse_iso8601(prod_prov["source_production_time"])
-                        - parse_iso8601(prod_prov["acquisition_start_time"])
-                    ).total_seconds() / 60.0
-                    prod_prov["total_latency"] += prod_prov["ground_system_latency"]
-                    prod_prov["access_latency"] = (
-                        tx_t2 - parse_iso8601(prod_prov["source_production_time"])
-                    ).total_seconds() / 60.0
-                    prod_prov["total_latency"] += prod_prov["access_latency"]
-            # write product provenance of the last product; not writing to an array under the
-            # product because kibana table panel won't show them correctly:
-            # https://github.com/elasticsearch/kibana/issues/998
-            job["job_info"]["metrics"]["product_provenance"] = prod_prov
-
-            product_staged_metadata = {
-                "path": prod_dir,
-                "disk_usage": prod_dir_usage,
-                "time_start": tx_t1.isoformat() + "Z",
-                "time_end": tx_t2.isoformat() + "Z",
-                "duration": tx_dur,
-                "transfer_rate": prod_dir_usage / tx_dur,
-                "id": prod_json["id"],
-                "urls": prod_json["urls"],
-                "browse_urls": prod_json["browse_urls"],
-                "dataset": prod_json["dataset"],
-                "ipath": prod_json["ipath"],
-                "system_version": prod_json["system_version"],
-                "dataset_level": prod_json["dataset_level"],
-                "dataset_type": prod_json["dataset_type"],
-                "index": prod_json["grq_index_result"]["index"],
-            }
-
-            prods_ingested_to_obj_store.append((prod_json, product_staged_metadata, metrics))
-    except Exception as e:
-        logger.error("Product failed to ingest to data store: %s" % traceback.format_exc())
-        for _, _, metrics in prods_ingested_to_obj_store:
-            if "pub_path_url" in metrics:
-                delete_from_object_store(metrics["pub_path_url"])
-            if "browse_path" in metrics:
-                delete_from_object_store(metrics["browse_path"])
+    if has_error is True:
+        with Pool(num_procs) as pool:
+            for _, _, metrics in prods_ingested_to_obj_store:
+                pool.apply_async(async_delete_files, args=(metrics,))
+            pool.close()
+            logger.warning("Rolling back datasets (file) ingest...")
+            pool.join()
         raise NotAllProductsIngested("Product failed to ingest to data store: %s" % traceback.format_exc())
 
     if len(prods_ingested_to_obj_store) > 0:
@@ -899,13 +953,13 @@ def publish_datasets(job, ctx):
             logger.info(f"publishing %d dataset(s) to Elasticsearch" % len(prods_ingested_to_obj_store))
             bulk_index_dataset(app.conf.GRQ_UPDATE_URL_BULK, prod_jsons)
             published_prods.extend(prod_jsons)
-        except Exception as e:
+        except (Exception, ):
+            with Pool(num_procs) as pool:
+                for _, _, metrics in prods_ingested_to_obj_store:
+                    pool.apply_async(async_delete_files, args=(metrics,))
+            pool.close()
             logger.error("datasets failed to publish to Elasticsearch, deleting object(s) from data store")
-            for _, _, metrics in prods_ingested_to_obj_store:
-                if "pub_path_url" in metrics:
-                    delete_from_object_store(metrics["pub_path_url"])
-                if "browse_path" in metrics:
-                    delete_from_object_store(metrics["browse_path"])
+            pool.join()
             raise NotAllProductsIngested("Products failed to index to elasticsearch: %s" % traceback.format_exc())
 
         if "products_staged" not in job["job_info"]["metrics"]:


### PR DESCRIPTION
Related ticket(s):
- https://hysds-core.atlassian.net/browse/HC-458
- https://hysds-core.atlassian.net/browse/HC-460
- https://jira.jpl.nasa.gov/browse/NSDS-2703

## Overview
- using celery's `multiprocessing` library (`billiard`) to parallelize the publishing of datasets
- parallelizing the rollback of datasets as well
- bump version

## Testing
when testing on a job that produces 300 `hello_world` datasets with a 150MB file each
- when using parallelization on a 16cpu verdi worker: ~3 minutes
- publishing datasets synchronously (one-by-one): ~50 minutes


## Force Branches
dev-e2e (reproc): [![Build Status](https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/dustinlo-force_branch-E2E-test/27/badge/icon)](https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/dustinlo-force_branch-E2E-test/27/)
