### PR TITLE
HC-479: Dataset Ingest Bulk throws KeyError: "found" error | HC-478: WatchDog Scripts are incorrectly trying to make an ES update to the alias instead of the actual index

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.8"
+__version__ = "1.2.9"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/event_processors.py
+++ b/hysds/event_processors.py
@@ -44,7 +44,8 @@ def fail_job(event, uuid, exc, short_error):
         }
     }
 
-    result = mozart_es.search(index="job_status-current", body=query)
+    result = mozart_es.search(index="job_status-current", body=query,
+                              _source_includes=["status", "error", "short_error", "traceback"])
     total = result["hits"]["total"]["value"]
     if total == 0:
         logger.error("Failed to query for task UUID %s" % uuid)

--- a/hysds/event_processors.py
+++ b/hysds/event_processors.py
@@ -36,20 +36,18 @@ mozart_es = get_mozart_es()
 def fail_job(event, uuid, exc, short_error):
     """Set job status to job-failed."""
 
-    query = {"query": {"bool": {"must": [{"term": {"uuid": uuid}}]}}}
-    search_url = "%s/job_status-current/_search" % app.conf["JOBS_ES_URL"]
+    query = {
+        "query": {
+            "bool": {
+                "must": [{"term": {"uuid": uuid}}]
+            }
+        }
+    }
 
-    headers = {"Content-Type": "application/json"}
-    r = requests.post(search_url, data=json.dumps(query), headers=headers)
-
-    if r.status_code != 200:
-        logger.error("Failed to query for task UUID %s: %s" % (uuid, r.content))
-        return
-
-    result = r.json()
+    result = mozart_es.search(index="job_status-current", body=query)
     total = result["hits"]["total"]["value"]
     if total == 0:
-        logger.error("Failed to query for task UUID %s: %s" % (uuid, r.content))
+        logger.error("Failed to query for task UUID %s" % uuid)
         return
 
     res = result["hits"]["hits"][0]

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -36,11 +36,12 @@ from bisect import insort
 
 from hysds.log_utils import logger, payload_hash_exists
 from hysds.celery import app
-from hysds.es_util import get_grq_es
+from hysds.es_util import get_grq_es, get_mozart_es
 
 import osaka.main
 
 grq_es = get_grq_es()
+mozart_es = get_mozart_es()
 
 # disk usage setting converter
 DU_CALC = {"GB": 1024 ** 3, "MB": 1024 ** 2, "KB": 1024}
@@ -412,20 +413,8 @@ def query_dedup_job(dedup_key, filter_id=None, states=None, is_worker=False):
         query["query"]["bool"]["must_not"] = {"term": {"uuid": filter_id}}
 
     logger.info("constructed query: %s" % json.dumps(query, indent=2))
-    es_url = "%s/job_status-current/_search" % app.conf["JOBS_ES_URL"]
-
-    headers = {"Content-Type": "application/json"}
-    r = requests.post(es_url, data=json.dumps(query), headers=headers)
-    if r.status_code != 200:
-        if r.status_code == 404:
-            logger.info(
-                "status_code 404, job_status-current index probably does not exist, returning None"
-            )
-            return None
-        else:
-            r.raise_for_status()
-    j = r.json()
-    logger.info("result: %s" % r.text)
+    j = mozart_es.search(index="job_status-current", body=query)
+    logger.info(j)
     if j["hits"]["total"]["value"] == 0:
         if hash_exists_in_redis is True:
             if is_worker:
@@ -454,15 +443,22 @@ def query_dedup_job(dedup_key, filter_id=None, states=None, is_worker=False):
 )
 def get_job_status(_id):
     """Get job status."""
+    query = {
+        "query": {
+            "bool": {
+                "must": [{"term": {"_id": _id}}]
+            }
+        }
+    }
 
-    es_url = "%s/job_status-current/_doc/%s" % (app.conf["JOBS_ES_URL"], _id)
-    r = requests.get(es_url, params={"_source": "status"})
+    res = mozart_es.search(index="job_status-current", body=query, _source_includes=["status"])
+    if res["hits"]["total"]["value"] == 0:
+        logger.warning("job not found, _id: %s" % _id)
+        return None
 
