### PR TITLE
HC-472: fix issues with concurrent osaka downloads and uploads using multiprocessing: deadlocks and IMDS query throttling

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.7"
+__version__ = "1.2.8"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/dataset_ingest.py
+++ b/hysds/dataset_ingest.py
@@ -35,9 +35,10 @@ from tempfile import mkdtemp
 import hysds
 import osaka
 from hysds.utils import get_disk_usage, makedirs, get_job_status, dataset_exists, get_func, parse_iso8601, \
-    log_prov_es, find_dataset_json
+    find_dataset_json
 from hysds.log_utils import (
     logger,
+    log_prov_es,
     log_publish_prov_es,
     backoff_max_value,
     backoff_max_tries,

--- a/hysds/dataset_ingest_bulk.py
+++ b/hysds/dataset_ingest_bulk.py
@@ -17,6 +17,8 @@ import requests
 import backoff
 import shutil
 import traceback
+import logging
+from logging.handlers import QueueHandler, QueueListener
 
 from glob import glob
 from datetime import datetime
@@ -28,6 +30,9 @@ from urllib.parse import urlparse
 from importlib import import_module
 
 from tempfile import mkdtemp
+
+from billiard import Manager, set_start_method, get_context, Queue  # noqa
+from billiard.pool import Pool, cpu_count  # noqa
 
 from hysds.utils import get_disk_usage, makedirs, get_job_status, dataset_exists, find_dataset_json
 from hysds.log_utils import logger, log_prov_es, log_custom_event, log_publish_prov_es, backoff_max_value, \
@@ -207,7 +212,6 @@ def ingest_to_object_store(
     force=False,
 ):
     """Run dataset ingest."""
-    logger.info("#" * 80)
     logger.info("datasets: %s" % dsets_file)
     logger.info("prod_path: %s" % prod_path)
     logger.info("job_path: %s" % job_path)
@@ -759,6 +763,158 @@ def queue_dataset(dataset, update_json, queue_name):
     do_submit_job(payload, queue_name)
 
 
+def async_publish_files(job, ctx, prod_dir, event=None, log_queue=None):
+    """
+    publish single dataset given the product directory, can be used in both multiprocessing or synchronous
+    :param job [Dict] - job object
+    :param ctx [Dict] - job context
+    :param prod_dir [Str] - str; product directory
+    :param event [Event, Optional] - Event to halt tasks if previous failed, taken from multiprocessing Manager()
+    :param log_queue [Queue, Optional] - The log queue for multiprocessing logging
+    """
+    if event and event.is_set():
+        logger.warning("Previous publish task failed, skipping %s..." % prod_dir)
+        return
+
+    if log_queue:
+        logger.addHandler(QueueHandler(log_queue))
+
+    try:
+        # get job info
+        job_dir = job["job_info"]["job_dir"]
+        time_start_iso = job["job_info"]["time_start"]
+        context_file = job["job_info"]["context_file"]
+        datasets_cfg_file = job["job_info"]["datasets_cfg_file"]
+
+        time_start = parse_iso8601(time_start_iso)  # time start
+
+        # check for PROV-ES JSON from PGE; if exists, append related PROV-ES info;
+        # also overwrite merged PROV-ES JSON file
+        prod_id = os.path.basename(prod_dir)
+        prov_es_file = os.path.join(prod_dir, "%s.prov_es.json" % prod_id)
+        prov_es_info = {}
+        if os.path.exists(prov_es_file):
+            with open(prov_es_file) as f:
+                try:
+                    prov_es_info = json.load(f)
+                except Exception as e:
+                    tb = traceback.format_exc()
+                    raise RuntimeError(
+                        "Failed to log PROV-ES from {}: {}\n{}".format(
+                            prov_es_file, str(e), tb
+                        )
+                    )
+            log_prov_es(job, prov_es_info, prov_es_file)
+
+        # copy _context.json
+        prod_context_file = os.path.join(prod_dir, "%s.context.json" % prod_id)
+        shutil.copy(context_file, prod_context_file)
+
+        # force ingest? (i.e. disable no-clobber)
+        ingest_kwargs = {"force": False}
+        if ctx.get("_force_ingest", False):
+            logger.info("Flag _force_ingest set to True.")
+            ingest_kwargs["force"] = True
+
+        # upload
+        tx_t1 = datetime.utcnow()
+        metrics, prod_json = ingest_to_object_store(
+            *(
+                prod_id,
+                datasets_cfg_file,
+                prod_dir,
+                job_dir,
+            ),
+            **ingest_kwargs
+        )
+
+        tx_t2 = datetime.utcnow()
+        tx_dur = (tx_t2 - tx_t1).total_seconds()
+        prod_dir_usage = get_disk_usage(prod_dir)
+
+        # set product provenance
+        prod_prov = {
+            "product_type": metrics["ipath"],
+            "processing_start_time": time_start.isoformat() + "Z",
+            "availability_time": tx_t2.isoformat() + "Z",
+            "processing_latency": (tx_t2 - time_start).total_seconds() / 60.0,
+            "total_latency": (tx_t2 - time_start).total_seconds() / 60.0,
+        }
+        prod_prov_file = os.path.join(prod_dir, "%s.prod_prov.json" % prod_id)
+        if os.path.exists(prod_prov_file):
+            with open(prod_prov_file) as f:
+                prod_prov.update(json.load(f))
+        if "acquisition_start_time" in prod_prov:
+            if "source_production_time" in prod_prov:
+                prod_prov["ground_system_latency"] = (
+                    parse_iso8601(prod_prov["source_production_time"])
+                    - parse_iso8601(prod_prov["acquisition_start_time"])
+                ).total_seconds() / 60.0
+                prod_prov["total_latency"] += prod_prov["ground_system_latency"]
+                prod_prov["access_latency"] = (
+                    tx_t2 - parse_iso8601(prod_prov["source_production_time"])
+                ).total_seconds() / 60.0
+                prod_prov["total_latency"] += prod_prov["access_latency"]
+        # write product provenance of the last product; not writing to an array under the
+        # product because kibana table panel won't show them correctly:
+        # https://github.com/elasticsearch/kibana/issues/998
+        job["job_info"]["metrics"]["product_provenance"] = prod_prov
+
+        product_staged_metadata = {
+            "path": prod_dir,
+            "disk_usage": prod_dir_usage,
+            "time_start": tx_t1.isoformat() + "Z",
+            "time_end": tx_t2.isoformat() + "Z",
+            "duration": tx_dur,
+            "transfer_rate": prod_dir_usage / tx_dur,
+            "id": prod_json["id"],
+            "urls": prod_json["urls"],
+            "browse_urls": prod_json["browse_urls"],
+            "dataset": prod_json["dataset"],
+            "ipath": prod_json["ipath"],
+            "system_version": prod_json["system_version"],
+            "dataset_level": prod_json["dataset_level"],
+            "dataset_type": prod_json["dataset_type"],
+            "index": prod_json["grq_index_result"]["index"],
+        }
+
+        return prod_json, product_staged_metadata, metrics
+    except Exception as e:
+        if event:
+            event.set()
+        tb = traceback.format_exc()
+        logger.error(tb)
+        raise RuntimeError("Failed to publish {}: {}\n{}".format(prod_dir, str(e), tb))
+
+
+def async_delete_files(metrics):
+    if "pub_path_url" in metrics:
+        delete_from_object_store(metrics["pub_path_url"])
+    if "browse_path" in metrics:
+        delete_from_object_store(metrics["browse_path"])
+
+
+def publish_datasets_handler(func):
+    """
+    https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+    decorator to set multiprocessing start method to spawn and back to fork when the function finishes
+    """
+    def inner_func(*args, **kwargs):
+        set_start_method("spawn", force=True)
+        logger.info("setting start_method to 'spawn'")
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            logger.error("something went wrong (decorator)")
+            logger.error(e)
+            raise
+        finally:
+            set_start_method("fork", force=True)
+            logger.info("setting start_method to 'fork'")
+    return inner_func
+
+
+@publish_datasets_handler
 def publish_datasets(job, ctx):
     """Publish a dataset. Track metrics."""
 
@@ -777,123 +933,56 @@ def publish_datasets(job, ctx):
         return True
 
     job_dir = job["job_info"]["job_dir"]
-    time_start_iso = job["job_info"]["time_start"]
-    context_file = job["job_info"]["context_file"]
-    datasets_cfg_file = job["job_info"]["datasets_cfg_file"]
-
-    dataset_directories = list(find_dataset_json(job_dir))
-
-    time_start = parse_iso8601(time_start_iso) # time start
+    datasets_list = list(find_dataset_json(job_dir))
 
     prods_ingested_to_obj_store = []
     published_prods = []  # find and publish
 
-    try:
-        for _, prod_dir in dataset_directories:
+    async_tasks = []
+    num_procs = min(max(cpu_count() - 2, 1), len(datasets_list))
+    logger.info("multiprocessing procs used: %d" % num_procs)
+
+    stdout_handler = logging.StreamHandler()
+    with get_context("spawn").Pool(num_procs) as pool, Manager() as manager:
+        log_queue = manager.Queue()
+        logger.addHandler(QueueHandler(log_queue))
+        log_listener = QueueListener(log_queue, stdout_handler)
+        log_listener.start()
+
+        event = manager.Event()
+        for _, prod_dir in datasets_list:
             signal_file = os.path.join(prod_dir, ".localized")  # skip if marked as localized input
             if os.path.exists(signal_file):
                 logger.info("Skipping publish of %s. Marked as localized input." % prod_dir)
                 continue
+            async_task = pool.apply_async(async_publish_files, args=(job, ctx, prod_dir, ),
+                                          kwds={"event": event, "log_queue": log_queue})
+            async_tasks.append(async_task)
+        pool.close()
+        logger.info("Waiting for dataset publishing tasks to complete...")
+        pool.join()
+        log_listener.enqueue_sentinel()
+        logger.handlers.clear()
 
-            # check for PROV-ES JSON from PGE; if exists, append related PROV-ES info;
-            # also overwrite merged PROV-ES JSON file
-            prod_id = os.path.basename(prod_dir)
-            prov_es_file = os.path.join(prod_dir, "%s.prov_es.json" % prod_id)
-            prov_es_info = {}
-            if os.path.exists(prov_es_file):
-                with open(prov_es_file) as f:
-                    try:
-                        prov_es_info = json.load(f)
-                    except Exception as e:
-                        tb = traceback.format_exc()
-                        raise RuntimeError(
-                            "Failed to log PROV-ES from {}: {}\n{}".format(
-                                prov_es_file, str(e), tb
-                            )
-                        )
-                log_prov_es(job, prov_es_info, prov_es_file)
+    has_error, err = False, ""
+    for t in async_tasks:
+        if t.successful():
+            result = t.get()
+            if result:
+                prods_ingested_to_obj_store.append(result)
+        else:
+            has_error = True
+            logger.error(t._value)  # noqa
+            err = t._value  # noqa
 
-            # copy _context.json
-            prod_context_file = os.path.join(prod_dir, "%s.context.json" % prod_id)
-            shutil.copy(context_file, prod_context_file)
-
-            # force ingest? (i.e. disable no-clobber)
-            ingest_kwargs = {"force": False}
-            if ctx.get("_force_ingest", False):
-                logger.info("Flag _force_ingest set to True.")
-                ingest_kwargs["force"] = True
-
-            # upload
-            tx_t1 = datetime.utcnow()
-            metrics, prod_json = ingest_to_object_store(
-                *(
-                    prod_id,
-                    datasets_cfg_file,
-                    prod_dir,
-                    job_dir,
-                ),
-                **ingest_kwargs
-            )
-
-            tx_t2 = datetime.utcnow()
-            tx_dur = (tx_t2 - tx_t1).total_seconds()
-            prod_dir_usage = get_disk_usage(prod_dir)
-
-            # set product provenance
-            prod_prov = {
-                "product_type": metrics["ipath"],
-                "processing_start_time": time_start.isoformat() + "Z",
-                "availability_time": tx_t2.isoformat() + "Z",
-                "processing_latency": (tx_t2 - time_start).total_seconds() / 60.0,
-                "total_latency": (tx_t2 - time_start).total_seconds() / 60.0,
-            }
-            prod_prov_file = os.path.join(prod_dir, "%s.prod_prov.json" % prod_id)
-            if os.path.exists(prod_prov_file):
-                with open(prod_prov_file) as f:
-                    prod_prov.update(json.load(f))
-            if "acquisition_start_time" in prod_prov:
-                if "source_production_time" in prod_prov:
-                    prod_prov["ground_system_latency"] = (
-                                                                 parse_iso8601(prod_prov["source_production_time"])
-                                                                 - parse_iso8601(prod_prov["acquisition_start_time"])
-                                                         ).total_seconds() / 60.0
-                    prod_prov["total_latency"] += prod_prov["ground_system_latency"]
-                    prod_prov["access_latency"] = (
-                                                          tx_t2 - parse_iso8601(prod_prov["source_production_time"])
-                                                  ).total_seconds() / 60.0
-                    prod_prov["total_latency"] += prod_prov["access_latency"]
-            # write product provenance of the last product; not writing to an array under the
-            # product because kibana table panel won't show them correctly:
-            # https://github.com/elasticsearch/kibana/issues/998
-            job["job_info"]["metrics"]["product_provenance"] = prod_prov
-
-            product_staged_metadata = {
-                "path": prod_dir,
-                "disk_usage": prod_dir_usage,
-                "time_start": tx_t1.isoformat() + "Z",
-                "time_end": tx_t2.isoformat() + "Z",
-                "duration": tx_dur,
-                "transfer_rate": prod_dir_usage / tx_dur,
-                "id": prod_json["id"],
-                "urls": prod_json["urls"],
-                "browse_urls": prod_json["browse_urls"],
-                "dataset": prod_json["dataset"],
-                "ipath": prod_json["ipath"],
-                "system_version": prod_json["system_version"],
-                "dataset_level": prod_json["dataset_level"],
-                "dataset_type": prod_json["dataset_type"],
-                "index": prod_json["grq_index_result"]["index"],
-            }
-
-            prods_ingested_to_obj_store.append((prod_json, product_staged_metadata, metrics))
-    except Exception:
-        logger.error("Product failed to ingest to data store: %s" % traceback.format_exc())
-        for _, _, metrics in prods_ingested_to_obj_store:
-            if "pub_path_url" in metrics:
-                delete_from_object_store(metrics["pub_path_url"])
-            if "browse_path" in metrics:
-                delete_from_object_store(metrics["browse_path"])
-        raise NotAllProductsIngested("Product failed to ingest to data store: %s" % traceback.format_exc())
+    if has_error is True:
+        with get_context("spawn").Pool(num_procs) as pool:
+            for _, _, metrics in prods_ingested_to_obj_store:
+                pool.apply_async(async_delete_files, args=(metrics,))
+            pool.close()
+            logger.warning("Rolling back datasets (file) ingest...")
+            pool.join()
+        raise NotAllProductsIngested("Product failed to ingest to data store: {}".format(err))
 
     if len(prods_ingested_to_obj_store) > 0:
         try:
@@ -902,11 +991,12 @@ def publish_datasets(job, ctx):
             bulk_index_dataset(app.conf.GRQ_UPDATE_URL_BULK, prod_jsons)
             published_prods.extend(prod_jsons)
         except Exception:
-            for _, _, metrics in prods_ingested_to_obj_store:
-                if "pub_path_url" in metrics:
-                    delete_from_object_store(metrics["pub_path_url"])
-                if "browse_path" in metrics:
-                    delete_from_object_store(metrics["browse_path"])
+            with get_context("spawn").Pool(num_procs) as pool:
+                for _, _, metrics in prods_ingested_to_obj_store:
+                    pool.apply_async(async_delete_files, args=(metrics,))
+            pool.close()
+            logger.error("datasets failed to publish to Elasticsearch, deleting object(s) from data store")
+            pool.join()
             raise NotAllProductsIngested("Products failed to index to elasticsearch: %s" % traceback.format_exc())
 
         if "products_staged" not in job["job_info"]["metrics"]:

--- a/hysds/dataset_ingest_bulk.py
+++ b/hysds/dataset_ingest_bulk.py
@@ -957,8 +957,9 @@ def publish_datasets(job, ctx):
         pool.close()
         logger.info("Waiting for dataset publishing tasks to complete...")
         pool.join()
+
+        logger.handlers.clear()  # clearing the queue and removing the handler to prevent broken pipe error
         log_listener.enqueue_sentinel()
-        logger.handlers.clear()
 
     has_error, err = False, ""
     for t in async_tasks:

--- a/hysds/dataset_ingest_bulk.py
+++ b/hysds/dataset_ingest_bulk.py
@@ -203,14 +203,7 @@ def parse_iso8601(t):
         return datetime.strptime(t, "%Y-%m-%dT%H:%M:%SZ")
 
 
-def ingest_to_object_store(
-    objectid,
-    dsets_file,
-    prod_path,
-    job_path,
-    dry_run=False,
-    force=False,
-):
+def ingest_to_object_store(objectid, dsets_file, prod_path, job_path, dry_run=False, force=False):
     """Run dataset ingest."""
     logger.info("datasets: %s" % dsets_file)
     logger.info("prod_path: %s" % prod_path)
@@ -777,6 +770,9 @@ def async_publish_files(job, ctx, prod_dir, event=None, log_queue=None):
         return
 
     if log_queue:
+        _logger = logging.getLogger()
+        _logger.setLevel(logging.INFO)
+        _logger.propagate = False
         logger.addHandler(QueueHandler(log_queue))
 
     try:

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -61,13 +61,15 @@ from hysds.containers.factory import container_engine_factory
 
 # built-in pre-processors
 PRE_PROCESSORS = (
-    "hysds.utils.localize_urls",
+    "hysds.localize.localize_urls",
     "hysds.utils.mark_localized_datasets",
     "hysds.utils.validate_checksum_files",
 )
 
 # built-in post-processors
-POST_PROCESSORS = ("hysds.dataset_ingest_bulk.publish_datasets",)
+POST_PROCESSORS = (
+    "hysds.dataset_ingest_bulk.publish_datasets",
+)
 
 # signal names
 SIG_NAMES = {

--- a/hysds/localize.py
+++ b/hysds/localize.py
@@ -1,0 +1,183 @@
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+
+from builtins import str
+# from builtins import int
+# from builtins import open
+from future import standard_library
+
+standard_library.install_aliases()
+
+import os
+import backoff
+import traceback
+import logging
+
+from datetime import datetime
+
+from billiard import Manager, get_context  # noqa
+from billiard.pool import Pool, cpu_count  # noqa
+
+from hysds.log_utils import logger
+from hysds.utils import download_file, makedirs, get_disk_usage
+
+
+def download_file_wrapper_backoff_handler(b, max_tries=6):
+    """
+    @param b: (Dict) backoff information
+        target: function wrapped by backoff
+        args: (tuple) function arguments
+        kwargs: (Dict) keyword arguments
+            cache: Bool (default False) pull from cache
+            event: (optional) Manager().event()
+        tries: (int) number of tries
+        elapsed: (float) function runtime
+        wait: (float) wait time after error
+        exception: (str) error/traceback raised by the function
+    @param max_tries: maximum number of tries allowed by backoff
+    """
+    tries = b["tries"]
+    kwargs = b["kwargs"]
+    args = b["args"]
+    logger.error("download_file_wrapper failed ({}) {} {}".format(tries, args, kwargs))
+
+    if tries >= max_tries - 1:
+        event = kwargs.get("event", None)
+        if event:
+            event.set()
+        exception = b["exception"]
+        raise exception
+
+
+@backoff.on_exception(
+    backoff.constant,
+    Exception,
+    max_tries=6,
+    interval=5,
+    on_backoff=download_file_wrapper_backoff_handler
+)
+def download_file_wrapper(url, path, cache=False, event=None):
+    """
+    @param url: Str
+    @param path: Str
+    @param cache: Bool (default False) pull from cache
+    @param event: Manager().event() (optional)
+    :return: Dict[Str: any] or None
+        if successful, will return localized data information
+        if None that means a previous task failed and will exit early
+    """
+    if event and event.is_set():
+        logger.warning("Previous localize task failed, skipping %s..." % url)
+        return
+
+    loc_t1 = datetime.utcnow()
+    try:
+        download_file(url, path, cache=cache)
+        loc_t2 = datetime.utcnow()
+        loc_dur = (loc_t2 - loc_t1).total_seconds()
+        path_disk_usage = get_disk_usage(path)
+        return {
+            "url": url,
+            "path": path,
+            "disk_usage": path_disk_usage,
+            "time_start": loc_t1.isoformat() + "Z",
+            "time_end": loc_t2.isoformat() + "Z",
+            "duration": loc_dur,
+            "transfer_rate": path_disk_usage / loc_dur,
+        }
+    except Exception as e:
+        tb = traceback.format_exc()
+        logger.error(tb)
+        raise RuntimeError("Failed to download {}: {}\n{}".format(url, str(e), tb))
+
+
+def init_pool_logger():
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter('[%(asctime)s: %(levelname)s/%(name)s] %(message)s'))
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+
+
+def localize_urls_parallel(job, ctx):
+    """
+    Localize urls for job inputs. Track metrics.
+    parallelized
+    """
+    job_dir = job["job_info"]["job_dir"]  # get job info
+
+    async_tasks = []
+    localize_urls_list = job.get("localize_urls", [])
+    num_procs = min(max(cpu_count() - 2, 1), len(localize_urls_list))
+    logger.info("multiprocessing procs used: %d" % num_procs)
+
+    with get_context("spawn").Pool(num_procs, initializer=init_pool_logger) as pool, Manager() as manager:
+        event = manager.Event()
+        for i in localize_urls_list:  # localize urls
+            url = i["url"]
+            path = i.get("local_path", None)
+            cache = i.get("cache", True)
+            if path is None:
+                path = "%s/" % job_dir
+            else:
+                if path.startswith("/"):
+                    pass
+                else:
+                    path = os.path.join(job_dir, path)
+            if os.path.isdir(path) or path.endswith("/"):
+                path = os.path.join(path, os.path.basename(url))
+            dir_path = os.path.dirname(path)
+            makedirs(dir_path)
+
+            async_task = pool.apply_async(download_file_wrapper,
+                                          args=(url, path, ), kwds={"cache": cache, "event": event})
+            async_tasks.append(async_task)
+        pool.close()
+        logger.info("Waiting for dataset localization tasks to complete...")
+        pool.join()
+
+        logger.handlers.clear()  # clearing the queue and removing the handler to prevent broken pipe error
+
+        has_error, err = False, ""
+        for t in async_tasks:
+            if t.successful():
+                result = t.get()
+                if result:
+                    job["job_info"]["metrics"]["inputs_localized"].append(result)
+            else:
+                has_error = True
+                logger.error(t._value)  # noqa
+                err = t._value  # noqa
+        if has_error is True:
+            raise RuntimeError("Failed to download {}".format(err))
+
+    return True  # signal run_job() to continue
+
+
+def localize_urls(job, ctx):
+    """Localize urls for job inputs. Track metrics."""
+
+    # get job info
+    job_dir = job["job_info"]["job_dir"]
+
+    # localize urls
+    for i in job["localize_urls"]:
+        url = i["url"]
+        path = i.get("local_path", None)
+        cache = i.get("cache", True)
+        if path is None:
+            path = "%s/" % job_dir
+        else:
+            if path.startswith("/"):
+                pass
+            else:
+                path = os.path.join(job_dir, path)
+        if os.path.isdir(path) or path.endswith("/"):
+            path = os.path.join(path, os.path.basename(url))
+        dir_path = os.path.dirname(path)
+        makedirs(dir_path)
+        localized_metadata = download_file_wrapper(url, path, cache=cache)
+        job["job_info"]["metrics"]["inputs_localized"].append(localized_metadata)
+
+    return True  # signal run_job() to continue

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -22,7 +22,6 @@ import errno
 import shutil
 import traceback
 import logging
-from logging.handlers import QueueHandler, QueueListener
 
 from datetime import datetime
 from subprocess import check_output
@@ -39,7 +38,7 @@ from billiard import Manager, set_start_method, get_context  # noqa
 from billiard.pool import Pool, cpu_count  # noqa
 
 # import hysds
-from hysds.log_utils import logger, log_prov_es, payload_hash_exists
+from hysds.log_utils import logger, payload_hash_exists
 from hysds.celery import app
 from hysds.es_util import get_grq_es
 
@@ -224,7 +223,7 @@ def download_file_async_backoff_handler(b, max_tries=6):
     interval=5,
     on_backoff=download_file_async_backoff_handler
 )
