### PR TITLE
HOTFIX: proper error handling when async file publish fails

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/dataset_ingest_bulk.py
+++ b/hysds/dataset_ingest_bulk.py
@@ -875,11 +875,12 @@ def async_publish_files(job, ctx, prod_dir, event=None):
         }
 
         return prod_json, product_staged_metadata, metrics
-    except (Exception, ):
+    except Exception:
         if event:
             event.set()
         logger.error("Publishing fialed on %s" % prod_dir)
         logger.error(traceback.format_exc())
+        raise
 
 
 def async_delete_files(metrics):

--- a/hysds/dataset_ingest_bulk.py
+++ b/hysds/dataset_ingest_bulk.py
@@ -929,7 +929,7 @@ def publish_datasets(job, ctx):
         logger.info("Waiting for dataset publishing tasks to complete...")
         pool.join()
 
-    has_error = False
+    has_error, err = False, ""
     for t in async_tasks:
         if t.successful():
             result = t.get()
@@ -938,6 +938,7 @@ def publish_datasets(job, ctx):
         else:
             has_error = True
             logger.error(t._value)  # noqa
+            err = t._value  # noqa
 
     if has_error is True:
         with Pool(num_procs) as pool:
@@ -946,7 +947,7 @@ def publish_datasets(job, ctx):
             pool.close()
             logger.warning("Rolling back datasets (file) ingest...")
             pool.join()
-        raise NotAllProductsIngested("Product failed to ingest to data store: %s" % traceback.format_exc())
+        raise NotAllProductsIngested("Product failed to ingest to data store: %s" % err)
 
     if len(prods_ingested_to_obj_store) > 0:
         try:


### PR DESCRIPTION
when using `traceback.format_exc()` not in an `except` block, it will raise this error
```
TypeError: exceptions must derive from BaseException
```
so now we'll have to extract the error when iterating over the results and raise it afterwards