### PR TITLE
HC-468: handle zero-length docker stats files

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1469,7 +1469,8 @@ def run_job(job, queue_when_finished=True):
                     str(e),
                     tb,
                 )
-                raise RuntimeError(err)
+                # raise RuntimeError(err)  # https://hysds-core.atlassian.net/browse/HC-468
+                logger.error(err)
         if len(usage_stats) > 0:
             job["job_info"]["metrics"]["usage_stats"].append(usage_stats)
 


### PR DESCRIPTION
Related ticket(s):
- https://hysds-core.atlassian.net/browse/HC-468

Change(s):
- commented out docker_stats exception, instead logging it
- bump version

sometimes when a job fails it will not write to the `_docker_stats.json` file, leaving it a blank file

```
Traceback (most recent call last):
  File "/home/ops/verdi/ops/hysds-1.2.3/hysds/job_worker.py", line 1464, in run_job
    usage_stats = json.load(f)
  File "/opt/conda/lib/python3.9/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/opt/conda/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/opt/conda/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/opt/conda/lib/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

@mcayanan @pymonger  i'm commenting it out and leaving a link to the HC ticket, should we remove the line instead?