### PR TITLE
rollback failed localization in backoff handler

### DIFF
--- a/hysds/dataset_ingest_bulk.py
+++ b/hysds/dataset_ingest_bulk.py
@@ -917,7 +917,7 @@ def publish_datasets(job, ctx):
     num_procs = max(cpu_count() - 2, 1)  # TODO: create configuration in sdscli? (maybe)
     logger.info("multiprocessing procs used: %d" % num_procs)
 
-    with Pool(num_procs) as pool, Manager() as manager:
+    with Pool(num_procs, maxtasksperchild=1) as pool, Manager() as manager:
         event = manager.Event()
         for _, prod_dir in dataset_directories:
             signal_file = os.path.join(prod_dir, ".localized")  # skip if marked as localized input
@@ -942,7 +942,7 @@ def publish_datasets(job, ctx):
             err = t._value  # noqa
 
     if has_error is True:
-        with Pool(num_procs) as pool:
+        with Pool(num_procs, maxtasksperchild=1) as pool:
             for _, _, metrics in prods_ingested_to_obj_store:
                 pool.apply_async(async_delete_files, args=(metrics,))
             pool.close()
@@ -957,7 +957,7 @@ def publish_datasets(job, ctx):
             bulk_index_dataset(app.conf.GRQ_UPDATE_URL_BULK, prod_jsons)
             published_prods.extend(prod_jsons)
         except (Exception, ):
-            with Pool(num_procs) as pool:
+            with Pool(num_procs, maxtasksperchild=1) as pool:
                 for _, _, metrics in prods_ingested_to_obj_store:
                     pool.apply_async(async_delete_files, args=(metrics,))
             pool.close()

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -180,9 +180,9 @@ def download_file(url, path, cache=False):
             logger.error(e)
             logger.warning("rolling back localized data: {}".format(path))
             shutil.rmtree(path, ignore_errors=True)
-            if os.path.exists(os.path.join(path, "osaka.locked.json")):
+            if os.path.exists(path + ".osaka.locked.json"):
                 logger.warning(".osaka.locked.json file found, rolling back...")
-                shutil.rmtree(os.path.join(path, "osaka.locked.json"))
+                shutil.rmtree(path + ".osaka.locked.json")
             raise
 
 

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -568,7 +568,7 @@ def localize_urls(job, ctx):
     num_procs = max(cpu_count() - 2, 1)
     logger.info("multiprocessing procs used: %d" % num_procs)
 
-    with Pool(num_procs) as pool, Manager() as manager:
+    with Pool(num_procs, maxtasksperchild=1) as pool, Manager() as manager:
         event = manager.Event()
 
         for i in job["localize_urls"]:  # localize urls

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -181,6 +181,7 @@ def download_file(url, path, cache=False):
             logger.warning("rolling back localized data: {}".format(path))
             shutil.rmtree(path, ignore_errors=True)
             if os.path.exists(os.path.join(path, "osaka.locked.json")):
+                logger.warning(".osaka.locked.json file found, rolling back...")
                 shutil.rmtree(os.path.join(path, "osaka.locked.json"))
             raise
 


### PR DESCRIPTION
change(s):
- ~rollback failed localization in `backoff` handler~
- wrap `try/except` in `osaka.main.get` in `download_file` add additional logging in backoff handler
  - rollback failed dataset localization in the `download_file` function
