### PR TITLE
HC-465: Fixed to properly log dedup jobs

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/orchestrator.py
+++ b/hysds/orchestrator.py
@@ -165,6 +165,9 @@ def submit_job(j):
         "job_info": j,
     }
 
+    current_time = datetime.utcnow()
+    job["job_info"]["index"] = f"job_status-{current_time.strftime('%Y.%m.%d')}"
+
     # set job type
     if "job_type" in j:
         match = JOB_TYPE_RE.search(j["job_type"])
@@ -403,12 +406,11 @@ def submit_job(j):
                 job_json["username"] = username
 
             # set job_info
-            time_queued = datetime.utcnow()
             job_json["job_info"] = {
                 "id": job_json["job_id"],
                 "job_queue": queue,
-                "time_queued": time_queued.isoformat() + "Z",
-                "index": f"job_status-{time_queued.strftime('%Y.%m.%d')}",
+                "time_queued": current_time.isoformat() + "Z",
+                "index": f"job_status-{current_time.strftime('%Y.%m.%d')}",
                 "time_limit": time_limit,
                 "soft_time_limit": soft_time_limit,
                 "payload_hash": payload_hash,


### PR DESCRIPTION
Related ticket(s):
- https://hysds-core.atlassian.net/browse/HC-465

## Overview
- During testing, a bug was found in which de-duped jobs were not being stored in the jobs database and were not visible on the Figaro UI. The only way to identify that the job was deduped was through Mozart's orchestrator logs.
- The fix was to include the `job_status` ES index in the `job_info` at the beginning of the `submit_job()` function within `orchestrator.py`. The `job_status` ES index was previously only being included for those jobs which get queued, however, for jobs that are not queued (de-duped, invalid, etc.), the `job_status` ES index was never set in the `job_info`. This led to those jobs never appearing in the jobs database's `job_status` index.

## Testing
- Using the HC-465 HySDS branch on Mozart:
![image](https://user-images.githubusercontent.com/100967535/236048690-5d5f4e76-99de-4e0b-baa4-fe45dfe6e493.png)

- Copy the same file to the staging bucket twice:
```shell
(mozart)$ aws s3 cp SMM_TUC_AXVCNE20161214_152427_19900101_000000_20380118_000000 s3://swot-dev-isl-fwd-drewm/gds/staging/
(mozart)$ aws s3 cp SMM_TUC_AXVCNE20161214_152427_19900101_000000_20380118_000000 s3://swot-dev-isl-fwd-drewm/gds/staging/
```
- Verify the first ingest job completes successfully:
![image](https://user-images.githubusercontent.com/100967535/236050330-8dcc0afd-4c6c-4cf3-a8d1-9f5451abb994.png)

- Verify the second ingest job gets de-duped:
![image](https://user-images.githubusercontent.com/100967535/236050215-c36f7edf-4a28-45be-9c69-2a1a8c187cf2.png)

## Force Branches
forward-using-MOE: [![Build Status](https://swot-pcm-ci.jpl.nasa.gov/buildStatus/icon?job=force-branches%2FDrew-force_branch-E2E-test&build=300)](https://swot-pcm-ci.jpl.nasa.gov/job/force-branches/job/Drew-force_branch-E2E-test/300/)
