### PR TITLE
HC-493: Updates to better handle jobs that fail due to connection timeouts but are never persisted back up to the job status

### DIFF
--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -18,11 +18,14 @@ task_queue_max_priority = 10
 
 task_reject_on_worker_lost = True
 
-broker_heartbeat = 120
+broker_heartbeat = 30
 broker_heartbeat_checkrate = 2
 
 broker_pool_limit = None
 broker_transport_options = { "confirm_publish": True }
+
+redis_socket_keepalive = True
+redis_backend_healh_check_interval = 30
 
 imports = [
     "hysds.task_worker",

--- a/hysds/event_processors.py
+++ b/hysds/event_processors.py
@@ -44,9 +44,9 @@ def fail_job(event, uuid, exc, short_error):
         }
     }
 
-    result = mozart_es.search(index="job_status-current", body=query,
-                              _source_includes=["status", "error", "short_error", "traceback"])
+    result = mozart_es.search(index="job_status-current", body=query)
     total = result["hits"]["total"]["value"]
+    logger.info(f"total results back from fail_job function: {total}")
     if total == 0:
         msg = "Failed to query for task UUID %s" % uuid
         logger.error(msg)

--- a/hysds/event_processors.py
+++ b/hysds/event_processors.py
@@ -25,7 +25,7 @@ from hysds.log_utils import (
     JOB_STATUS_KEY_TMPL,
 )
 from hysds.es_util import get_mozart_es
-
+from user_rules_job import queue_finished_job
 
 mozart_es = get_mozart_es()
 

--- a/hysds/event_processors.py
+++ b/hysds/event_processors.py
@@ -48,8 +48,9 @@ def fail_job(event, uuid, exc, short_error):
                               _source_includes=["status", "error", "short_error", "traceback"])
     total = result["hits"]["total"]["value"]
     if total == 0:
-        logger.error("Failed to query for task UUID %s" % uuid)
-        return
+        msg = "Failed to query for task UUID %s" % uuid
+        logger.error(msg)
+        raise RuntimeError(msg)
 
     res = result["hits"]["hits"][0]
     job_status = res["_source"]

--- a/hysds/event_processors.py
+++ b/hysds/event_processors.py
@@ -66,7 +66,7 @@ def fail_job(event, uuid, exc, short_error):
         job_status.setdefault("job", {}).setdefault("job_info", {})["time_end"] = time_end
         log_job_status(job_status)
 
-        queue_finished_job(uuid, index=res["_index"])
+        queue_finished_job(job_status["payload_id"], index=res["_index"])
     else:
         logger.info(
             f"fail_job - {uuid}: Will not re-log and requeue job as job status is already set "

--- a/hysds/event_processors.py
+++ b/hysds/event_processors.py
@@ -31,7 +31,7 @@ mozart_es = get_mozart_es()
 
 
 @backoff.on_exception(
-    backoff.expo, Exception, max_tries=2, max_value=10
+    backoff.expo, Exception, max_tries=5, max_value=10
 )
 def fail_job(event, uuid, exc, short_error):
     """Set job status to job-failed."""

--- a/hysds/event_processors.py
+++ b/hysds/event_processors.py
@@ -62,7 +62,7 @@ def fail_job(event, uuid, exc, short_error):
     time_end = datetime.utcnow().isoformat() + "Z"
     job_status.setdefault("job", {}).setdefault("job_info", {})["time_end"] = time_end
     log_job_status(job_status)
-
+    queue_finished_job(uuid, index=res["_index"])
 
 @backoff.on_exception(
     backoff.expo, Exception, max_tries=backoff_max_tries, max_value=backoff_max_value

--- a/hysds/event_processors.py
+++ b/hysds/event_processors.py
@@ -31,7 +31,7 @@ mozart_es = get_mozart_es()
 
 
 @backoff.on_exception(
-    backoff.expo, Exception, max_tries=backoff_max_tries, max_value=backoff_max_value
+    backoff.expo, Exception, max_tries=2, max_value=10
 )
 def fail_job(event, uuid, exc, short_error):
     """Set job status to job-failed."""

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1401,7 +1401,7 @@ def run_job(job, queue_when_finished=True):
             .get("job_specification", {})
             .get("disable_post_builtins", False)
         )
-        post_processors = [] if disable_post else list(POST_PROCESSORS)
+        post_processors = [] if disable_post or job_status_json["status"] == "job-deduped" else list(POST_PROCESSORS)
         post_processors.extend(
             job.get("params", {}).get("job_specification", {}).get("post", [])
         )

--- a/hysds/orchestrator.py
+++ b/hysds/orchestrator.py
@@ -43,6 +43,7 @@ from hysds.utils import (
 )
 from hysds.user_rules_dataset import queue_dataset_evaluation
 
+from user_rules_job import queue_finished_job
 
 # error template
 ERROR_TMPL = Template("Error queueing job from $orch_queue: $error")

--- a/hysds/orchestrator.py
+++ b/hysds/orchestrator.py
@@ -461,6 +461,7 @@ def submit_job(j):
                     "traceback": traceback.format_exc(),
                 }
                 log_job_status(job_status_json)
