### PR TITLE
HC-170: time value: unit is missing or unrecognized error with grq search timeout call

### DIFF
--- a/hysds/user_rules_dataset.py
+++ b/hysds/user_rules_dataset.py
@@ -93,7 +93,7 @@ def update_query(_id, system_version, rule):
     backoff.expo, Exception, max_tries=backoff_max_tries, max_value=backoff_max_value
 )
 def search_es(index, body):
-    return grq_es.es.search(index=index, body=body, timeout=30)
+    return grq_es.es.search(index=index, body=body, request_timeout=30)
 
 
 def evaluate_user_rules_dataset(

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         "redis>=3.2.1,<4.5.2",  # https://github.com/redis/redis-py/issues/2629
         "celery>=5.2.2,<6.0.0,!=5.2.3",
-        "click-repl>=0.2.0,<0.3.0",
+        "prompt-toolkit==1.0.18",
         "requests>=2.20.0",
         "flower>=1.0.0",
         "eventlet>=0.17.2",

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     install_requires=[
         "redis>=3.2.1,<4.5.2",  # https://github.com/redis/redis-py/issues/2629
         "celery>=5.2.2,<6.0.0,!=5.2.3",
+        "click-repl>=0.2.0,<0.3.0",
         "requests>=2.20.0",
         "flower>=1.0.0",
         "eventlet>=0.17.2",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         "redis>=3.2.1,<4.5.2",  # https://github.com/redis/redis-py/issues/2629
         "celery>=5.2.2,<6.0.0,!=5.2.3",
-        "prompt-toolkit==1.0.18",
+        "prompt-toolkit==1.0.18",  # TODO: celery uses new verison of click which broke this, wil remove later
         "requests>=2.20.0",
         "flower>=1.0.0",
         "eventlet>=0.17.2",


### PR DESCRIPTION
https://github.com/hysds/hysds/issues/170

[2023-06-15 12:35:08,714: INFO/ForkPoolWorker-1] Backing off search_es(...) for 9.5s (elasticsearch.exceptions.RequestError: RequestError(400, 'illegal_argument_exception', 'failed to parse setting [timeout] with value [30] as a time value: unit is missing or unrecognized'))
[2023-06-15 12:35:18,246: WARNING/ForkPoolWorker-1] POST http://100.104.10.49:9200/grq/_search?timeout=30 [status:400 request:0.002s]
[2023-06-15 12:35:18,246: INFO/ForkPoolWorker-1] Backing off search_es(...) for 48.7s (elasticsearch.exceptions.RequestError: RequestError(400, 'illegal_argument_exception', 'failed to parse setting [timeout] with value [30] as a time value: unit is missing or unrecognized'))