### PR TITLE
HC-489: Update Job Watchdog to sort worker queries by latest

### DIFF
--- a/scripts/watchdog_job_timeouts.py
+++ b/scripts/watchdog_job_timeouts.py
@@ -79,7 +79,7 @@ def tag_timedout_jobs(url, timeout):
             worker_query = {
                 "query": {"term": {"_id": celery_hostname}},
                 "_source": ["status", "tags"],
-                "sort": ["@timestamp:desc"]
+                "sort": [{"@timestamp": "desc"}]
             }
 
             worker_res = job_utils.es_query(worker_query, index="worker_status-current")

--- a/scripts/watchdog_job_timeouts.py
+++ b/scripts/watchdog_job_timeouts.py
@@ -79,6 +79,7 @@ def tag_timedout_jobs(url, timeout):
             worker_query = {
                 "query": {"term": {"_id": celery_hostname}},
                 "_source": ["status", "tags"],
+                "sort": ["@timestamp:desc"]
             }
 
             worker_res = job_utils.es_query(worker_query, index="worker_status-current")


### PR DESCRIPTION
This PR updates the job watchdog such that when it queries for worker events for a particular worker, it will sort the records by latest. We need to do this as the worker history can span across multiple indices now.

Once I made the fix, I deployed onto the Load Test cluster and it seems to be working fine now:

```
[2023-08-09 00:56:34,162: INFO/watchdog_job_timeouts] search **kwargs: {'index': 'worker_status-current', 'body': '{"query": {"term": {"_id": "celery@nisar-job_worker-datatake-acct.172.31.27.200"}}, "_source": ["status", "tags"], "sort": [{"@timestamp": "desc"}]}'}
[2023-08-09 00:56:34,163: INFO/watchdog_job_timeouts] POST http://127.0.0.1:9200/worker_status-current/_search [status:200 request:0.001s]
[2023-08-09 00:56:34,163: INFO/watchdog_job_timeouts] worker_res: {"took": 0, "timed_out": false, "_shards": {"total": 15, "successful": 15, "skipped": 0, "failed": 0}, "hits": {"total": {"value": 2, "relation": "eq"}, "max_score": null, "hits": [{"_index": "worker_status-2023.08.09", "_type": "_doc", "_id": "celery@nisar-job_worker-datatake-acct.172.31.27.200", "_score": null, "_source": {"status": "worker-heartbeat", "tags": []}, "sort": [1691542573419]}, {"_index": "worker_status-2023.08.08", "_type": "_doc", "_id": "celery@nisar-job_worker-datatake-acct.172.31.27.200", "_score": null, "_source": {"status": "worker-heartbeat", "tags": ["timedout"]}, "sort": [1691539153251]}]}}
```