-def download_file_async(url, path, cache=False, event=None, log_queue=None):
+def download_file_async(url, path, cache=False, event=None):
     """
     @param url: Str
     @param path: Str
@@ -237,12 +236,6 @@ def download_file_async(url, path, cache=False, event=None, log_queue=None):
     if event and event.is_set():
         logger.warning("Previous localize task failed, skipping %s..." % url)
         return
-
-    if log_queue:
-        _logger = logging.getLogger()
-        _logger.setLevel(logging.INFO)
-        _logger.propagate = False
-        logger.addHandler(QueueHandler(log_queue))
 
     loc_t1 = datetime.utcnow()
     try:

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -585,7 +585,7 @@ def localize_urls(job, ctx):
     num_procs = min(max(cpu_count() - 2, 1), len(localize_urls_list))
     logger.info("multiprocessing procs used: %d" % num_procs)
 
-    with get_context("spawn").Pool(num_procs) as pool, Manager() as manager:
+    with get_context("spawn").Pool(num_procs, initializer=init_pool_logger) as pool, Manager() as manager:
         event = manager.Event()
         for i in localize_urls_list:  # localize urls
             url = i["url"]

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -496,7 +496,6 @@ def init_pool_logger():
     logger.addHandler(handler)
 
 
-# TODO: create new function to filter out the .localized datasets
 def find_dataset_json(work_dir):
     """Search for *.dataset.json files."""
 

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -523,6 +523,15 @@ def find_dataset_json(work_dir):
                     yield dataset_file, prod_dir
 
 
+def find_non_localized_datasets(work_dir):
+    """
+    :param work_dir - Str; work directory to traverse for dataset directories
+    :return: List[str] - list of dataset directories
+    """
+    datasets_list = find_dataset_json(work_dir)
+    return [prod_dir for _, prod_dir in datasets_list if not os.path.isfile(os.path.join(prod_dir, ".localized"))]
+
+
 def mark_localized_datasets(job, ctx):
     """Mark localized datasets to prevent republishing."""
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "atomicwrites>=1.1.5",
         "future>=0.17.1",
         "greenlet>=0.4.15",
-        "fabric3",
+        "fab-classic>=1.19.2",
         "pytz",
         "pytest",
         "tabulate>=0.8.6",


### PR DESCRIPTION
related ticket(s):
- https://hysds-core.atlassian.net/browse/HC-472

related PR(s):
- https://github.com/hysds/osaka/pull/38

related articles:
- https://pythonspeed.com/articles/python-multiprocessing/
- https://superfastpython.com/multiprocessing-deadlock/
- https://britishgeologicalsurvey.github.io/science/python-forking-vs-spawn/#other-multiprocessing-tricks

**change(s):**
- moved `localize_urls` from `utils.py` to its own dedicated file, `localize.py`
- added addtl' logic in `download_file` that removes the `.osaka.locked.json` if it errors
- new function `find_non_localized_datasets` to filter out datasets with a `.localized` file
  - this is to prevent over-using cores on datasets that would not be published
- separated functions into parallelized and non-parallelized
  - separated `localize_urls`
    - `localize_urls` vs `localize_urls_parallel`
  - separated `publish_datasets`
    - `publish_datasets` vs `publish_datasets_parallel`
  - by default `job_worker` will use the non-parallelized version of localize and publish functions, this is to prevent over-using cores on factotum
    - using the parallelized version of the post/pre-processors will have to be defined in the job-spec, `disable_pre_builtins` and/or `disable_post_builtins` set to `true`
    - add the functions into `pre` & `post` (@pymonger  correct me if im wrong i cant find documentation on this):
      - ```
         pre: [
            "hysds.localize.localize_urls_parallel",  # <-- HERE
            "hysds.utils.mark_localized_datasets",
            "hysds.utils.validate_checksum_files",
         ]
         ```
      - ```
         post: [
            hysds.dataset_ingest_bulk.publish_datasets_parallel  # <-- HERE
         ]
         ```

**addtl' change(s):**
- replacing `fabric3` with `fab-classic>=1.19.2` in `setup.py` b/c sdscli is using `fab-classic`, also it is compatible with python3.10 in case we want to upgrade
  - https://github.com/sdskit/sdscli/pull/96
- removed unused imports
  - `log_prov_es` is now imported from `hysds.log_utils` instead of `hysds.utils` in `dataset_ingest.py`

**performance improvements, tested on SCIFLO_L0A_TE job with 16 cores:**
- 10 hours (no osaka caching + no parallelization)
- ~40min (only osaka caching)
- ~5min (osaka caching + parallelization)

logs:
```log
[2023-06-14 18:42:56,194: INFO/ForkPoolWorker-1] hysds.job_worker.run_job[7c783df5-1d86-467c-8062-4250f0b24f78]: Running post-processor: hysds.dataset_ingest_bulk.publish_datasets_parallel
[2023-06-14 18:42:56,218: INFO/ForkPoolWorker-1] hysds.job_worker.run_job[7c783df5-1d86-467c-8062-4250f0b24f78]: multiprocessing procs used: 14
[2023-06-14 18:42:56,867: INFO/SpawnPoolWorker-1:5] child process 508 calling self.run()
[2023-06-14 18:42:56,872: INFO/hysds.log_utils] datasets: /home/ops/verdi/etc/datasets.json
[2023-06-14 18:42:56,873: INFO/hysds.log_utils] prod_path: /data/work/jobs/2023/06/14/18/19/test_bulk_product_publishing__develop-single_submission-20230614T181352.475322Z/NISAR_L0_RRST_VC29_20230127T014408_20230127T014409_D00330_J_001
[2023-06-14 18:42:56,873: INFO/hysds.log_utils] job_path: /data/work/jobs/2023/06/14/18/19/test_bulk_product_publishing__develop-single_submission-20230614T181352.475322Z
[2023-06-14 18:42:56,873: INFO/hysds.log_utils] dry_run: False
[2023-06-14 18:42:56,873: INFO/hysds.log_utils] force: False
[2023-06-14 18:42:56,873: INFO/hysds.log_utils] task_id: 7c783df5-1d86-467c-8062-4250f0b24f78
[2023-06-14 18:42:56,873: INFO/hysds.log_utils] payload_id: 343dae8e-4f09-4c1b-9661-bfc9cc471566
[2023-06-14 18:42:56,873: INFO/hysds.log_utils] payload_hash: 0a03ed46213a67a9f8dfc0480f7c2ea7
.
.
.
[2023-06-14 18:47:57,475: INFO/hysds.log_utils] Browse publish is configured.
[2023-06-14 18:47:58,734: INFO/ForkPoolWorker-1] hysds.job_worker.run_job[7c783df5-1d86-467c-8062-4250f0b24f78]: publishing 352 dataset(s) to Elasticsearch
```