### PR TITLE
hot-fix: Ignore 404 errors as we had before when making requests calls

### DIFF
--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -413,7 +413,7 @@ def query_dedup_job(dedup_key, filter_id=None, states=None, is_worker=False):
         query["query"]["bool"]["must_not"] = {"term": {"uuid": filter_id}}
 
     logger.info("constructed query: %s" % json.dumps(query, indent=2))
-    j = mozart_es.search(index="job_status-current", body=query, ignore=[404])
+    j = mozart_es.search(index="job_status-current", body=query, ignore=404)
     logger.info(j)
     # Check for 404 status first and return None immediately as we had been before
     if "status" in j.keys() and j.get("status") == 404:

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -413,7 +413,7 @@ def query_dedup_job(dedup_key, filter_id=None, states=None, is_worker=False):
         query["query"]["bool"]["must_not"] = {"term": {"uuid": filter_id}}
 
     logger.info("constructed query: %s" % json.dumps(query, indent=2))
-    j = mozart_es.search(index="job_status-current", body=query)
+    j = mozart_es.search(index="job_status-current", body=query, ignore=[404])
     logger.info(j)
     if j["hits"]["total"]["value"] == 0:
         if hash_exists_in_redis is True:

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -415,7 +415,7 @@ def query_dedup_job(dedup_key, filter_id=None, states=None, is_worker=False):
     logger.info("constructed query: %s" % json.dumps(query, indent=2))
     j = mozart_es.search(index="job_status-current", body=query, ignore=[404])
     logger.info(j)
-    if j["hits"]["total"]["value"] == 0:
+    if j.get("hits", {}).get("total", {}).get("value", 0) == 0:
         if hash_exists_in_redis is True:
             if is_worker:
                 return None

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -415,7 +415,14 @@ def query_dedup_job(dedup_key, filter_id=None, states=None, is_worker=False):
     logger.info("constructed query: %s" % json.dumps(query, indent=2))
     j = mozart_es.search(index="job_status-current", body=query, ignore=[404])
     logger.info(j)
-    if j.get("hits", {}).get("total", {}).get("value", 0) == 0:
+    # Check for 404 status first and return None immediately as we had been before
+    if "status" in j.keys() and j.get("status") == 404:
+        logger.info(
+            "status_code 404, job_status-current index probably does not exist, returning None"
+        )
+        return None
+
+    if j["hits"]["total"]["value"] == 0:
         if hash_exists_in_redis is True:
             if is_worker:
                 return None


### PR DESCRIPTION
There appears to be an issue with the recent changes made in https://github.com/hysds/hysds/pull/174

Didn't notice this before, but it looks like in the querying of the dedup jobs, that PR updated the function to use mozart_es instead of the requests call:

![image](https://github.com/hysds/hysds/assets/42812746/50f586e1-7fa9-40bd-8d31-f238710c82e5)

However, it forgot to take into account gracefully ignoring 404 errors. 