-    logger.info("get_job_status status: %s" % r.status_code)
-    result = r.json()
-
-    logger.info("get_job_status result: %s" % json.dumps(result, indent=2))
-    return result["_source"]["status"] if result["found"] else None
+    logger.info("get_job_status result: %s" % json.dumps(res, indent=2))
+    doc = res["hits"]["hits"][0]
+    return doc["status"]
 
 
 @backoff.on_exception(

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -458,7 +458,7 @@ def get_job_status(_id):
 
     logger.info("get_job_status result: %s" % json.dumps(res, indent=2))
     doc = res["hits"]["hits"][0]
-    return doc["status"]
+    return doc["_source"]["status"]
 
 
 @backoff.on_exception(

--- a/scripts/job_utils.py
+++ b/scripts/job_utils.py
@@ -38,9 +38,7 @@ def get_timedout_query(timeout, status, source_data):
 
 
 def es_query(query, index="job_status-current"):
-
     print("es_query : query : {}".format(query))
-
     ES = es_util.get_mozart_es()
     result = ES.search(index=index, body=json.dumps(query))
     print("run_query : result : \n{}".format(json.dumps(result, indent=2)))
@@ -56,6 +54,7 @@ def run_query_with_scroll(query, index="job_status-current"):
 
 
 def update_es(doc_id, data, index="job_status-current"):
+    print(data)
     ES = es_util.get_mozart_es()
     response = ES.update_document(index=index, id=doc_id, body=data)
     print(response)

--- a/scripts/watchdog_job_timeouts.py
+++ b/scripts/watchdog_job_timeouts.py
@@ -46,7 +46,8 @@ def tag_timedout_jobs(url, timeout):
 
     # tag each with timedout
     for res in results:
-        id = res["_id"]
+        _id = res["_id"]
+        _index = res["_index"]
         src = res.get("_source", {})
         status = src["status"]
         tags = src.get("tags", [])
@@ -70,10 +71,7 @@ def tag_timedout_jobs(url, timeout):
             task_res = job_utils.es_query(task_query, index="task_status-current")
 
             if len(task_res["hits"]["hits"]) == 0:
-                logging.error(
-                    "No result found with : query\n%s"
-                    % (json.dumps(task_query, indent=2))
-                )
+                logging.error("No result found with : query\n%s" % json.dumps(task_query, indent=2))
 
             logging.info("task_res: {}".format(json.dumps(task_res)))
 
@@ -118,30 +116,28 @@ def tag_timedout_jobs(url, timeout):
                     "doc_as_upsert": True,
                 }
                 print(json.dumps(new_doc, indent=2))
-                response = job_utils.update_es(id, new_doc, index="job_status-current")
+                response = job_utils.update_es(_id, new_doc, index="job_status-current")
                 if response["result"].strip() != "updated":
                     err_str = "Failed to update status for {} : {}".format(
-                        id, json.dumps(response, indent=2)
+                        _id, json.dumps(response, indent=2)
                     )
                     logging.error(err_str)
                     raise Exception(err_str)
                 logging.info(
-                    "Set job {} to {} and tagged as timedout.".format(id, new_status)
+                    "Set job {} to {} and tagged as timedout.".format(_id, new_status)
                 )
                 continue
 
         if "timedout" in tags:
-            logging.info("%s already tagged as timedout." % id)
+            logging.info("%s already tagged as timedout." % _id)
         else:
             if duration > time_limit:
                 tags.append("timedout")
                 new_doc = {"doc": {"tags": tags}, "doc_as_upsert": True}
                 print(json.dumps(new_doc, indent=2))
-                response = job_utils.update_es(id, new_doc, index="job_status-current")
+                response = job_utils.update_es(_id, new_doc, index=_index)
                 if response["result"].strip() != "updated":
-                    err_str = "Failed to update status for {} : {}".format(
-                        id, json.dumps(response, indent=2)
-                    )
+                    err_str = "Failed to update status for {} : {}".format(_id, json.dumps(response, indent=2))
                     logging.error(err_str)
                     raise Exception(err_str)
 

--- a/scripts/watchdog_job_timeouts.py
+++ b/scripts/watchdog_job_timeouts.py
@@ -110,12 +110,13 @@ def tag_timedout_jobs(url, timeout):
             if status != new_status:
                 logging.info("updating status from {} to {}".format(status, new_status))
                 if duration > time_limit and "timedout" not in tags:
+                    logging.info("adding 'timedout' to tag, %s/%s" % (_index, _id))
                     tags.append("timedout")
                 new_doc = {
                     "doc": {"status": new_status, "tags": tags},
                     "doc_as_upsert": True,
                 }
-                print(json.dumps(new_doc, indent=2))
+                logging.info(json.dumps(new_doc, indent=2))
                 response = job_utils.update_es(_id, new_doc, index=_index)
                 if response["result"].strip() != "updated":
                     err_str = "Failed to update status for {} : {}".format(
@@ -132,9 +133,10 @@ def tag_timedout_jobs(url, timeout):
             logging.info("%s already tagged as timedout." % _id)
         else:
             if duration > time_limit:
+                logging.info("adding 'timedout' to tag, %s/%s" % (_index, _id))
                 tags.append("timedout")
                 new_doc = {"doc": {"tags": tags}, "doc_as_upsert": True}
-                print(json.dumps(new_doc, indent=2))
+                logging.info(json.dumps(new_doc, indent=2))
                 response = job_utils.update_es(_id, new_doc, index=_index)
                 if response["result"].strip() != "updated":
                     err_str = "Failed to update status for {} : {}".format(_id, json.dumps(response, indent=2))
@@ -166,7 +168,7 @@ def daemon(interval, url, timeout):
 if __name__ == "__main__":
     desc = "Watchdog jobs stuck in job-offline or job-started."
     host = app.conf.get("JOBS_ES_URL", "http://localhost:9200")
-    print("host : {}".format(host))
+    logging.info("host : {}".format(host))
     parser = argparse.ArgumentParser(description=desc)
     parser.add_argument(
         "-i",

--- a/scripts/watchdog_job_timeouts.py
+++ b/scripts/watchdog_job_timeouts.py
@@ -116,7 +116,7 @@ def tag_timedout_jobs(url, timeout):
                     "doc_as_upsert": True,
                 }
                 print(json.dumps(new_doc, indent=2))
-                response = job_utils.update_es(_id, new_doc, index="job_status-current")
+                response = job_utils.update_es(_id, new_doc, index=_index)
                 if response["result"].strip() != "updated":
                     err_str = "Failed to update status for {} : {}".format(
                         _id, json.dumps(response, indent=2)

--- a/scripts/watchdog_task_timeouts.py
+++ b/scripts/watchdog_task_timeouts.py
@@ -40,27 +40,26 @@ def tag_timedout_tasks(url, timeout):
 
     # tag each with timedout
     for res in results:
-        id = res["_id"]
+        _id = res["_id"]
+        _index = res["_index"]
         src = res.get("_source", {})
-        status = src["status"]
+        # status = src["status"]
         tags = src.get("tags", [])
-        task_id = src["uuid"]
+        # task_id = src["uuid"]
 
         if "timedout" not in tags:
             tags.append("timedout")
             new_doc = {"doc": {"tags": tags}, "doc_as_upsert": True}
 
-            response = job_utils.update_es(id, new_doc, index="task_status-current")
+            response = job_utils.update_es(_id, new_doc, index=_index)
             if response["result"].strip() != "updated":
-                err_str = "Failed to update status for {} : {}".format(
-                    id, json.dumps(response, indent=2)
-                )
+                err_str = "Failed to update status for {} : {}".format(_id, json.dumps(response, indent=2))
                 logging.error(err_str)
                 raise Exception(err_str)
 
-            logging.info("Tagged %s as timedout." % id)
+            logging.info("Tagged %s as timedout." % _id)
         else:
-            logging.info("%s already tagged as timedout." % id)
+            logging.info("%s already tagged as timedout." % _id)
 
 
 def daemon(interval, url, timeout):


### PR DESCRIPTION
dev-e2e: 
- https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/dustinlo-force_branch-E2E-test/42
- https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/ci-force_branch-E2E-test/267/

# HC-479 - Dataset Ingest Bulk throws KeyError: "found" error
related ticket: https://hysds-core.atlassian.net/browse/HC-479

related PR(s):
- https://github.com/hysds/hysds/pull/154

Description:
- bug found in the `get_job_status` function in `hysds.utils` where its is trying to grab the job document by `_id` on `job_status-current`
`job_status-current` used to be the sole index, but since we moved to rolling indices (ex. `job_status-2023.06.23`) `job_status-current` is now an alias
- we can't get the document directly by alias so we need to use the `_search` API instead
- moving away from using `requests` and instead using the elasticsearch python API
- functions affected:
  - `get_job_status`
  - `query_dedup_job`
  - `fail_job`

# HC-478 - WatchDog Scripts are incorrectly trying to make an ES update to the alias instead of the actual index
related ticket: https://hysds-core.atlassian.net/browse/HC-478

Change(s):
- fixing `tag_timedout_workers` function to use the proper `_index` to update the document
- renaming `id` to `_id` because `id` is a builtin function for python