### PR TITLE
HC-482: Make User Rule Job evaluation more targeted

### DIFF
--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1491,7 +1491,8 @@ def run_job(job, queue_when_finished=True):
 
         # queue job finished for user rules processing
         if queue_when_finished is True:
-            queue_finished_job(payload_id)
+            job_index = job.get("job_info", {}).get("index")
+            queue_finished_job(payload_id, index=job_index)
     except Exception as e:
         error = str(e)
         job_status_json = {


### PR DESCRIPTION
Change(s):
- passing the job doc's index to userrules task
- removed alias 'job_status' in favor of `job_status-current` in user rules job evaluation

Related ticket:
- https://hysds-core.atlassian.net/browse/HC-482

Related PR(s):
- https://github.com/hysds/lightweight-jobs/pull/29

Jenkins:
- dev-e2e (reproc): https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/ci-force_branch-E2E-test/272/
- dev-e2e (fwd): https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/ci-force_branch-E2E-test/273/

`job_worker.py` will now pass the index to the user rules job evaluation, the logs:
```
[2023-07-12 23:15:39,472: INFO/ForkPoolWorker-1] hysds.task_worker.run_task[f31be517-7e03-49ac-8aef-7c02229db2f8]: Final query: {"query": {"bool": {"must": [{"bool": {"must": [{"bool": {"must": [{"term": {"job.type": "job-lightweight-echo:v1.2.4"}}]}}]}}, {"term": {"_id": "fe5030be-0bf9-4020-85bd-3b497afb4b4a"}}]}}}
[2023-07-12 23:15:39,472: INFO/ForkPoolWorker-1] hysds.task_worker.run_task[f31be517-7e03-49ac-8aef-7c02229db2f8]: updated query: "{\"query\": {\"bool\": {\"must\": [{\"bool\": {\"must\": [{\"bool\": {\"must\": [{\"term\": {\"job.type\": \"job-lightweight-echo:v1.2.4\"}}]}}]}}, {\"term\": {\"_id\": \"fe5030be-0bf9-4020-85bd-3b497afb4b4a\"}}]}}}"
[2023-07-12 23:15:39,475: INFO/ForkPoolWorker-1] POST http://100.104.10.203:9200/job_status-2023.07.12/_search [status:200 request:0.003s]
[2023-07-12 23:15:39,475: INFO/ForkPoolWorker-1] hysds.task_worker.run_task[f31be517-7e03-49ac-8aef-7c02229db2f8]: Rule 'dustin_test_rule' successfully matched for fe5030be-0bf9-4020-85bd-3b497afb4b4a
[2023-07-12 23:15:39,502: INFO/ForkPoolWorker-1] hysds.task_worker.run_task[f31be517-7e03-49ac-8aef-7c02229db2f8]: Trigger task submitted for fe5030be-0bf9-4020-85bd-3b497afb4b4a: hysds-io-lw-mozart-notify-by-email:v1.2.4
```

if you look at where ES is called, instead of using the alias `job_status` it now uses the specific index (`job_status-2023.07.12`) where the document resides:
```
[2023-07-12 23:15:39,475: INFO/ForkPoolWorker-1] POST http://100.104.10.203:9200/job_status-2023.07.12/_search [status:200 request:0.003s]
```