+                queue_finished_job(task_id, index=job_json["job_info"]["index"])
 
     return results
 

--- a/hysds/orchestrator.py
+++ b/hysds/orchestrator.py
@@ -469,6 +469,16 @@ def submit_job(j):
     backoff.expo, socket.error, max_tries=backoff_max_tries, max_value=backoff_max_value
 )
 def do_run_job(job_json, queue, time_limit, soft_time_limit, priority):
+    """
+    Run job wrapper with exponential backoff and full jitter.
+
+    :param job_json:
+    :param queue:
+    :param time_limit:
+    :param soft_time_limit:
+    :param priority:
+    :return:
+    """
     return run_job.apply_async(
         (job_json,),
         queue=queue,

--- a/hysds/orchestrator.py
+++ b/hysds/orchestrator.py
@@ -43,7 +43,7 @@ from hysds.utils import (
 )
 from hysds.user_rules_dataset import queue_dataset_evaluation
 
-from user_rules_job import queue_finished_job
+from hysds.user_rules_job import queue_finished_job
 
 # error template
 ERROR_TMPL = Template("Error queueing job from $orch_queue: $error")

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -396,7 +396,7 @@ def query_dedup_job(dedup_key, filter_id=None, states=None, is_worker=False):
         "query": {
             "bool": {
                 "must": [
-                    {"term": {"payload_hash": dedup_key}},
+                    {"term": {"payload_hash.keyword": dedup_key}},
                     {
                         "bool": {
                             "should": [

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -396,7 +396,7 @@ def query_dedup_job(dedup_key, filter_id=None, states=None, is_worker=False):
         "query": {
             "bool": {
                 "must": [
-                    {"term": {"payload_hash.keyword": dedup_key}},
+                    {"term": {"payload_hash": dedup_key}},
                     {
                         "bool": {
                             "should": [

--- a/scripts/process_events.py
+++ b/scripts/process_events.py
@@ -41,7 +41,7 @@ ORCH_NAME_RE = re.compile(r"^hysds.orchestrator.submit_job")
 
 # regex for task-failed errors that won't be updated in ES because
 # worker had no chance to send update
-TASK_FAILED_RE = re.compile(r"^(WorkerLostError|TimeLimitExceeded|ConnectionError)")
+TASK_FAILED_RE = re.compile(r"(WorkerLostError|TimeLimitExceeded|ConnectionError)")
 
 # regex for extracting type and hostname from worker
 TYPE_RE = re.compile(r"'type': '(.+?)',")

--- a/scripts/process_events.py
+++ b/scripts/process_events.py
@@ -41,7 +41,7 @@ ORCH_NAME_RE = re.compile(r"^hysds.orchestrator.submit_job")
 
 # regex for task-failed errors that won't be updated in ES because
 # worker had no chance to send update
-TASK_FAILED_RE = re.compile(r"^(WorkerLostError|TimeLimitExceeded)")
+TASK_FAILED_RE = re.compile(r"^(WorkerLostError|TimeLimitExceeded|ConnectionError)")
 
 # regex for extracting type and hostname from worker
 TYPE_RE = re.compile(r"'type': '(.+?)',")


### PR DESCRIPTION
This PR updates the system to better handle jobs where connection timeouts occur, but never get caught by the system. Therefore, at the operator level, the jobs appear "stuck" at job-started or job-queued.

Here are the changes:

**Orchestrator**
Add backoff to the run_job call when submitting a job to be queued. We also reversed the order such that we make the call first, then set the job status to `job-queued` rather than the other way around as it was in the previous implementation. Lastly, if the exponential backoff still fails after it hits its max retries, then we added the capability to set the job status to `job-failed`, followed by sending it off to user rule job evaluation.

**Process Events**
Additionally look for ConnectionError task failures. When these kinds of failures occur, then we make sure to fail the job.

**Process Events Tasks**
When failing the job, if we cannot find the job record in ES, apply exponential backoff to give time for the job record to be searchable. Once we find the job record, only set it to job failed if the job has not yet completed.