### PR TITLE
HC-479: Dataset Ingest Bulk throws KeyError: "found" error

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.8"
+__version__ = "1.2.9"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/event_processors.py
+++ b/hysds/event_processors.py
@@ -44,7 +44,8 @@ def fail_job(event, uuid, exc, short_error):
         }
     }
 
-    result = mozart_es.search(index="job_status-current", body=query)
+    result = mozart_es.search(index="job_status-current", body=query,
+                              _source_includes=["status", "error", "short_error", "traceback"])
     total = result["hits"]["total"]["value"]
     if total == 0:
         logger.error("Failed to query for task UUID %s" % uuid)

--- a/hysds/event_processors.py
+++ b/hysds/event_processors.py
@@ -36,20 +36,18 @@ mozart_es = get_mozart_es()
 def fail_job(event, uuid, exc, short_error):
     """Set job status to job-failed."""
 
-    query = {"query": {"bool": {"must": [{"term": {"uuid": uuid}}]}}}
-    search_url = "%s/job_status-current/_search" % app.conf["JOBS_ES_URL"]
+    query = {
+        "query": {
+            "bool": {
+                "must": [{"term": {"uuid": uuid}}]
+            }
+        }
+    }
 
-    headers = {"Content-Type": "application/json"}
-    r = requests.post(search_url, data=json.dumps(query), headers=headers)
-
-    if r.status_code != 200:
-        logger.error("Failed to query for task UUID %s: %s" % (uuid, r.content))
-        return
-
-    result = r.json()
+    result = mozart_es.search(index="job_status-current", body=query)
     total = result["hits"]["total"]["value"]
     if total == 0:
-        logger.error("Failed to query for task UUID %s: %s" % (uuid, r.content))
+        logger.error("Failed to query for task UUID %s" % uuid)
         return
 
     res = result["hits"]["hits"][0]

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -36,11 +36,12 @@ from bisect import insort
 
 from hysds.log_utils import logger, payload_hash_exists
 from hysds.celery import app
-from hysds.es_util import get_grq_es
+from hysds.es_util import get_grq_es, get_mozart_es
 
 import osaka.main
 
 grq_es = get_grq_es()
+mozart_es = get_mozart_es()
 
 # disk usage setting converter
 DU_CALC = {"GB": 1024 ** 3, "MB": 1024 ** 2, "KB": 1024}
@@ -412,20 +413,8 @@ def query_dedup_job(dedup_key, filter_id=None, states=None, is_worker=False):
         query["query"]["bool"]["must_not"] = {"term": {"uuid": filter_id}}
 
     logger.info("constructed query: %s" % json.dumps(query, indent=2))
-    es_url = "%s/job_status-current/_search" % app.conf["JOBS_ES_URL"]
-
-    headers = {"Content-Type": "application/json"}
-    r = requests.post(es_url, data=json.dumps(query), headers=headers)
-    if r.status_code != 200:
-        if r.status_code == 404:
-            logger.info(
-                "status_code 404, job_status-current index probably does not exist, returning None"
-            )
-            return None
-        else:
-            r.raise_for_status()
-    j = r.json()
-    logger.info("result: %s" % r.text)
+    j = mozart_es.search(index="job_status-current", body=query)
+    logger.info(j)
     if j["hits"]["total"]["value"] == 0:
         if hash_exists_in_redis is True:
             if is_worker:
@@ -454,15 +443,22 @@ def query_dedup_job(dedup_key, filter_id=None, states=None, is_worker=False):
 )
 def get_job_status(_id):
     """Get job status."""
+    query = {
+        "query": {
+            "bool": {
+                "must": [{"term": {"_id": _id}}]
+            }
+        }
+    }
 
-    es_url = "%s/job_status-current/_doc/%s" % (app.conf["JOBS_ES_URL"], _id)
-    r = requests.get(es_url, params={"_source": "status"})
+    res = mozart_es.search(index="job_status-current", body=query, _source_includes=["status"])
+    if res["hits"]["total"]["value"] == 0:
+        logger.warning("job not found, _id: %s" % _id)
+        return None
 
-    logger.info("get_job_status status: %s" % r.status_code)
-    result = r.json()
-
-    logger.info("get_job_status result: %s" % json.dumps(result, indent=2))
-    return result["_source"]["status"] if result["found"] else None
+    logger.info("get_job_status result: %s" % json.dumps(res, indent=2))
+    doc = res["hits"]["hits"][0]
+    return doc["status"]
 
 
 @backoff.on_exception(

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -458,7 +458,7 @@ def get_job_status(_id):
 
     logger.info("get_job_status result: %s" % json.dumps(res, indent=2))
     doc = res["hits"]["hits"][0]
-    return doc["status"]
+    return doc["_source"]["status"]
 
 
 @backoff.on_exception(


### PR DESCRIPTION
related ticket: https://hysds-core.atlassian.net/browse/HC-479

related PR(s):
- https://github.com/hysds/hysds/pull/154

Description:
- bug found in the `get_job_status` function in `hysds.utils` where its is trying to grab the job document by `_id` on `job_status-current`
`job_status-current` used to be the sole index, but since we moved to rolling indices (ex. `job_status-2023.06.23`) `job_status-current` is now an alias
- we can't get the document directly by alias so we need to use the `_search` API instead
- moving away from using `requests` and instead using the elasticsearch python API
- functions affected:
  - `get_job_status`
  - `query_dedup_job`
  - `fail_job`