### PR TITLE
HOTFIX: forgot to raise error when async_publish_files fails

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/dataset_ingest_bulk.py
+++ b/hysds/dataset_ingest_bulk.py
@@ -875,11 +875,12 @@ def async_publish_files(job, ctx, prod_dir, event=None):
         }
 
         return prod_json, product_staged_metadata, metrics
-    except (Exception, ):
+    except Exception:
         if event:
             event.set()
         logger.error("Publishing fialed on %s" % prod_dir)
         logger.error(traceback.format_exc())
+        raise
 
 
 def async_delete_files(metrics):


### PR DESCRIPTION
b/c we're not properly raising the error, it only logs it and technically the job will complete