### PR TITLE
HC-484: OpenSearch support

### DIFF
--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -63,7 +63,11 @@ PYMONITOREDRUNNER_CFG = {
 
 MOZART_URL = "https://{{ MOZART_PVT_IP }}/mozart/"
 MOZART_REST_URL = "http://{{ MOZART_PVT_IP }}:8888/api/v0.1"
-JOBS_ES_URL = "http://{{ MOZART_ES_PVT_IP }}:9200"
+
+JOBS_ES_ENGINE = {{ JOBS_ES_ENGINE or 'elasticsearch' }}
+JOBS_AWS_ES = {{ JOBS_AWS_ES or False }}
+JOBS_ES_URL = {{ 'https://'~MOZART_ES_PVT_IP if JOBS_AWS_ES == true else 'http://'~MOZART_ES_PVT_IP~':9200' }}
+
 JOBS_PROCESSED_QUEUE = "jobs_processed"
 USER_RULES_JOB_QUEUE = "user_rules_job"
 ON_DEMAND_JOB_QUEUE = "on_demand_job"
@@ -76,12 +80,10 @@ GRQ_REST_URL = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.1"
 GRQ_UPDATE_URL = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.1/grq/dataset/index"
 GRQ_UPDATE_URL_BULK = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.2/grq/dataset/index"
 
-
+GRQ_ES_ENGINE = {{ GRQ_ES_ENGINE or 'elasticsearch' }}
 GRQ_AWS_ES = {{ GRQ_AWS_ES or False }}
-GRQ_ES_HOST = "{{ GRQ_ES_PVT_IP }}"
-GRQ_ES_PORT = {{ GRQ_ES_PORT or 9200 }}
-GRQ_ES_PROTOCOL = "{{ GRQ_ES_PROTOCOL or 'http' }}"
-GRQ_ES_URL = '%s://%s:%d' % (GRQ_ES_PROTOCOL, GRQ_ES_HOST, GRQ_ES_PORT)
+GRQ_ES_URL = {{ 'https://'~GRQ_ES_PVT_IP if GRQ_AWS_ES == true else 'http://'~GRQ_ES_PVT_IP~':9200' }}
+
 
 CONTAINER_ENGINE = "{{ CONTAINER_ENGINE or 'docker' }}"
 

--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -64,9 +64,9 @@ PYMONITOREDRUNNER_CFG = {
 MOZART_URL = "https://{{ MOZART_PVT_IP }}/mozart/"
 MOZART_REST_URL = "http://{{ MOZART_PVT_IP }}:8888/api/v0.1"
 
-JOBS_ES_ENGINE = {{ JOBS_ES_ENGINE or 'elasticsearch' }}
+JOBS_ES_ENGINE = "{{ JOBS_ES_ENGINE or 'elasticsearch' }}"
 JOBS_AWS_ES = {{ JOBS_AWS_ES or False }}
-JOBS_ES_URL = {{ 'https://'~MOZART_ES_PVT_IP if JOBS_AWS_ES == true else 'http://'~MOZART_ES_PVT_IP~':9200' }}
+JOBS_ES_URL = "{{ 'https://'~MOZART_ES_PVT_IP if JOBS_AWS_ES == true else 'http://'~MOZART_ES_PVT_IP~':9200' }}"
 
 JOBS_PROCESSED_QUEUE = "jobs_processed"
 USER_RULES_JOB_QUEUE = "user_rules_job"
@@ -80,9 +80,9 @@ GRQ_REST_URL = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.1"
 GRQ_UPDATE_URL = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.1/grq/dataset/index"
 GRQ_UPDATE_URL_BULK = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.2/grq/dataset/index"
 
-GRQ_ES_ENGINE = {{ GRQ_ES_ENGINE or 'elasticsearch' }}
+GRQ_ES_ENGINE = "{{ GRQ_ES_ENGINE or 'elasticsearch' }}"
 GRQ_AWS_ES = {{ GRQ_AWS_ES or False }}
-GRQ_ES_URL = {{ 'https://'~GRQ_ES_PVT_IP if GRQ_AWS_ES == true else 'http://'~GRQ_ES_PVT_IP~':9200' }}
+GRQ_ES_URL = "{{ 'https://'~GRQ_ES_PVT_IP if GRQ_AWS_ES == true else 'http://'~GRQ_ES_PVT_IP~':9200' }}"
 
 
 CONTAINER_ENGINE = "{{ CONTAINER_ENGINE or 'docker' }}"

--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -66,7 +66,11 @@ MOZART_REST_URL = "http://{{ MOZART_PVT_IP }}:8888/api/v0.1"
 
 JOBS_ES_ENGINE = "{{ JOBS_ES_ENGINE or 'elasticsearch' }}"
 JOBS_AWS_ES = {{ JOBS_AWS_ES or False }}
-JOBS_ES_URL = "{{ 'https://'~MOZART_ES_PVT_IP if JOBS_AWS_ES == true else 'http://'~MOZART_ES_PVT_IP~':9200' }}"
+{% if JOB_ES_PVT_IP.startswith('https://') %}
+JOBS_ES_URL = "{{ JOB_ES_PVT_IP }}"
+{% else %}
+JOBS_ES_URL = "{{ 'https://'~JOB_ES_PVT_IP if JOB_AWS_ES == true or 'es.amazonaws.com' in JOB_ES_PVT_IP else 'http://'~JOB_ES_PVT_IP~':9200' }}"
+{% endif %}
 
 JOBS_PROCESSED_QUEUE = "jobs_processed"
 USER_RULES_JOB_QUEUE = "user_rules_job"
@@ -82,7 +86,12 @@ GRQ_UPDATE_URL_BULK = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.2/grq/datas
 
 GRQ_ES_ENGINE = "{{ GRQ_ES_ENGINE or 'elasticsearch' }}"
 GRQ_AWS_ES = {{ GRQ_AWS_ES or False }}
-GRQ_ES_URL = "{{ 'https://'~GRQ_ES_PVT_IP if GRQ_AWS_ES == true else 'http://'~GRQ_ES_PVT_IP~':9200' }}"
+{% if GRQ_ES_PVT_IP.startswith('https://') %}
+GRQ_ES_URL = "{{ GRQ_ES_PVT_IP }}"
+{% else %}
+GRQ_ES_URL = "{{ 'https://'~GRQ_ES_PVT_IP if GRQ_AWS_ES == true or 'es.amazonaws.com' in GRQ_ES_PVT_IP else 'http://'~GRQ_ES_PVT_IP~':9200' }}"
+{% endif %}
+
 
 
 CONTAINER_ENGINE = "{{ CONTAINER_ENGINE or 'docker' }}"

--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -66,11 +66,23 @@ MOZART_REST_URL = "http://{{ MOZART_PVT_IP }}:8888/api/v0.1"
 
 JOBS_ES_ENGINE = "{{ MOZART_ES_ENGINE or 'elasticsearch' }}"
 JOBS_AWS_ES = {{ MOZART_AWS_ES or False }}
-{% if MOZART_ES_PVT_IP.startswith('https://') %}
+{%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
+JOBS_ES_URL = [
+    {%- for url in MOZART_ES_PVT_IP %}
+        {%- if url.startswith('https://') %}
+    "{{ url }}",
+        {%- else %}
+    "{{ 'https://'~url if MOZART_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}",
+        {%- endif %}
+    {%- endfor %}
+]
+{%- else %}
+    {%- if MOZART_ES_PVT_IP.startswith('https://') %}
 JOBS_ES_URL = "{{ MOZART_ES_PVT_IP }}"
-{% else %}
+    {%- else %}
 JOBS_ES_URL = "{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"
-{% endif %}
+    {%- endif %}
+{%- endif %}
 
 JOBS_PROCESSED_QUEUE = "jobs_processed"
 USER_RULES_JOB_QUEUE = "user_rules_job"
@@ -86,13 +98,23 @@ GRQ_UPDATE_URL_BULK = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.2/grq/datas
 
 GRQ_ES_ENGINE = "{{ GRQ_ES_ENGINE or 'elasticsearch' }}"
 GRQ_AWS_ES = {{ GRQ_AWS_ES or False }}
-{% if GRQ_ES_PVT_IP.startswith('https://') %}
+{%- if GRQ_ES_PVT_IP is iterable and GRQ_ES_PVT_IP is not string %}
+GRQ_ES_URL = [
+    {%- for url in GRQ_ES_PVT_IP %}
+        {%- if url.startswith('https://') %}
+    "{{ url }}",
+        {%- else %}
+    "{{ 'https://'~url if GRQ_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}",
+        {%- endif %}
+    {%- endfor %}
+]
+{%- else %}
+    {%- if GRQ_ES_PVT_IP.startswith('https://') %}
 GRQ_ES_URL = "{{ GRQ_ES_PVT_IP }}"
-{% else %}
+    {%- else %}
 GRQ_ES_URL = "{{ 'https://'~GRQ_ES_PVT_IP if GRQ_AWS_ES == true or 'es.amazonaws.com' in GRQ_ES_PVT_IP else 'http://'~GRQ_ES_PVT_IP~':9200' }}"
-{% endif %}
-
-
+    {%- endif %}
+{%- endif %}
 
 CONTAINER_ENGINE = "{{ CONTAINER_ENGINE or 'docker' }}"
 
@@ -109,7 +131,25 @@ USER_RULES_TRIGGER_QUEUE = "user_rules_trigger"
 
 PROCESS_EVENTS_TASKS_QUEUE = "process_events_tasks"
 
-METRICS_ES_URL = "http://{{ METRICS_ES_PVT_IP }}:9200"
+METRICS_ES_ENGINE = "{{ METRICS_ES_ENGINE or 'elasticsearch' }}"
+METRICS_AWS_ES = {{ METRICS_AWS_ES or False }}
+{%- if METRICS_ES_PVT_IP is iterable and METRICS_ES_PVT_IP is not string %}
+METRICS_ES_URL = [
+    {%- for url in METRICS_ES_PVT_IP %}
+        {%- if url.startswith('https://') %}
+    "{{ url }}",
+        {%- else %}
+    "{{ 'https://'~url if METRICS_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}",
+        {%- endif %}
+    {%- endfor %}
+]
+{%- else %}
+    {%- if METRICS_ES_PVT_IP.startswith('https://') %}
+METRICS_ES_URL = "{{ METRICS_ES_PVT_IP }}"
+    {%- else %}
+METRICS_ES_URL = "{{ 'https://'~METRICS_ES_PVT_IP if METRICS_AWS_ES == true or 'es.amazonaws.com' in METRICS_ES_PVT_IP else 'http://'~METRICS_ES_PVT_IP~':9200' }}"
+    {%- endif %}
+{%- endif %}
 
 REDIS_JOB_STATUS_URL = "redis://:{{ MOZART_REDIS_PASSWORD }}@{{ MOZART_REDIS_PVT_IP }}"
 REDIS_JOB_STATUS_KEY = "logstash"

--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -64,12 +64,12 @@ PYMONITOREDRUNNER_CFG = {
 MOZART_URL = "https://{{ MOZART_PVT_IP }}/mozart/"
 MOZART_REST_URL = "http://{{ MOZART_PVT_IP }}:8888/api/v0.1"
 
-JOBS_ES_ENGINE = "{{ JOBS_ES_ENGINE or 'elasticsearch' }}"
-JOBS_AWS_ES = {{ JOBS_AWS_ES or False }}
-{% if JOB_ES_PVT_IP.startswith('https://') %}
-JOBS_ES_URL = "{{ JOB_ES_PVT_IP }}"
+JOBS_ES_ENGINE = "{{ MOZART_ES_ENGINE or 'elasticsearch' }}"
+JOBS_AWS_ES = {{ MOZART_AWS_ES or False }}
+{% if MOZART_ES_PVT_IP.startswith('https://') %}
+JOBS_ES_URL = "{{ MOZART_ES_PVT_IP }}"
 {% else %}
-JOBS_ES_URL = "{{ 'https://'~JOB_ES_PVT_IP if JOB_AWS_ES == true or 'es.amazonaws.com' in JOB_ES_PVT_IP else 'http://'~JOB_ES_PVT_IP~':9200' }}"
+JOBS_ES_URL = "{{ 'https://'~MOZART_ES_PVT_IP if JOB_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"
 {% endif %}
 
 JOBS_PROCESSED_QUEUE = "jobs_processed"

--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -69,7 +69,7 @@ JOBS_AWS_ES = {{ MOZART_AWS_ES or False }}
 {% if MOZART_ES_PVT_IP.startswith('https://') %}
 JOBS_ES_URL = "{{ MOZART_ES_PVT_IP }}"
 {% else %}
-JOBS_ES_URL = "{{ 'https://'~MOZART_ES_PVT_IP if JOB_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"
+JOBS_ES_URL = "{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"
 {% endif %}
 
 JOBS_PROCESSED_QUEUE = "jobs_processed"

--- a/configs/logstash/indexer.conf.metrics
+++ b/configs/logstash/indexer.conf.metrics
@@ -48,7 +48,7 @@ output {
       {%- if METRICS_ES_PVT_IP.startswith('https://') %}
     hosts => ["{{ METRICS_ES_PVT_IP }}"]
       {%- else %}
-    hosts => ["{{ 'https://'~METRICS_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in METRICS_ES_PVT_IP else 'http://'~METRICS_ES_PVT_IP~':9200' }}"]
+    hosts => ["{{ 'https://'~METRICS_ES_PVT_IP if METRICS_AWS_ES == true or 'es.amazonaws.com' in METRICS_ES_PVT_IP else 'http://'~METRICS_ES_PVT_IP~':9200' }}"]
       {%- endif %}
     {%- endif %}
     index => "%{[@index]}"

--- a/configs/logstash/indexer.conf.metrics
+++ b/configs/logstash/indexer.conf.metrics
@@ -33,9 +33,24 @@ input {
 output {
   #stdout { codec => rubydebug }
 
-  elasticsearch {
-    hosts => ["{{ METRICS_ES_PVT_IP }}:9200"]
+  opensearch {
+    {%- if METRICS_ES_PVT_IP is iterable and METRICS_ES_PVT_IP is not string %}
+    hosts => [
+      {%- for url in METRICS_ES_PVT_IP %}
+        {%- if url.startswith('https://') %}
+      "{{ url }}"{{ "," if not loop.last else "" }}
+        {%- else %}
+      "{{ 'https://'~url if MOZART_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}"{{ "," if not loop.last else "" }}
+        {%- endif %}
+      {%- endfor %}
+    ]
+    {%- else %}
+      {%- if METRICS_ES_PVT_IP.startswith('https://') %}
+    hosts => ["{{ METRICS_ES_PVT_IP }}"]
+      {%- else %}
+    hosts => ["{{ 'https://'~METRICS_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in METRICS_ES_PVT_IP else 'http://'~METRICS_ES_PVT_IP~':9200' }}"]
+      {%- endif %}
+    {%- endif %}
     index => "%{[@index]}"
   }
 }
-

--- a/configs/logstash/indexer.conf.metrics
+++ b/configs/logstash/indexer.conf.metrics
@@ -33,7 +33,7 @@ input {
 output {
   #stdout { codec => rubydebug }
 
-  {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
+  {{ 'opensearch' if METRICS_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
     {%- if METRICS_ES_PVT_IP is iterable and METRICS_ES_PVT_IP is not string %}
     hosts => [
       {%- for url in METRICS_ES_PVT_IP %}

--- a/configs/logstash/indexer.conf.metrics
+++ b/configs/logstash/indexer.conf.metrics
@@ -33,7 +33,7 @@ input {
 output {
   #stdout { codec => rubydebug }
 
-  opensearch {
+  {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
     {%- if METRICS_ES_PVT_IP is iterable and METRICS_ES_PVT_IP is not string %}
     hosts => [
       {%- for url in METRICS_ES_PVT_IP %}

--- a/configs/logstash/indexer.conf.metrics
+++ b/configs/logstash/indexer.conf.metrics
@@ -40,7 +40,7 @@ output {
         {%- if url.startswith('https://') %}
       "{{ url }}"{{ "," if not loop.last else "" }}
         {%- else %}
-      "{{ 'https://'~url if MOZART_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}"{{ "," if not loop.last else "" }}
+      "{{ 'https://'~url if METRICS_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}"{{ "," if not loop.last else "" }}
         {%- endif %}
       {%- endfor %}
     ]

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -52,7 +52,7 @@ output {
   #stdout { codec => rubydebug }
 
   if [resource] == "job" {
-    opensearch {
+    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
       {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
       hosts => [
         {%- for url in MOZART_ES_PVT_IP %}
@@ -75,7 +75,7 @@ output {
       ecs_compatibility => disabled
     }
   } else if [resource] == "worker" {
-    opensearch {
+    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
       {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
       hosts => [
         {%- for url in MOZART_ES_PVT_IP %}
@@ -98,7 +98,7 @@ output {
       ecs_compatibility => disabled
     }
   } else if [resource] == "task" {
-    opensearch {
+    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
       {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
       hosts => [
         {%- for url in MOZART_ES_PVT_IP %}
@@ -121,7 +121,7 @@ output {
       ecs_compatibility => disabled
     }
   } else if [resource] == "event" {
-    opensearch {
+    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
       {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
       hosts => [
         {%- for url in MOZART_ES_PVT_IP %}

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -53,70 +53,30 @@ output {
 
   if [resource] == "job" {
     opensearch {
-      {%- if MOZART_ES_PVT_IP.startswith('https://') -%}
-      hosts => ["{{ MOZART_ES_PVT_IP }}"]
-      {% else %}
-      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
-      {%- endif %}
+      hosts => ["{{ MOZART_PVT_IP }}:9200"]
       index => "%{[job][job_info][index]}"
       document_id => "%{payload_id}"
-      {%- if MOZART_AWS_ES %}
-      auth_type => {
-        type => 'aws_iam'
-        region => "{{ AWS_REGION or 'us-west-2' }}"
-      }
-      {%- endif %}
       ecs_compatibility => disabled
     }
   } else if [resource] == "worker" {
     opensearch {
-      {%- if MOZART_ES_PVT_IP.startswith('https://') -%}
-      hosts => ["{{ MOZART_ES_PVT_IP }}"]
-      {% else %}
-      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
-      {%- endif %}
+      hosts => ["{{ MOZART_PVT_IP }}:9200"]
       index => "worker_status-%{+YYYY.MM.dd}"
       document_id => "%{celery_hostname}"
-      {%- if MOZART_AWS_ES %}
-      auth_type => {
-        type => 'aws_iam'
-        region => "{{ AWS_REGION or 'us-west-2' }}"
-      }
-      {%- endif %}
       ecs_compatibility => disabled
     }
   } else if [resource] == "task" {
     opensearch {
-      {%- if MOZART_ES_PVT_IP.startswith('https://') -%}
-      hosts => ["{{ MOZART_ES_PVT_IP }}"]
-      {% else %}
-      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
-      {%- endif %}
+      hosts => ["{{ MOZART_PVT_IP }}:9200"]
       index => "%{index}"
       document_id => "%{uuid}"
-      {%- if MOZART_AWS_ES %}
-      auth_type => {
-        type => 'aws_iam'
-        region => "{{ AWS_REGION or 'us-west-2' }}"
-      }
-      {%- endif %}
       ecs_compatibility => disabled
     }
   } else if [resource] == "event" {
     opensearch {
-      {%- if MOZART_ES_PVT_IP.startswith('https://') -%}
-      hosts => ["{{ MOZART_ES_PVT_IP }}"]
-      {% else %}
-      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
-      {%- endif %}
+      hosts => ["{{ MOZART_PVT_IP }}:9200"]
       index => "event_status-%{+YYYY.MM.dd}"
       document_id => "%{uuid}"
-      {%- if MOZART_AWS_ES %}
-      auth_type => {
-        type => 'aws_iam'
-        region => "{{ AWS_REGION or 'us-west-2' }}"
-      }
-      {%- endif %}
       ecs_compatibility => disabled
     }
   } else {}

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -52,32 +52,36 @@ output {
   #stdout { codec => rubydebug }
 
   if [resource] == "job" {
-    elasticsearch {
+    opensearch {
       hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
       index => "%{[job][job_info][index]}"
       document_id => "%{payload_id}"
-      ilm_enabled => false
+      #ilm_enabled => false
+      ecs_compatibility => disabled
     }
   } else if [resource] == "worker" {
-    elasticsearch {
+    opensearch {
       hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
       index => "worker_status-%{+YYYY.MM.dd}"
       document_id => "%{celery_hostname}"
-      ilm_enabled => false
+      #ilm_enabled => false
+      ecs_compatibility => disabled
     }
   } else if [resource] == "task" {
-    elasticsearch {
+    opensearch {
       hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
       index => "%{index}"
       document_id => "%{uuid}"
-      ilm_enabled => false
+      #ilm_enabled => false
+      ecs_compatibility => disabled
     }
   } else if [resource] == "event" {
-    elasticsearch {
+    opensearch {
       hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
       index => "event_status-%{+YYYY.MM.dd}"
       document_id => "%{uuid}"
-      ilm_enabled => false
+      #ilm_enabled => false
+      ecs_compatibility => disabled
     }
   } else {}
 }

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -53,34 +53,94 @@ output {
 
   if [resource] == "job" {
     opensearch {
-      hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
+      {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
+      hosts => [
+        {%- for url in MOZART_ES_PVT_IP %}
+          {%- if url.startswith('https://') %}
+        "{{ url }}"{{ "," if not loop.last else "" }}
+          {%- else %}
+        "{{ 'https://'~url if MOZART_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}"{{ "," if not loop.last else "" }}
+          {%- endif %}
+        {%- endfor %}
+      ]
+      {%- else %}
+        {%- if MOZART_ES_PVT_IP.startswith('https://') %}
+      hosts => ["{{ MOZART_ES_PVT_IP }}"]
+        {%- else %}
+      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+        {%- endif %}
+      {%- endif %}
       index => "%{[job][job_info][index]}"
       document_id => "%{payload_id}"
-      #ilm_enabled => false
       ecs_compatibility => disabled
     }
   } else if [resource] == "worker" {
     opensearch {
-      hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
+      {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
+      hosts => [
+        {%- for url in MOZART_ES_PVT_IP %}
+          {%- if url.startswith('https://') %}
+        "{{ url }}"{{ "," if not loop.last else "" }}
+          {%- else %}
+        "{{ 'https://'~url if MOZART_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}"{{ "," if not loop.last else "" }}
+          {%- endif %}
+        {%- endfor %}
+      ]
+      {%- else %}
+        {%- if MOZART_ES_PVT_IP.startswith('https://') %}
+      hosts => ["{{ MOZART_ES_PVT_IP }}"]
+        {%- else %}
+      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+        {%- endif %}
+      {%- endif %}
       index => "worker_status-%{+YYYY.MM.dd}"
       document_id => "%{celery_hostname}"
-      #ilm_enabled => false
       ecs_compatibility => disabled
     }
   } else if [resource] == "task" {
     opensearch {
-      hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
+      {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
+      hosts => [
+        {%- for url in MOZART_ES_PVT_IP %}
+          {%- if url.startswith('https://') %}
+        "{{ url }}"{{ "," if not loop.last else "" }}
+          {%- else %}
+        "{{ 'https://'~url if MOZART_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}"{{ "," if not loop.last else "" }}
+          {%- endif %}
+        {%- endfor %}
+      ]
+      {%- else %}
+        {%- if MOZART_ES_PVT_IP.startswith('https://') %}
+      hosts => ["{{ MOZART_ES_PVT_IP }}"]
+        {%- else %}
+      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+        {%- endif %}
+      {%- endif %}
       index => "%{index}"
       document_id => "%{uuid}"
-      #ilm_enabled => false
       ecs_compatibility => disabled
     }
   } else if [resource] == "event" {
     opensearch {
-      hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
+      {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
+      hosts => [
+        {%- for url in MOZART_ES_PVT_IP %}
+          {%- if url.startswith('https://') %}
+        "{{ url }}"{{ "," if not loop.last else "" }}
+          {%- else %}
+        "{{ 'https://'~url if MOZART_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}"{{ "," if not loop.last else "" }}
+          {%- endif %}
+        {%- endfor %}
+      ]
+      {%- else %}
+        {%- if MOZART_ES_PVT_IP.startswith('https://') %}
+      hosts => ["{{ MOZART_ES_PVT_IP }}"]
+        {%- else %}
+      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+        {%- endif %}
+      {%- endif %}
       index => "event_status-%{+YYYY.MM.dd}"
       document_id => "%{uuid}"
-      #ilm_enabled => false
       ecs_compatibility => disabled
     }
   } else {}

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -56,24 +56,28 @@ output {
       hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
       index => "%{[job][job_info][index]}"
       document_id => "%{payload_id}"
+      ilm_enabled => false
     }
   } else if [resource] == "worker" {
     elasticsearch {
       hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
       index => "worker_status-%{+YYYY.MM.dd}"
       document_id => "%{celery_hostname}"
+      ilm_enabled => false
     }
   } else if [resource] == "task" {
     elasticsearch {
       hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
       index => "%{index}"
       document_id => "%{uuid}"
+      ilm_enabled => false
     }
   } else if [resource] == "event" {
     elasticsearch {
       hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
       index => "event_status-%{+YYYY.MM.dd}"
       document_id => "%{uuid}"
+      ilm_enabled => false
     }
   } else {}
 }

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -52,11 +52,11 @@ output {
   #stdout { codec => rubydebug }
 
   if [resource] == "job" {
-    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' or MOZART_AWS_ES == true else 'elasticsearch' }} {
+    opensearch {
       {%- if MOZART_ES_PVT_IP.startswith('https://') -%}
       hosts => ["{{ MOZART_ES_PVT_IP }}"]
       {% else %}
-      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if JOB_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
       {%- endif %}
       index => "%{[job][job_info][index]}"
       document_id => "%{payload_id}"
@@ -66,13 +66,14 @@ output {
         region => "{{ AWS_REGION or 'us-west-2' }}"
       }
       {%- endif %}
+      ecs_compatibility => disabled
     }
   } else if [resource] == "worker" {
-    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' or MOZART_AWS_ES == true else 'elasticsearch' }} {
+    opensearch {
       {%- if MOZART_ES_PVT_IP.startswith('https://') -%}
       hosts => ["{{ MOZART_ES_PVT_IP }}"]
       {% else %}
-      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if JOB_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
       {%- endif %}
       index => "worker_status-%{+YYYY.MM.dd}"
       document_id => "%{celery_hostname}"
@@ -82,13 +83,14 @@ output {
         region => "{{ AWS_REGION or 'us-west-2' }}"
       }
       {%- endif %}
+      ecs_compatibility => disabled
     }
   } else if [resource] == "task" {
-    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' or MOZART_AWS_ES == true else 'elasticsearch' }} {
+    opensearch {
       {%- if MOZART_ES_PVT_IP.startswith('https://') -%}
       hosts => ["{{ MOZART_ES_PVT_IP }}"]
       {% else %}
-      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if JOB_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
       {%- endif %}
       index => "%{index}"
       document_id => "%{uuid}"
@@ -98,13 +100,14 @@ output {
         region => "{{ AWS_REGION or 'us-west-2' }}"
       }
       {%- endif %}
+      ecs_compatibility => disabled
     }
   } else if [resource] == "event" {
-    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' or MOZART_AWS_ES == true else 'elasticsearch' }} {
+    opensearch {
       {%- if MOZART_ES_PVT_IP.startswith('https://') -%}
       hosts => ["{{ MOZART_ES_PVT_IP }}"]
       {% else %}
-      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if JOB_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
       {%- endif %}
       index => "event_status-%{+YYYY.MM.dd}"
       document_id => "%{uuid}"
@@ -114,6 +117,7 @@ output {
         region => "{{ AWS_REGION or 'us-west-2' }}"
       }
       {%- endif %}
+      ecs_compatibility => disabled
     }
   } else {}
 }

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -53,25 +53,25 @@ output {
 
   if [resource] == "job" {
     elasticsearch {
-      hosts => ["{{ MOZART_PVT_IP }}:9200"]
+      hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
       index => "%{[job][job_info][index]}"
       document_id => "%{payload_id}"
     }
   } else if [resource] == "worker" {
     elasticsearch {
-      hosts => ["{{ MOZART_PVT_IP }}:9200"]
+      hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
       index => "worker_status-%{+YYYY.MM.dd}"
       document_id => "%{celery_hostname}"
     }
   } else if [resource] == "task" {
     elasticsearch {
-      hosts => ["{{ MOZART_PVT_IP }}:9200"]
+      hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
       index => "%{index}"
       document_id => "%{uuid}"
     }
   } else if [resource] == "event" {
     elasticsearch {
-      hosts => ["{{ MOZART_PVT_IP }}:9200"]
+      hosts => ["http://{{ MOZART_PVT_IP }}:9200"]
       index => "event_status-%{+YYYY.MM.dd}"
       document_id => "%{uuid}"
     }

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -52,32 +52,28 @@ output {
   #stdout { codec => rubydebug }
 
   if [resource] == "job" {
-    opensearch {
+    elasticsearch {
       hosts => ["{{ MOZART_PVT_IP }}:9200"]
       index => "%{[job][job_info][index]}"
       document_id => "%{payload_id}"
-      ecs_compatibility => disabled
     }
   } else if [resource] == "worker" {
-    opensearch {
+    elasticsearch {
       hosts => ["{{ MOZART_PVT_IP }}:9200"]
       index => "worker_status-%{+YYYY.MM.dd}"
       document_id => "%{celery_hostname}"
-      ecs_compatibility => disabled
     }
   } else if [resource] == "task" {
-    opensearch {
+    elasticsearch {
       hosts => ["{{ MOZART_PVT_IP }}:9200"]
       index => "%{index}"
       document_id => "%{uuid}"
-      ecs_compatibility => disabled
     }
   } else if [resource] == "event" {
-    opensearch {
+    elasticsearch {
       hosts => ["{{ MOZART_PVT_IP }}:9200"]
       index => "event_status-%{+YYYY.MM.dd}"
       document_id => "%{uuid}"
-      ecs_compatibility => disabled
     }
   } else {}
 }

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -1,7 +1,9 @@
 input {
   redis {
     host => "{{ MOZART_REDIS_PVT_IP }}"
-    {% if MOZART_REDIS_PASSWORD != "" %}password => "{{ MOZART_REDIS_PASSWORD }}"{% endif %}
+    {%- if MOZART_REDIS_PASSWORD != "" %}
+    password => "{{ MOZART_REDIS_PASSWORD }}"
+    {%- endif %}
     # these settings should match the output of the agent
     data_type => "list"
     key => "logstash"
@@ -50,28 +52,68 @@ output {
   #stdout { codec => rubydebug }
 
   if [resource] == "job" {
-    elasticsearch {
-      hosts => ["{{ MOZART_ES_PVT_IP }}:9200"]
+    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' or MOZART_AWS_ES == true else 'elasticsearch' }} {
+      {%- if MOZART_ES_PVT_IP.startswith('https://') -%}
+      hosts => ["{{ MOZART_ES_PVT_IP }}"]
+      {% else %}
+      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if JOB_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+      {%- endif %}
       index => "%{[job][job_info][index]}"
       document_id => "%{payload_id}"
+      {%- if MOZART_AWS_ES %}
+      auth_type => {
+        type => 'aws_iam'
+        region => "{{ AWS_REGION or 'us-west-2' }}"
+      }
+      {%- endif %}
     }
   } else if [resource] == "worker" {
-    elasticsearch {
-      hosts => ["{{ MOZART_ES_PVT_IP }}:9200"]
+    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' or MOZART_AWS_ES == true else 'elasticsearch' }} {
+      {%- if MOZART_ES_PVT_IP.startswith('https://') -%}
+      hosts => ["{{ MOZART_ES_PVT_IP }}"]
+      {% else %}
+      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if JOB_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+      {%- endif %}
       index => "worker_status-%{+YYYY.MM.dd}"
       document_id => "%{celery_hostname}"
+      {%- if MOZART_AWS_ES %}
+      auth_type => {
+        type => 'aws_iam'
+        region => "{{ AWS_REGION or 'us-west-2' }}"
+      }
+      {%- endif %}
     }
   } else if [resource] == "task" {
-    elasticsearch {
-      hosts => ["{{ MOZART_ES_PVT_IP }}:9200"]
+    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' or MOZART_AWS_ES == true else 'elasticsearch' }} {
+      {%- if MOZART_ES_PVT_IP.startswith('https://') -%}
+      hosts => ["{{ MOZART_ES_PVT_IP }}"]
+      {% else %}
+      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if JOB_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+      {%- endif %}
       index => "%{index}"
       document_id => "%{uuid}"
+      {%- if MOZART_AWS_ES %}
+      auth_type => {
+        type => 'aws_iam'
+        region => "{{ AWS_REGION or 'us-west-2' }}"
+      }
+      {%- endif %}
     }
   } else if [resource] == "event" {
-    elasticsearch {
-      hosts => ["{{ MOZART_ES_PVT_IP }}:9200"]
+    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' or MOZART_AWS_ES == true else 'elasticsearch' }} {
+      {%- if MOZART_ES_PVT_IP.startswith('https://') -%}
+      hosts => ["{{ MOZART_ES_PVT_IP }}"]
+      {% else %}
+      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if JOB_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+      {%- endif %}
       index => "event_status-%{+YYYY.MM.dd}"
       document_id => "%{uuid}"
+      {%- if MOZART_AWS_ES %}
+      auth_type => {
+        type => 'aws_iam'
+        region => "{{ AWS_REGION or 'us-west-2' }}"
+      }
+      {%- endif %}
     }
   } else {}
 }

--- a/configs/supervisor/supervisord.conf.metrics
+++ b/configs/supervisor/supervisord.conf.metrics
@@ -35,6 +35,7 @@ stdout_logfile_maxbytes=100MB
 stdout_logfile_backups=10
 startsecs=10
 
+{%- if METRICS_ES_ENGINE != 'opensearch' %}
 [program:kibana]
 directory={{ OPS_HOME }}/kibana
 command={{ OPS_HOME }}/kibana/bin/kibana
@@ -47,6 +48,7 @@ stdout_logfile=%(here)s/../log/%(program_name)s.log
 stdout_logfile_maxbytes=100MB
 stdout_logfile_backups=10
 startsecs=10
+{% endif %}
 
 [program:logstash_indexer]
 directory={{ OPS_HOME }}/logstash/bin

--- a/configs/supervisor/supervisord.conf.metrics
+++ b/configs/supervisor/supervisord.conf.metrics
@@ -35,7 +35,6 @@ stdout_logfile_maxbytes=100MB
 stdout_logfile_backups=10
 startsecs=10
 
-{%- if METRICS_ES_ENGINE != 'opensearch' %}
 [program:kibana]
 directory={{ OPS_HOME }}/kibana
 command={{ OPS_HOME }}/kibana/bin/kibana
@@ -48,7 +47,6 @@ stdout_logfile=%(here)s/../log/%(program_name)s.log
 stdout_logfile_maxbytes=100MB
 stdout_logfile_backups=10
 startsecs=10
-{% endif %}
 
 [program:logstash_indexer]
 directory={{ OPS_HOME }}/logstash/bin

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.10"
+__version__ = "1.3.0"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/es_util.py
+++ b/hysds/es_util.py
@@ -52,7 +52,7 @@ def get_mozart_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    # sniff_on_start=True,
+                    sniff_on_start=True,
                 )
             else:
                 MOZART_ES = OpenSearchUtility(
@@ -60,7 +60,7 @@ def get_mozart_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    # sniff_on_start=True,
+                    sniff_on_start=True,
                 )
         else:
             if aws_es is True or "es.amazonaws.com" in es_url:
@@ -76,7 +76,7 @@ def get_mozart_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    # sniff_on_start=True,
+                    sniff_on_start=True,
                 )
             else:
                 MOZART_ES = ElasticsearchUtility(
@@ -84,7 +84,7 @@ def get_mozart_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    # sniff_on_start=True,
+                    sniff_on_start=True,
                 )
     return MOZART_ES
 
@@ -116,7 +116,7 @@ def get_grq_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    # sniff_on_start=True,
+                    sniff_on_start=True,
                 )
             else:
                 GRQ_ES = OpenSearchUtility(
@@ -124,7 +124,7 @@ def get_grq_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    # sniff_on_start=True,
+                    sniff_on_start=True,
                 )
         else:
             if aws_es is True or "es.amazonaws.com" in es_url:
@@ -140,7 +140,7 @@ def get_grq_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    # sniff_on_start=True,
+                    sniff_on_start=True,
                 )
             else:
                 GRQ_ES = ElasticsearchUtility(
@@ -148,7 +148,7 @@ def get_grq_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    # sniff_on_start=True,
+                    sniff_on_start=True,
                 )
     return GRQ_ES
 
@@ -180,7 +180,7 @@ def get_metrics_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    # sniff_on_start=True,
+                    sniff_on_start=True,
                 )
             else:
                 METRICS_ES = OpenSearchUtility(
@@ -188,7 +188,7 @@ def get_metrics_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    # sniff_on_start=True,
+                    sniff_on_start=True,
                 )
         else:
             if aws_es is True or "es.amazonaws.com" in es_url:
@@ -204,7 +204,7 @@ def get_metrics_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    # sniff_on_start=True,
+                    sniff_on_start=True,
                 )
             else:
                 METRICS_ES = ElasticsearchUtility(
@@ -212,6 +212,6 @@ def get_metrics_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    # sniff_on_start=True,
+                    sniff_on_start=True,
                 )
     return METRICS_ES

--- a/hysds/es_util.py
+++ b/hysds/es_util.py
@@ -24,15 +24,13 @@ except (ImportError, ModuleNotFoundError):
 MOZART_ES = None
 GRQ_ES = None
 
-REGEX_PATTERN = r"\.([a-z]+-[a-z].+-\d+)\."
 
-
-def get_mozart_es():
+def get_mozart_es(hosts=None):
     global MOZART_ES
     if MOZART_ES is None:
         jobs_es_engine = app.conf.get("JOBS_ES_ENGINE", "elasticsearch")
         aws_es = app.conf.get("JOBS_AWS_ES", False)
-        es_url = app.conf["JOBS_ES_URL"]
+        es_url = hosts or app.conf["JOBS_ES_URL"]
         region = app.conf.get("AWS_REGION", "us-west-2")
 
         if jobs_es_engine == "opensearch":
@@ -72,13 +70,13 @@ def get_mozart_es():
     return MOZART_ES
 
 
-def get_grq_es():
+def get_grq_es(hosts=None):
     global GRQ_ES
 
     if GRQ_ES is None:
         grq_es_engine = app.conf.get("GRQ_ES_ENGINE", "elasticsearch")
         aws_es = app.conf.get("GRQ_AWS_ES", False)
-        es_url = app.conf["GRQ_ES_URL"]
+        es_url = hosts or app.conf["GRQ_ES_URL"]
         region = app.conf.get("AWS_REGION", "us-west-2")
 
         if grq_es_engine == "opensearch":

--- a/hysds/es_util.py
+++ b/hysds/es_util.py
@@ -52,7 +52,7 @@ def get_mozart_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    sniff_on_start=True,
+                    # sniff_on_start=True,
                 )
             else:
                 MOZART_ES = OpenSearchUtility(
@@ -60,7 +60,7 @@ def get_mozart_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    sniff_on_start=True,
+                    # sniff_on_start=True,
                 )
         else:
             if aws_es is True or "es.amazonaws.com" in es_url:
@@ -76,7 +76,7 @@ def get_mozart_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    sniff_on_start=True,
+                    # sniff_on_start=True,
                 )
             else:
                 MOZART_ES = ElasticsearchUtility(
@@ -84,7 +84,7 @@ def get_mozart_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    sniff_on_start=True,
+                    # sniff_on_start=True,
                 )
     return MOZART_ES
 
@@ -116,7 +116,7 @@ def get_grq_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    sniff_on_start=True,
+                    # sniff_on_start=True,
                 )
             else:
                 GRQ_ES = OpenSearchUtility(
@@ -124,7 +124,7 @@ def get_grq_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    sniff_on_start=True,
+                    # sniff_on_start=True,
                 )
         else:
             if aws_es is True or "es.amazonaws.com" in es_url:
@@ -140,7 +140,7 @@ def get_grq_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    sniff_on_start=True,
+                    # sniff_on_start=True,
                 )
             else:
                 GRQ_ES = ElasticsearchUtility(
@@ -148,7 +148,7 @@ def get_grq_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    sniff_on_start=True,
+                    # sniff_on_start=True,
                 )
     return GRQ_ES
 
@@ -180,7 +180,7 @@ def get_metrics_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    sniff_on_start=True,
+                    # sniff_on_start=True,
                 )
             else:
                 METRICS_ES = OpenSearchUtility(
@@ -188,7 +188,7 @@ def get_metrics_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    sniff_on_start=True,
+                    # sniff_on_start=True,
                 )
         else:
             if aws_es is True or "es.amazonaws.com" in es_url:
@@ -204,7 +204,7 @@ def get_metrics_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    sniff_on_start=True,
+                    # sniff_on_start=True,
                 )
             else:
                 METRICS_ES = ElasticsearchUtility(
@@ -212,6 +212,6 @@ def get_metrics_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
-                    sniff_on_start=True,
+                    # sniff_on_start=True,
                 )
     return METRICS_ES

--- a/hysds/es_util.py
+++ b/hysds/es_util.py
@@ -3,8 +3,10 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
-from elasticsearch import RequestsHttpConnection
+import boto3
+from opensearchpy import AWSV4SignerAuth
+from elasticsearch import RequestsHttpConnection as RequestsHttpConnectionES
+from opensearchpy import RequestsHttpConnection as RequestsHttpConnectionOS
 
 from hysds.celery import app
 from hysds.log_utils import logger
@@ -14,6 +16,11 @@ try:
 except (ImportError, ModuleNotFoundError):
     logger.error("Cannot import hysds_commons.elasticsearch_utils")
 
+try:
+    from hysds_commons.opensearch_utils import OpenSearchUtility
+except (ImportError, ModuleNotFoundError):
+    logger.error("Cannot import hysds_commons.opensearch_utils")
+
 MOZART_ES = None
 GRQ_ES = None
 
@@ -21,7 +28,45 @@ GRQ_ES = None
 def get_mozart_es():
     global MOZART_ES
     if MOZART_ES is None:
-        MOZART_ES = ElasticsearchUtility(app.conf.JOBS_ES_URL, logger)
+        jobs_es_engine = app.conf.get("JOBS_ES_ENGINE", "elasticsearch")
+        aws_es = app.conf.get("JOBS_AWS_ES", False)
+        es_url = app.conf["JOBS_ES_URL"]
+        region = app.conf.get("AWS_REGION", "us-west-2")
+
+        if jobs_es_engine == "opensearch":
+            if aws_es is True:
+                credentials = boto3.Session().get_credentials()
+                auth = AWSV4SignerAuth(credentials, region)
+                MOZART_ES = OpenSearchUtility(
+                    es_url,
+                    http_auth=auth,
+                    connection_class=RequestsHttpConnectionOS,
+                    use_ssl=True,
+                    verify_certs=False,
+                    ssl_show_warn=False,
+                    timeout=30,
+                    max_retries=10,
+                    retry_on_timeout=True,
+                )
+            else:
+                MOZART_ES = OpenSearchUtility(es_url)
+        else:
+            if aws_es is True:
+                credentials = boto3.Session().get_credentials()
+                auth = AWSV4SignerAuth(credentials, region)
+                MOZART_ES = ElasticsearchUtility(
+                    es_url,
+                    http_auth=auth,
+                    connection_class=RequestsHttpConnectionES,
+                    use_ssl=True,
+                    verify_certs=False,
+                    ssl_show_warn=False,
+                    timeout=30,
+                    max_retries=10,
+                    retry_on_timeout=True,
+                )
+            else:
+                MOZART_ES = ElasticsearchUtility(es_url)
     return MOZART_ES
 
 
@@ -29,27 +74,43 @@ def get_grq_es():
     global GRQ_ES
 
     if GRQ_ES is None:
+        grq_es_engine = app.conf.get("GRQ_ES_ENGINE", "elasticsearch")
         aws_es = app.conf.get("GRQ_AWS_ES", False)
-        es_host = app.conf["GRQ_ES_HOST"]
         es_url = app.conf["GRQ_ES_URL"]
-        region = app.conf["AWS_REGION"]
+        region = app.conf.get("AWS_REGION", "us-west-2")
 
-        if aws_es is True:
-            aws_auth = BotoAWSRequestsAuth(
-                aws_host=es_host, aws_region=region, aws_service="es"
-            )
-            GRQ_ES = ElasticsearchUtility(
-                es_url=es_url,
-                logger=logger,
-                http_auth=aws_auth,
-                connection_class=RequestsHttpConnection,
-                use_ssl=True,
-                verify_certs=False,
-                ssl_show_warn=False,
-                timeout=30,
-                max_retries=10,
-                retry_on_timeout=True,
-            )
+        if grq_es_engine == "opensearch":
+            if aws_es is True:
+                credentials = boto3.Session().get_credentials()
+                auth = AWSV4SignerAuth(credentials, region)
+                GRQ_ES = OpenSearchUtility(
+                    es_url,
+                    http_auth=auth,
+                    connection_class=RequestsHttpConnectionOS,
+                    use_ssl=True,
+                    verify_certs=False,
+                    ssl_show_warn=False,
+                    timeout=30,
+                    max_retries=10,
+                    retry_on_timeout=True,
+                )
+            else:
+                GRQ_ES = OpenSearchUtility(es_url)
         else:
-            GRQ_ES = ElasticsearchUtility(es_url, logger)
+            if aws_es is True:
+                credentials = boto3.Session().get_credentials()
+                auth = AWSV4SignerAuth(credentials, region)
+                GRQ_ES = ElasticsearchUtility(
+                    es_url,
+                    http_auth=auth,
+                    connection_class=RequestsHttpConnectionES,
+                    use_ssl=True,
+                    verify_certs=False,
+                    ssl_show_warn=False,
+                    timeout=30,
+                    max_retries=10,
+                    retry_on_timeout=True,
+                )
+            else:
+                GRQ_ES = ElasticsearchUtility(es_url)
     return GRQ_ES

--- a/hysds/es_util.py
+++ b/hysds/es_util.py
@@ -48,9 +48,16 @@ def get_mozart_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
+                    # sniff_on_start=True,
                 )
             else:
-                MOZART_ES = OpenSearchUtility(es_url)
+                MOZART_ES = OpenSearchUtility(
+                    es_url,
+                    timeout=30,
+                    max_retries=10,
+                    retry_on_timeout=True,
+                    # sniff_on_start=True,
+                )
         else:
             if aws_es is True or "es.amazonaws.com" in es_url:
                 credentials = boto3.Session().get_credentials()
@@ -65,9 +72,16 @@ def get_mozart_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
+                    # sniff_on_start=True,
                 )
             else:
-                MOZART_ES = ElasticsearchUtility(es_url)
+                MOZART_ES = ElasticsearchUtility(
+                    es_url,
+                    timeout=30,
+                    max_retries=10,
+                    retry_on_timeout=True,
+                    # sniff_on_start=True,
+                )
     return MOZART_ES
 
 
@@ -94,13 +108,15 @@ def get_grq_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
+                    # sniff_on_start=True,
                 )
             else:
                 GRQ_ES = OpenSearchUtility(
                     es_url,
                     timeout=30,
                     max_retries=10,
-                    retry_on_timeout=True
+                    retry_on_timeout=True,
+                    # sniff_on_start=True,
                 )
         else:
             if aws_es is True or "es.amazonaws.com" in es_url:
@@ -116,13 +132,15 @@ def get_grq_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
+                    # sniff_on_start=True,
                 )
             else:
                 GRQ_ES = ElasticsearchUtility(
                     es_url,
                     timeout=30,
                     max_retries=10,
-                    retry_on_timeout=True
+                    retry_on_timeout=True,
+                    # sniff_on_start=True,
                 )
     return GRQ_ES
 
@@ -150,13 +168,15 @@ def get_metrics_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
+                    # sniff_on_start=True,
                 )
             else:
                 METRICS_ES = OpenSearchUtility(
                     es_url,
                     timeout=30,
                     max_retries=10,
-                    retry_on_timeout=True
+                    retry_on_timeout=True,
+                    # sniff_on_start=True,
                 )
         else:
             if aws_es is True or "es.amazonaws.com" in es_url:
@@ -172,12 +192,14 @@ def get_metrics_es(hosts=None):
                     timeout=30,
                     max_retries=10,
                     retry_on_timeout=True,
+                    # sniff_on_start=True,
                 )
             else:
                 METRICS_ES = ElasticsearchUtility(
                     es_url,
                     timeout=30,
                     max_retries=10,
-                    retry_on_timeout=True
+                    retry_on_timeout=True,
+                    # sniff_on_start=True,
                 )
     return METRICS_ES

--- a/hysds/es_util.py
+++ b/hysds/es_util.py
@@ -102,7 +102,12 @@ def get_grq_es():
                     retry_on_timeout=True,
                 )
             else:
-                GRQ_ES = OpenSearchUtility(es_url)
+                GRQ_ES = OpenSearchUtility(
+                    es_url,
+                    timeout=30,
+                    max_retries=10,
+                    retry_on_timeout=True
+                )
         else:
             if aws_es is True or "es.amazonaws.com" in es_url:
                 credentials = boto3.Session().get_credentials()
@@ -119,5 +124,10 @@ def get_grq_es():
                     retry_on_timeout=True,
                 )
             else:
-                GRQ_ES = ElasticsearchUtility(es_url)
+                GRQ_ES = ElasticsearchUtility(
+                    es_url,
+                    timeout=30,
+                    max_retries=10,
+                    retry_on_timeout=True
+                )
     return GRQ_ES

--- a/hysds/es_util.py
+++ b/hysds/es_util.py
@@ -26,10 +26,14 @@ GRQ_ES = None
 METRICS_ES = None
 
 
+def get_mozart_es_engine():
+    return app.conf.get("JOBS_ES_ENGINE", "elasticsearch")
+
+
 def get_mozart_es(hosts=None):
     global MOZART_ES
     if MOZART_ES is None:
-        jobs_es_engine = app.conf.get("JOBS_ES_ENGINE", "elasticsearch")
+        jobs_es_engine = get_mozart_es_engine()
         aws_es = app.conf.get("JOBS_AWS_ES", False)
         es_url = hosts or app.conf["JOBS_ES_URL"]
         region = app.conf.get("AWS_REGION", "us-west-2")
@@ -85,11 +89,15 @@ def get_mozart_es(hosts=None):
     return MOZART_ES
 
 
+def get_grq_es_engine():
+    return app.conf.get("GRQ_ES_ENGINE", "elasticsearch")
+
+
 def get_grq_es(hosts=None):
     global GRQ_ES
 
     if GRQ_ES is None:
-        grq_es_engine = app.conf.get("GRQ_ES_ENGINE", "elasticsearch")
+        grq_es_engine = get_grq_es_engine()
         aws_es = app.conf.get("GRQ_AWS_ES", False)
         es_url = hosts or app.conf["GRQ_ES_URL"]
         region = app.conf.get("AWS_REGION", "us-west-2")
@@ -145,11 +153,15 @@ def get_grq_es(hosts=None):
     return GRQ_ES
 
 
+def get_metrics_es_engine():
+    return app.conf.get("METRICS_ES_ENGINE", "elasticsearch")
+
+
 def get_metrics_es(hosts=None):
     global METRICS_ES
 
     if METRICS_ES is None:
-        grq_es_engine = app.conf.get("METRICS_ES_ENGINE", "elasticsearch")
+        grq_es_engine = get_metrics_es_engine()
         aws_es = app.conf.get("METRICS_AWS_ES", False)
         es_url = hosts or app.conf["METRICS_ES_URL"]
         region = app.conf.get("AWS_REGION", "us-west-2")

--- a/hysds/es_util.py
+++ b/hysds/es_util.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-import re
 import boto3
 from opensearchpy import AWSV4SignerAuth
 from elasticsearch import RequestsHttpConnection as RequestsHttpConnectionES
@@ -34,9 +33,7 @@ def get_mozart_es():
         jobs_es_engine = app.conf.get("JOBS_ES_ENGINE", "elasticsearch")
         aws_es = app.conf.get("JOBS_AWS_ES", False)
         es_url = app.conf["JOBS_ES_URL"]
-
-        m = re.search(REGEX_PATTERN, es_url)
-        region = m.group(1) if m else app.conf.get("AWS_REGION", "us-west-2")
+        region = app.conf.get("AWS_REGION", "us-west-2")
 
         if jobs_es_engine == "opensearch":
             if aws_es is True or "es.amazonaws.com" in es_url:
@@ -82,9 +79,7 @@ def get_grq_es():
         grq_es_engine = app.conf.get("GRQ_ES_ENGINE", "elasticsearch")
         aws_es = app.conf.get("GRQ_AWS_ES", False)
         es_url = app.conf["GRQ_ES_URL"]
-
-        m = re.search(REGEX_PATTERN, es_url)
-        region = m.group(1) if m else app.conf.get("AWS_REGION", "us-west-2")
+        region = app.conf.get("AWS_REGION", "us-west-2")
 
         if grq_es_engine == "opensearch":
             if aws_es is True or "es.amazonaws.com" in es_url:

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -28,7 +28,7 @@ from subprocess import check_output, CalledProcessError
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.signals import task_revoked
 
-import hysds  # TODO: may fix some cyclical import issues, will need to test more
+import hysds  # fixes some cyclical import issues
 from hysds.celery import app
 from hysds.log_utils import (
     logger,

--- a/hysds/user_rules_dataset.py
+++ b/hysds/user_rules_dataset.py
@@ -28,9 +28,6 @@ JOBS_PROCESSED_QUEUE = app.conf.JOBS_PROCESSED_QUEUE  # queue names
 USER_RULES_TRIGGER_QUEUE = app.conf.USER_RULES_TRIGGER_QUEUE
 USER_RULES_DATASET_QUEUE = app.conf.USER_RULES_DATASET_QUEUE
 
-mozart_es = get_mozart_es()
-grq_es = get_grq_es()
-
 
 @backoff.on_exception(
     backoff.expo, Exception, max_tries=backoff_max_tries, max_value=backoff_max_value
@@ -50,6 +47,7 @@ def ensure_dataset_indexed(objectid, system_version, alias):
 
     logger.info("ensure_dataset_indexed query: %s" % json.dumps(query))
     try:
+        grq_es = get_grq_es()
         count = grq_es.get_count(index=alias, body=query)
         if count == 0:
             error_message = "Failed to find indexed dataset: %s (%s)" % (
@@ -92,6 +90,7 @@ def update_query(_id, system_version, rule):
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=5, max_value=32)
 def search_es(index, body):
+    grq_es = get_grq_es()
     return grq_es.es.search(index=index, body=body, request_timeout=30)
 
 
@@ -114,6 +113,7 @@ def evaluate_user_rules_dataset(
             }
         }
     }
+    mozart_es = get_mozart_es()
     rules = mozart_es.query(index=USER_RULES_DATASET_INDEX, body=query)
     logger.info("Total %d enabled rules to check." % len(rules))
 

--- a/hysds/user_rules_dataset.py
+++ b/hysds/user_rules_dataset.py
@@ -14,8 +14,7 @@ import socket
 import elasticsearch.exceptions
 import opensearchpy.exceptions
 
-# import hysds
-import hysds.task_worker
+import hysds  # avoids cyclical import
 from hysds.celery import app
 from hysds.utils import validate_index_pattern
 from hysds.log_utils import logger, backoff_max_tries, backoff_max_value
@@ -173,7 +172,7 @@ def queue_dataset_evaluation(info):
         "function": "hysds.user_rules_dataset.evaluate_user_rules_dataset",
         "args": [info["id"], info["system_version"]],
     }
-    hysds.task_worker.run_task.apply_async((payload,), queue=app.conf.USER_RULES_DATASET_QUEUE)
+    hysds.task_worker.run_task.apply_async((payload,), queue=app.conf.USER_RULES_DATASET_QUEUE)  # noqa
 
 
 @backoff.on_exception(
@@ -187,4 +186,4 @@ def queue_dataset_trigger(doc_res, rule, job_name):
         "args": [doc_res, rule],
         "kwargs": {"job_name": job_name, "component": "grq"},
     }
-    hysds.task_worker.run_task.apply_async((payload,), queue=USER_RULES_TRIGGER_QUEUE)
+    hysds.task_worker.run_task.apply_async((payload,), queue=USER_RULES_TRIGGER_QUEUE)  # noqa

--- a/hysds/user_rules_dataset.py
+++ b/hysds/user_rules_dataset.py
@@ -47,16 +47,21 @@ def ensure_dataset_indexed(objectid, system_version, alias):
             }
         }
     }
+
     logger.info("ensure_dataset_indexed query: %s" % json.dumps(query))
-    count = grq_es.get_count(index=alias, body=query)
-    if count == 0:
-        error_message = "Failed to find indexed dataset: %s (%s)" % (
-            objectid,
-            system_version,
-        )
-        logger.error(error_message)
-        raise RuntimeError(error_message)
-    logger.info("Found indexed dataset: %s (%s)" % (objectid, system_version))
+    try:
+        count = grq_es.get_count(index=alias, body=query)
+        if count == 0:
+            error_message = "Failed to find indexed dataset: %s (%s)" % (
+                objectid,
+                system_version,
+            )
+            logger.error(error_message)
+            raise RuntimeError(error_message)
+        logger.info("Found indexed dataset: %s (%s)" % (objectid, system_version))
+    except (elasticsearch.exceptions.ElasticsearchException, opensearchpy.exceptions.OpenSearchException) as e:
+        logger.error(e)
+        raise e
 
 
 def update_query(_id, system_version, rule):

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -14,7 +14,7 @@ import socket
 import elasticsearch.exceptions
 import opensearchpy.exceptions
 
-import hysds
+import hysds  # avoids cyclical import
 from hysds.celery import app
 from hysds.log_utils import logger, backoff_max_tries, backoff_max_value
 from hysds.es_util import get_mozart_es
@@ -155,7 +155,7 @@ def queue_finished_job(_id, index=None):
         "args": [_id],
         "kwargs": {"index": index},
     }
-    hysds.task_worker.run_task.apply_async((payload,), queue=USER_RULES_JOB_QUEUE)
+    hysds.task_worker.run_task.apply_async((payload,), queue=USER_RULES_JOB_QUEUE)  # noqa
 
 
 @backoff.on_exception(
@@ -169,4 +169,4 @@ def queue_job_trigger(doc_res, rule):
         "args": [doc_res, rule],
         "kwargs": {"component": "mozart"},
     }
-    hysds.task_worker.run_task.apply_async((payload,), queue=USER_RULES_TRIGGER_QUEUE)
+    hysds.task_worker.run_task.apply_async((payload,), queue=USER_RULES_TRIGGER_QUEUE)  # noqa

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -40,9 +40,6 @@ from hysds.es_util import get_grq_es, get_mozart_es
 
 import osaka.main
 
-grq_es = get_grq_es()
-mozart_es = get_mozart_es()
-
 # disk usage setting converter
 DU_CALC = {"GB": 1024 ** 3, "MB": 1024 ** 2, "KB": 1024}
 
@@ -282,7 +279,7 @@ def getXmlEtree(xml):
 
     parser = XMLParser(remove_blank_text=True)
     if xml.startswith("<?xml") or xml.startswith("<"):
-        return (parse(StringIO(xml), parser).getroot(), getNamespacePrefixDict(xml))
+        return parse(StringIO(xml), parser).getroot(), getNamespacePrefixDict(xml)
     else:
         if os.path.isfile(xml):
             xmlStr = open(xml).read()
@@ -413,6 +410,7 @@ def query_dedup_job(dedup_key, filter_id=None, states=None, is_worker=False):
         query["query"]["bool"]["must_not"] = {"term": {"uuid": filter_id}}
 
     logger.info("constructed query: %s" % json.dumps(query, indent=2))
+    mozart_es = get_mozart_es()
     j = mozart_es.search(index="job_status-current", body=query, ignore=404)
     logger.info(j)
     # Check for 404 status first and return None immediately as we had been before
@@ -457,7 +455,7 @@ def get_job_status(_id):
             }
         }
     }
-
+    mozart_es = get_mozart_es()
     res = mozart_es.search(index="job_status-current", body=query, _source_includes=["status"])
     if res["hits"]["total"]["value"] == 0:
         logger.warning("job not found, _id: %s" % _id)
@@ -483,6 +481,7 @@ def check_dataset(_id, es_index="grq"):
             }
         }
     }
+    grq_es = get_grq_es()
     count = grq_es.get_count(index=es_index, body=query)
     return count
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ blinker==1.4
 boto==2.49.0
 boto3==1.11.1
 botocore==1.14.1
-aws-requests-auth==0.4.2
+opensearch-py==2.3.0
 cachetools==4.0.0
 celery>=5.2.2,<6.0.0,!=5.2.3
 Click

--- a/scripts/clean_es_cluster.py
+++ b/scripts/clean_es_cluster.py
@@ -16,6 +16,7 @@ if __name__ == "__main__":
                 k.startswith("user_rules-") or \
                 k == "job_specs" or \
                 k == "containers":
+            print(f"deleted {k} index")
             mozart_es.es.indices.delete(index=k)
 
     mozart_es.es.indices.delete_index_template(name="job_status", ignore=404)
@@ -60,6 +61,7 @@ if __name__ == "__main__":
     aliases = grq_es.es.indices.get_alias()
     for k, _ in aliases.items():
         if k.startswith("grq_"):
+            print(f"deleted {k} index")
             grq_es.es.indices.delete(index=k)
 
     grq_es.es.indices.delete_template(name="grq", ignore=404)

--- a/scripts/clean_es_cluster.py
+++ b/scripts/clean_es_cluster.py
@@ -1,0 +1,66 @@
+from hysds.es_util import get_mozart_es, get_grq_es
+
+
+if __name__ == "__main__":
+    mozart_es = get_mozart_es()
+    grq_es = get_grq_es()
+
+    # MOZART
+    aliases = mozart_es.es.indices.get_alias()
+    for k, _ in aliases.items():
+        if k.startswith("job_status-") or \
+                k.startswith("worker_status-") or \
+                k.startswith("event_status-") or \
+                k.startswith("task_status-") or \
+                k.startswith("hysds_ios-") or \
+                k.startswith("user_rules-") or \
+                k == "job_specs" or \
+                k == "containers":
+            mozart_es.es.indices.delete(index=k)
+
+    mozart_es.es.indices.delete_index_template(name="job_status", ignore=404)
+    print("deleted job_status template")
+    mozart_es.es.indices.delete_index_template(name="task_status", ignore=404)
+    print("deleted task_status template")
+    mozart_es.es.indices.delete_index_template(name="worker_status", ignore=404)
+    print("deleted worker_status template")
+    mozart_es.es.indices.delete_index_template(name="event_status", ignore=404)
+    print("deleted event_status template")
+
+    mozart_es.es.indices.delete_template(name="containers", ignore=404)
+    print("deleted containers template")
+    mozart_es.es.indices.delete_template(name="job_specs", ignore=404)
+    print("deleted job_specs template")
+    mozart_es.es.indices.delete_template(name="hysds_ios", ignore=404)
+    print("deleted hysds_ios template")
+
+    mozart_es.es.indices.delete_template(name="logstash", ignore=404)
+    mozart_es.es.indices.delete_template(name="ecs-logstash", ignore=404)
+    print("deleted logstash template")
+
+    info = mozart_es.es.info()
+    version_info = info["version"]
+    build_flavor = version_info.get("build_flavor", None)
+    distribution = version_info.get("distribution", "elasticsearch")
+
+    policy_name = "ilm_policy_mozart"
+    if build_flavor == "oss" and distribution != "opensearch":
+        # Elasticsearch OSS
+        mozart_es.es.transport.perform_request("DELETE", f"/_opendistro/_ism/policies/{policy_name}", params={"ignore": 404})
+    elif distribution == "opensearch":
+        if hasattr(mozart_es.es, "index_management"):
+            mozart_es.es.plugins.index_management.delete_policy(policy_name, ignore=404)
+        else:
+            mozart_es.es.transport.perform_request("DELETE", f"/_plugins/_ism/policies/{policy_name}", params={"ignore": 404})
+    else:  # regular Elasticsearch
+        mozart_es.es.ilm.delete_lifecycle(policy=policy_name, ignore=404)
+    print("deleted ILM/ISM policy")
+
+    # GRQ
+    aliases = grq_es.es.indices.get_alias()
+    for k, _ in aliases.items():
+        if k.startswith("grq_"):
+            grq_es.es.indices.delete(index=k)
+
+    grq_es.es.indices.delete_template(name="grq", ignore=404)
+    print("deleted grq template")

--- a/scripts/clean_indices_from_alias.py
+++ b/scripts/clean_indices_from_alias.py
@@ -24,7 +24,9 @@ def delete_job_status(alias):
     mozart_es = get_mozart_es()
 
     res = mozart_es.es.indices.get_alias(name=alias, ignore=404)
-    if res["status"] != 404:
+    if res.get("status") == 404:
+        logging.info(f"404 Client Error: Not Found for querying for alias={alias}")
+    else:
         logging.info(f"Found indices associated with alias {alias}:\n{json.dumps(res, indent=2)}")
         for index in res.keys():
             logging.info(f"Deleting from Mozart ES: {index}")

--- a/scripts/install_ilm_policy.py
+++ b/scripts/install_ilm_policy.py
@@ -1,0 +1,55 @@
+import argparse
+import json
+import warnings
+
+from hysds.es_util import get_mozart_es
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--policy-name", type=str, default="ilm_policy_mozart", help="ISM/ILM policy name")
+    parser.add_argument("--ilm-policy", type=str, help="location of the ILM policy file")
+    parser.add_argument("--ism-policy", type=str, help="location of the ISM policy file")
+
+    args = parser.parse_args()
+    policy_name = args.policy_name
+    _ilm_policy_file = args.ilm_policy
+    _ism_policy_file = args.ism_policy
+
+    if not _ism_policy_file and not _ilm_policy_file:
+        raise RuntimeError("--ilm-policy or --ism-policy must be provided")
+
+    mozart_es = get_mozart_es()
+    info = mozart_es.es.info()
+
+    version_info = info["version"]
+    build_flavor = version_info.get("build_flavor", None)
+    distribution = version_info.get("distribution", "elasticsearch")
+
+    if build_flavor == "oss" and distribution != "opensearch":
+        # Elasticsearch OSS
+        with open(_ism_policy_file) as f:
+            ism_template = json.load(f)
+            exists = mozart_es.es.transport.perform_request("GET", f"/_opendistro/_ism/policies/{policy_name}",
+                                                            body=ism_template, ignore=[404])
+            if exists.get("status") == 404:
+                warnings.simplefilter('always', UserWarning)
+                warnings.warn(f"{policy_name} already exists, skipping...")
+            else:
+                res = mozart_es.es.transport.perform_request("PUT", f"/_opendistro/_ism/policies/{policy_name}",
+                                                             body=ism_template, ignore=[400])
+    elif distribution == "opensearch":
+        with open(_ism_policy_file) as f:
+            ism_template = json.load(f)
+            if hasattr(mozart_es.es, "index_management"):
+                res = mozart_es.es.plugins.index_management.put_policy(policy_name, body=ism_template)
+            else:
+                res = mozart_es.es.transport.perform_request("PUT", f"/_plugins/_ism/policies/{policy_name}",
+                                                             body=ism_template, ignore=[400])
+    else:
+        # regular Elasticsearch
+        with open(_ilm_policy_file) as f:
+            ilm_template = json.load(f)
+            res = mozart_es.es.ilm.put_lifecycle(policy=policy_name, body=ilm_template, ignore=[400])
+
+    print(json.dumps(res, indent=2))

--- a/scripts/install_job_status_template.py
+++ b/scripts/install_job_status_template.py
@@ -28,9 +28,9 @@ def install_mozart_template(name, template_file):
 
         # elasticsearch-oss
         if build_flavor == "oss" and distribution != "opensearch":
-            if version_number <= MIN_ES_OSS_ISM_VERSION:
+            if version_number < MIN_ES_OSS_ISM_VERSION:
                 warnings.warn("ISM in Open Distro < 1.13.0 requires the policy to added to the template")
-                template["template"]["settings"]["opendistro.index_state_management.policy_id": "policy_id"] = POLICY_NAME
+                template["template"]["settings"]["opendistro.index_state_management.policy_id"] = POLICY_NAME
         elif distribution == "opensearch":
             # the policy should populate the ISM if the index patterns match
             warnings.warn("Opensearch 1.13+ ISM does not require the policy to added to the template")
@@ -39,10 +39,9 @@ def install_mozart_template(name, template_file):
                 "name": "ilm_policy_mozart"
             }
             template["template"]["settings"]["index"]["lifecycle"] = ilm_lifecycle
-        print(json.dumps(template, indent=2))
 
-        res = mozart_es.es.indices.put_index_template(name=name, body=template, ignore=[400])
-        print(json.dumps(res, indent=2))
+        res = mozart_es.es.indices.put_index_template(name=name, body=template)
+        print(json.dumps(res))
 
 
 if __name__ == "__main__":

--- a/scripts/install_job_status_template.py
+++ b/scripts/install_job_status_template.py
@@ -1,0 +1,52 @@
+import sys
+import json
+import warnings
+from packaging import version
+
+from hysds.es_util import get_mozart_es
+
+
+MIN_ES_OSS_ISM_VERSION = version.parse("7.10.2")
+POLICY_NAME = "ilm_policy_mozart"
+
+warnings.simplefilter('always', UserWarning)
+
+
+# https://opendistro.github.io/for-elasticsearch-docs/version-history/
+# https://opendistro.github.io/for-elasticsearch-docs/docs/im/ism/#step-1-set-up-policies
+def install_mozart_template(name, template_file):
+    mozart_es = get_mozart_es()
+    info = mozart_es.es.info()
+
+    version_info = info["version"]
+    version_number = version.parse(version_info["number"])
+    build_flavor = version_info.get("build_flavor", None)
+    distribution = version_info.get("distribution", "elasticsearch")
+
+    with open(template_file) as f:
+        template = json.load(f)
+
+        # elasticsearch-oss
+        if build_flavor == "oss" and distribution != "opensearch":
+            if version_number <= MIN_ES_OSS_ISM_VERSION:
+                warnings.warn("ISM in Open Distro < 1.13.0 requires the policy to added to the template")
+                template["template"]["settings"]["opendistro.index_state_management.policy_id": "policy_id"] = POLICY_NAME
+        elif distribution == "opensearch":
+            # the policy should populate the ISM if the index patterns match
+            warnings.warn("Opensearch 1.13+ ISM does not require the policy to added to the template")
+        else:
+            ilm_lifecycle = {
+                "name": "ilm_policy_mozart"
+            }
+            template["template"]["settings"]["index"]["lifecycle"] = ilm_lifecycle
+        print(json.dumps(template, indent=2))
+
+        res = mozart_es.es.indices.put_index_template(name=name, body=template, ignore=[400])
+        print(json.dumps(res, indent=2))
+
+
+if __name__ == "__main__":
+    _name = sys.argv[1]
+    _template_file = sys.argv[2]
+
+    install_mozart_template(_name, _template_file)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         "pytz",
         "pytest",
         "tabulate>=0.8.6",
-        "aws-requests-auth>=0.4.3,<1.0.0",
         "pyyaml"
     ],
     setup_requires=["pytest-runner"],

--- a/test/test_job_worker.py
+++ b/test/test_job_worker.py
@@ -6,7 +6,9 @@ try:
     import unittest.mock as umock
 except ImportError:
     import mock as umock
-import unittest
+# import unittest
+from unittest import TestCase
+from unittest.mock import patch
 import logging
 import tempfile
 import shutil
@@ -18,7 +20,7 @@ sys.modules["hysds.celery"] = umock.MagicMock()
 logging.basicConfig()
 
 
-class TestJobWorkerFuncs(unittest.TestCase):
+class TestJobWorkerFuncs(TestCase):
     def setUp(self):
         self.examples_dir = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "examples"
@@ -31,22 +33,23 @@ class TestJobWorkerFuncs(unittest.TestCase):
         shutil.rmtree(self.job_dir)
 
     def test_find_usage_stats(self):
-        import hysds.job_worker
+        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
+            import hysds.job_worker
 
-        # copy example _docker_stats.json
-        stats_file = os.path.join(self.examples_dir, "_docker_stats.json")
-        shutil.copy(stats_file, self.job_dir)
-        subdir = os.path.join(self.job_dir, "subdir1", "subdir2")
-        os.makedirs(subdir)
-        shutil.copy(stats_file, subdir)
+            # copy example _docker_stats.json
+            stats_file = os.path.join(self.examples_dir, "_docker_stats.json")
+            shutil.copy(stats_file, self.job_dir)
+            subdir = os.path.join(self.job_dir, "subdir1", "subdir2")
+            os.makedirs(subdir)
+            shutil.copy(stats_file, subdir)
 
-        # expected results
-        expected_stats_file = os.path.join(self.job_dir, "_docker_stats.json")
-        expected_stats_file2 = os.path.join(subdir, "_docker_stats.json")
+            # expected results
+            expected_stats_file = os.path.join(self.job_dir, "_docker_stats.json")
+            expected_stats_file2 = os.path.join(subdir, "_docker_stats.json")
 
-        # test execution
-        result = hysds.job_worker.find_usage_stats(self.job_dir)
+            # test execution
+            result = hysds.job_worker.find_usage_stats(self.job_dir)
 
-        # assertions
-        self.assertTrue(expected_stats_file in result)
-        self.assertTrue(expected_stats_file2 in result)
+            # assertions
+            self.assertTrue(expected_stats_file in result)
+            self.assertTrue(expected_stats_file2 in result)

--- a/test/test_job_worker.py
+++ b/test/test_job_worker.py
@@ -1,18 +1,15 @@
 import os
 import sys
-import json
 
 try:
     import unittest.mock as umock
 except ImportError:
     import mock as umock
-# import unittest
 from unittest import TestCase
 from unittest.mock import patch
 import logging
 import tempfile
 import shutil
-import glob
 
 # hysds.celery searches for configuration on import. So we need to make sure we
 # mock it out before the first time it is imported

--- a/test/test_job_worker.py
+++ b/test/test_job_worker.py
@@ -30,23 +30,22 @@ class TestJobWorkerFuncs(TestCase):
         shutil.rmtree(self.job_dir)
 
     def test_find_usage_stats(self):
-        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
-            import hysds.job_worker
+        import hysds.job_worker
 
-            # copy example _docker_stats.json
-            stats_file = os.path.join(self.examples_dir, "_docker_stats.json")
-            shutil.copy(stats_file, self.job_dir)
-            subdir = os.path.join(self.job_dir, "subdir1", "subdir2")
-            os.makedirs(subdir)
-            shutil.copy(stats_file, subdir)
+        # copy example _docker_stats.json
+        stats_file = os.path.join(self.examples_dir, "_docker_stats.json")
+        shutil.copy(stats_file, self.job_dir)
+        subdir = os.path.join(self.job_dir, "subdir1", "subdir2")
+        os.makedirs(subdir)
+        shutil.copy(stats_file, subdir)
 
-            # expected results
-            expected_stats_file = os.path.join(self.job_dir, "_docker_stats.json")
-            expected_stats_file2 = os.path.join(subdir, "_docker_stats.json")
+        # expected results
+        expected_stats_file = os.path.join(self.job_dir, "_docker_stats.json")
+        expected_stats_file2 = os.path.join(subdir, "_docker_stats.json")
 
-            # test execution
-            result = hysds.job_worker.find_usage_stats(self.job_dir)
+        # test execution
+        result = hysds.job_worker.find_usage_stats(self.job_dir)
 
-            # assertions
-            self.assertTrue(expected_stats_file in result)
-            self.assertTrue(expected_stats_file2 in result)
+        # assertions
+        self.assertTrue(expected_stats_file in result)
+        self.assertTrue(expected_stats_file2 in result)

--- a/test/test_preprocessing_checksum.py
+++ b/test/test_preprocessing_checksum.py
@@ -5,21 +5,13 @@ import shutil
 import hashlib
 import copy
 import pytest
-from mock import patch
 try:
     import unittest.mock as umock
 except ImportError:
     import mock as umock
 
-# from hysds.utils import (
-#     hashlib_mapper,
-#     calculate_checksum_from_localized_file,
-#     read_checksum_file,
-#     generate_list_checksum_files,
-#     validate_checksum_files,
-# )
-
 sys.modules['opensearchpy'] = umock.Mock()
+sys.modules['opensearchpy.exceptions'] = umock.Mock()
 
 
 class TestPreProcessingChecksum:
@@ -82,24 +74,23 @@ class TestPreProcessingChecksum:
         shutil.rmtree(os.path.join("/tmp", self.test_directory))
 
     def test_hashlib_mapper(self):
-        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
-            from hysds.utils import hashlib_mapper
+        from hysds.utils import hashlib_mapper
 
-            with pytest.raises(Exception):
-                hashlib_mapper("non-existing-hashing-algorithm")
+        with pytest.raises(Exception):
+            hashlib_mapper("non-existing-hashing-algorithm")
 
-            assert hashlib_mapper("md5").name == hashlib.md5().name
-            assert hashlib_mapper("MD5").name == hashlib.md5().name
-            assert hashlib_mapper("sha1").name == hashlib.sha1().name
-            assert hashlib_mapper("SHA1").name == hashlib.sha1().name
-            assert hashlib_mapper("sha224").name == hashlib.sha224().name
-            assert hashlib_mapper("SHA224").name == hashlib.sha224().name
-            assert hashlib_mapper("sha256").name == hashlib.sha256().name
-            assert hashlib_mapper("SHA256").name == hashlib.sha256().name
-            assert hashlib_mapper("sha384").name == hashlib.sha384().name
-            assert hashlib_mapper("SHA384").name == hashlib.sha384().name
-            assert hashlib_mapper("sha512").name == hashlib.sha512().name
-            assert hashlib_mapper("SHA512").name == hashlib.sha512().name
+        assert hashlib_mapper("md5").name == hashlib.md5().name
+        assert hashlib_mapper("MD5").name == hashlib.md5().name
+        assert hashlib_mapper("sha1").name == hashlib.sha1().name
+        assert hashlib_mapper("SHA1").name == hashlib.sha1().name
+        assert hashlib_mapper("sha224").name == hashlib.sha224().name
+        assert hashlib_mapper("SHA224").name == hashlib.sha224().name
+        assert hashlib_mapper("sha256").name == hashlib.sha256().name
+        assert hashlib_mapper("SHA256").name == hashlib.sha256().name
+        assert hashlib_mapper("sha384").name == hashlib.sha384().name
+        assert hashlib_mapper("SHA384").name == hashlib.sha384().name
+        assert hashlib_mapper("sha512").name == hashlib.sha512().name
+        assert hashlib_mapper("SHA512").name == hashlib.sha512().name
 
         # hashlib supports more hashing algorithms in python 3:
         #   sha3_224 sha3_256, sha3_384, blake2b, blake2s, sha3_512, shake_256, shake_128
@@ -122,125 +113,121 @@ class TestPreProcessingChecksum:
             assert hashlib_mapper("SHAKE_128").name == hashlib.shake_128().name
 
     def test_calculate_checksum_from_localized_file(self):
-        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
-            from hysds.utils import calculate_checksum_from_localized_file
+        from hysds.utils import calculate_checksum_from_localized_file
 
-            test_file_name = "/tmp/test_calculate_checksum_from_localized_file.zip"
-            test_string = "testing testing 123"
+        test_file_name = "/tmp/test_calculate_checksum_from_localized_file.zip"
+        test_string = "testing testing 123"
 
-            with open(
-                test_file_name, "w"
-            ) as f:  # creating a test file with random stuff to md5 hash
-                f.write(test_string)
+        with open(
+            test_file_name, "w"
+        ) as f:  # creating a test file with random stuff to md5 hash
+            f.write(test_string)
 
-            assert (
-                calculate_checksum_from_localized_file(test_file_name, "md5")
-                == "5c9bee4c87b80170f57f1ef696fa1992"
-            )
-            assert (
-                calculate_checksum_from_localized_file(test_file_name, "sha1")
-                == "89512ac8c5fa4e72773049beea2549c2dc3e8dd3"
-            )
-            assert (
-                calculate_checksum_from_localized_file(test_file_name, "sha224")
-                == "1c8c0df757fb6915b89d468bb07d0df183722217a96b837cc1bdd485"
-            )
-            assert (
-                calculate_checksum_from_localized_file(test_file_name, "sha256")
-                == "7b6f7e8c7911a867c82e5be63ffcb330b3c8fff7528a58b83f74a1304fd05566"
-            )
-            assert (
-                calculate_checksum_from_localized_file(test_file_name, "sha384")
-                == "4b9d911363d3e5f1bcebe5490e813ace3de464c90e6f914473d146ce165a17f9515117ce5e2df0d0fef994a234a5364c"
-            )
-            assert (
-                calculate_checksum_from_localized_file(test_file_name, "sha512")
-                == "efc75d56682a615a61de8626075fbaa799fe57e991644fc1b4e6e9d0004b7239f32467aa20c7189f8e4827e189f30f755977fc6fa3464133fbd213d571d77e97"
-            )
+        assert (
+            calculate_checksum_from_localized_file(test_file_name, "md5")
+            == "5c9bee4c87b80170f57f1ef696fa1992"
+        )
+        assert (
+            calculate_checksum_from_localized_file(test_file_name, "sha1")
+            == "89512ac8c5fa4e72773049beea2549c2dc3e8dd3"
+        )
+        assert (
+            calculate_checksum_from_localized_file(test_file_name, "sha224")
+            == "1c8c0df757fb6915b89d468bb07d0df183722217a96b837cc1bdd485"
+        )
+        assert (
+            calculate_checksum_from_localized_file(test_file_name, "sha256")
+            == "7b6f7e8c7911a867c82e5be63ffcb330b3c8fff7528a58b83f74a1304fd05566"
+        )
+        assert (
+            calculate_checksum_from_localized_file(test_file_name, "sha384")
+            == "4b9d911363d3e5f1bcebe5490e813ace3de464c90e6f914473d146ce165a17f9515117ce5e2df0d0fef994a234a5364c"
+        )
+        assert (
+            calculate_checksum_from_localized_file(test_file_name, "sha512")
+            == "efc75d56682a615a61de8626075fbaa799fe57e991644fc1b4e6e9d0004b7239f32467aa20c7189f8e4827e189f30f755977fc6fa3464133fbd213d571d77e97"
+        )
 
-            if sys.version_info[:2] >= (3, 0):
-                assert (
-                    calculate_checksum_from_localized_file(test_file_name, "sha3_224")
-                    == "8374697d745e2a5155d04b28fb39910c923920ff7cc15219329c7f76"
-                )
-                assert (
-                    calculate_checksum_from_localized_file(test_file_name, "sha3_256")
-                    == "8317ca633d3f8a98cc2de2f9fb5b675d5afa8542031dc9040352d3668423bb56"
-                )
-                assert (
-                    calculate_checksum_from_localized_file(test_file_name, "sha3_384")
-                    == "875b7bc1dcd7c26c66b58ee91aa37b83a3f086d709054d496eba9a75cd1d8f8c0b4f44ef8c7fd41f1ba0a87d5c4fcb92"
-                )
-                assert (
-                    calculate_checksum_from_localized_file(test_file_name, "sha3_512")
-                    == "5bb79282e3c8aabd5aa56c474bc16f43417961f2934c00c4062d2832848a19fe34d6e0d153b01c9f5809059a8ea24bb3c8d85948b10b19492ea1c4ac7b18a551"
-                )
-                assert (
-                    calculate_checksum_from_localized_file(test_file_name, "blake2b")
-                    == "e0602b05f20ff6ec967dad2f7459f1c830f89becde8f51df8de6883833239ea211b59f71503ed46fe2161d2fbe3c9debb93826490d37fb209f9dc07442f5d60f"
-                )
-                assert (
-                    calculate_checksum_from_localized_file(test_file_name, "blake2s")
-                    == "735329022444d0bb427454ae66ef1f0479387b13af0100e53f59319491f1100a"
-                )
-                assert (
-                    calculate_checksum_from_localized_file(test_file_name, "shake_256")
-                    == "1d52cf879f8cd17c6a9293d346c35bc1fdf9d67794d818ddffa5c3fa8221a4ab73ddb736cb3afc20843f0383bd4ee7336b0dd64dc9bc8999f68a24a8f39c65b58653474a40fed0143601c041f7f61a98f5f3611b88346233b5c8167bb88ad81fa7edac034f9eb03f132cd166d9feec779ca6d71e9a3e45eece962afa02ee17ab24de7cc4ca9a6be277323d9c71ed5804f8a98418972769ed57a309f266ff58d1be9c5b6517106cb98cf90881ab69d828446ffb9545f81d9f9c3caa70d85265005b3857d0b0ea164d9641a5e37ed3a347b010202b99115637f0921388d266e7dc79ceacfbcd074fff9bab5207f5bbc73e169f5843ab414a5615136f0f4988d5"
-                )
-                assert (
-                    calculate_checksum_from_localized_file(test_file_name, "shake_128")
-                    == "4e319ddc183f6753409d8c80f7524b17dd3b8754595648b8789cf507be31c7891502b347fb37243b8fc534d61bb27ddf3cc3ee3a3598449e532015509845e57bc7a3afa0133f70f86a2e6c7eb304b57f1ffe5b7105349a5a3238a7a34cae5e89ad0bb24d63757790f3340e4c520120e5ce587486f0a31342ce3e152299006d5d87c4bf6aac17d558a85061329feaf1575479111c5f229f8d8f72c6026d663ea1c8a952ffe9d289db769ab4a6cde6e14df78dd9c112ffbc3e49219f9aaa4db413666164c8c5132dafb1d4a65139a00b623903f8879cd77b1403c696c9fc49e4345da45c1af5d83bd03bf3309e28823d7388c44c7d05771c7bcf3d83a6e8d2c6"
-                )
-            os.remove(test_file_name)
+        if sys.version_info[:2] >= (3, 0):
+            assert (
+                calculate_checksum_from_localized_file(test_file_name, "sha3_224")
+                == "8374697d745e2a5155d04b28fb39910c923920ff7cc15219329c7f76"
+            )
+            assert (
+                calculate_checksum_from_localized_file(test_file_name, "sha3_256")
+                == "8317ca633d3f8a98cc2de2f9fb5b675d5afa8542031dc9040352d3668423bb56"
+            )
+            assert (
+                calculate_checksum_from_localized_file(test_file_name, "sha3_384")
+                == "875b7bc1dcd7c26c66b58ee91aa37b83a3f086d709054d496eba9a75cd1d8f8c0b4f44ef8c7fd41f1ba0a87d5c4fcb92"
+            )
+            assert (
+                calculate_checksum_from_localized_file(test_file_name, "sha3_512")
+                == "5bb79282e3c8aabd5aa56c474bc16f43417961f2934c00c4062d2832848a19fe34d6e0d153b01c9f5809059a8ea24bb3c8d85948b10b19492ea1c4ac7b18a551"
+            )
+            assert (
+                calculate_checksum_from_localized_file(test_file_name, "blake2b")
+                == "e0602b05f20ff6ec967dad2f7459f1c830f89becde8f51df8de6883833239ea211b59f71503ed46fe2161d2fbe3c9debb93826490d37fb209f9dc07442f5d60f"
+            )
+            assert (
+                calculate_checksum_from_localized_file(test_file_name, "blake2s")
+                == "735329022444d0bb427454ae66ef1f0479387b13af0100e53f59319491f1100a"
+            )
+            assert (
+                calculate_checksum_from_localized_file(test_file_name, "shake_256")
+                == "1d52cf879f8cd17c6a9293d346c35bc1fdf9d67794d818ddffa5c3fa8221a4ab73ddb736cb3afc20843f0383bd4ee7336b0dd64dc9bc8999f68a24a8f39c65b58653474a40fed0143601c041f7f61a98f5f3611b88346233b5c8167bb88ad81fa7edac034f9eb03f132cd166d9feec779ca6d71e9a3e45eece962afa02ee17ab24de7cc4ca9a6be277323d9c71ed5804f8a98418972769ed57a309f266ff58d1be9c5b6517106cb98cf90881ab69d828446ffb9545f81d9f9c3caa70d85265005b3857d0b0ea164d9641a5e37ed3a347b010202b99115637f0921388d266e7dc79ceacfbcd074fff9bab5207f5bbc73e169f5843ab414a5615136f0f4988d5"
+            )
+            assert (
+                calculate_checksum_from_localized_file(test_file_name, "shake_128")
+                == "4e319ddc183f6753409d8c80f7524b17dd3b8754595648b8789cf507be31c7891502b347fb37243b8fc534d61bb27ddf3cc3ee3a3598449e532015509845e57bc7a3afa0133f70f86a2e6c7eb304b57f1ffe5b7105349a5a3238a7a34cae5e89ad0bb24d63757790f3340e4c520120e5ce587486f0a31342ce3e152299006d5d87c4bf6aac17d558a85061329feaf1575479111c5f229f8d8f72c6026d663ea1c8a952ffe9d289db769ab4a6cde6e14df78dd9c112ffbc3e49219f9aaa4db413666164c8c5132dafb1d4a65139a00b623903f8879cd77b1403c696c9fc49e4345da45c1af5d83bd03bf3309e28823d7388c44c7d05771c7bcf3d83a6e8d2c6"
+            )
+        os.remove(test_file_name)
 
     def test_generate_list_checksum_files(self):
-        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
-            from hysds.utils import generate_list_checksum_files
+        from hysds.utils import generate_list_checksum_files
 
-            self.constructor()
-            self.create_test_directory_and_files()
-            list_checksums = generate_list_checksum_files(self.test_job_json)
-            self.clear_test_directory_and_files()
+        self.constructor()
+        self.create_test_directory_and_files()
+        list_checksums = generate_list_checksum_files(self.test_job_json)
+        self.clear_test_directory_and_files()
 
-            assert len(list_checksums) == 4
+        assert len(list_checksums) == 4
 
-            algorithms_guaranteed = hashlib.algorithms_guaranteed
-            for checksum_file in list_checksums:
-                algo_type = checksum_file["algo"]
-                assert algo_type in algorithms_guaranteed
+        algorithms_guaranteed = hashlib.algorithms_guaranteed
+        for checksum_file in list_checksums:
+            algo_type = checksum_file["algo"]
+            assert algo_type in algorithms_guaranteed
 
     def test_validate_checksum_files(self):
-        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
-            from hysds.utils import validate_checksum_files
+        from hysds.utils import validate_checksum_files
 
-            self.constructor()
-            self.create_test_directory_and_files()
-            validate_checksum_files(self.test_job_json, {})
-            self.clear_test_directory_and_files()
+        self.constructor()
+        self.create_test_directory_and_files()
+        validate_checksum_files(self.test_job_json, {})
+        self.clear_test_directory_and_files()
 
     def test_validate_checksum_files_error(self):
-        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
-            from hysds.utils import validate_checksum_files
+        from hysds.utils import validate_checksum_files
 
-            self.constructor()
-            self.create_test_directory_and_files()
+        self.constructor()
+        self.create_test_directory_and_files()
 
-            error_test_file = "/tmp/test_err.zip"
-            error_test_file_md5 = "/tmp/test_err.zip.md5"
+        error_test_file = "/tmp/test_err.zip"
+        error_test_file_md5 = "/tmp/test_err.zip.md5"
 
-            with open(error_test_file, "w") as f:
-                f.write("testing testing 123")
+        with open(error_test_file, "w") as f:
+            f.write("testing testing 123")
 
-            with open(error_test_file_md5, "w") as f:
-                f.write("jfdslkfjdslkfdjsfljfdlsjfsjfl")
+        with open(error_test_file_md5, "w") as f:
+            f.write("jfdslkfjdslkfdjsfljfdlsjfsjfl")
 
-            test_job_json = copy.deepcopy(self.test_job_json)
-            test_job_json["localize_urls"].append({"url": error_test_file})
-            test_job_json["localize_urls"].append({"url": error_test_file_md5})
+        test_job_json = copy.deepcopy(self.test_job_json)
+        test_job_json["localize_urls"].append({"url": error_test_file})
+        test_job_json["localize_urls"].append({"url": error_test_file_md5})
 
-            with pytest.raises(Exception):
-                validate_checksum_files(test_job_json)
+        with pytest.raises(Exception):
+            validate_checksum_files(test_job_json)
 
-            self.clear_test_directory_and_files()
-            os.remove(error_test_file_md5)
-            os.remove(error_test_file)
+        self.clear_test_directory_and_files()
+        os.remove(error_test_file_md5)
+        os.remove(error_test_file)

--- a/test/test_preprocessing_checksum.py
+++ b/test/test_preprocessing_checksum.py
@@ -5,14 +5,21 @@ import shutil
 import hashlib
 import copy
 import pytest
+from mock import patch
+try:
+    import unittest.mock as umock
+except ImportError:
+    import mock as umock
 
-from hysds.utils import (
-    hashlib_mapper,
-    calculate_checksum_from_localized_file,
-    read_checksum_file,
-    generate_list_checksum_files,
-    validate_checksum_files,
-)
+# from hysds.utils import (
+#     hashlib_mapper,
+#     calculate_checksum_from_localized_file,
+#     read_checksum_file,
+#     generate_list_checksum_files,
+#     validate_checksum_files,
+# )
+
+sys.modules['opensearchpy'] = umock.Mock()
 
 
 class TestPreProcessingChecksum:
@@ -75,21 +82,24 @@ class TestPreProcessingChecksum:
         shutil.rmtree(os.path.join("/tmp", self.test_directory))
 
     def test_hashlib_mapper(self):
-        with pytest.raises(Exception):
-            hashlib_mapper("non-existing-hashing-algorithm")
+        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
+            from hysds.utils import hashlib_mapper
 
-        assert hashlib_mapper("md5").name == hashlib.md5().name
-        assert hashlib_mapper("MD5").name == hashlib.md5().name
-        assert hashlib_mapper("sha1").name == hashlib.sha1().name
-        assert hashlib_mapper("SHA1").name == hashlib.sha1().name
-        assert hashlib_mapper("sha224").name == hashlib.sha224().name
-        assert hashlib_mapper("SHA224").name == hashlib.sha224().name
-        assert hashlib_mapper("sha256").name == hashlib.sha256().name
-        assert hashlib_mapper("SHA256").name == hashlib.sha256().name
-        assert hashlib_mapper("sha384").name == hashlib.sha384().name
-        assert hashlib_mapper("SHA384").name == hashlib.sha384().name
-        assert hashlib_mapper("sha512").name == hashlib.sha512().name
-        assert hashlib_mapper("SHA512").name == hashlib.sha512().name
+            with pytest.raises(Exception):
+                hashlib_mapper("non-existing-hashing-algorithm")
+
+            assert hashlib_mapper("md5").name == hashlib.md5().name
+            assert hashlib_mapper("MD5").name == hashlib.md5().name
+            assert hashlib_mapper("sha1").name == hashlib.sha1().name
+            assert hashlib_mapper("SHA1").name == hashlib.sha1().name
+            assert hashlib_mapper("sha224").name == hashlib.sha224().name
+            assert hashlib_mapper("SHA224").name == hashlib.sha224().name
+            assert hashlib_mapper("sha256").name == hashlib.sha256().name
+            assert hashlib_mapper("SHA256").name == hashlib.sha256().name
+            assert hashlib_mapper("sha384").name == hashlib.sha384().name
+            assert hashlib_mapper("SHA384").name == hashlib.sha384().name
+            assert hashlib_mapper("sha512").name == hashlib.sha512().name
+            assert hashlib_mapper("SHA512").name == hashlib.sha512().name
 
         # hashlib supports more hashing algorithms in python 3:
         #   sha3_224 sha3_256, sha3_384, blake2b, blake2s, sha3_512, shake_256, shake_128
@@ -112,113 +122,125 @@ class TestPreProcessingChecksum:
             assert hashlib_mapper("SHAKE_128").name == hashlib.shake_128().name
 
     def test_calculate_checksum_from_localized_file(self):
-        test_file_name = "/tmp/test_calculate_checksum_from_localized_file.zip"
-        test_string = "testing testing 123"
+        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
+            from hysds.utils import calculate_checksum_from_localized_file
 
-        with open(
-            test_file_name, "w"
-        ) as f:  # creating a test file with random stuff to md5 hash
-            f.write(test_string)
+            test_file_name = "/tmp/test_calculate_checksum_from_localized_file.zip"
+            test_string = "testing testing 123"
 
-        assert (
-            calculate_checksum_from_localized_file(test_file_name, "md5")
-            == "5c9bee4c87b80170f57f1ef696fa1992"
-        )
-        assert (
-            calculate_checksum_from_localized_file(test_file_name, "sha1")
-            == "89512ac8c5fa4e72773049beea2549c2dc3e8dd3"
-        )
-        assert (
-            calculate_checksum_from_localized_file(test_file_name, "sha224")
-            == "1c8c0df757fb6915b89d468bb07d0df183722217a96b837cc1bdd485"
-        )
-        assert (
-            calculate_checksum_from_localized_file(test_file_name, "sha256")
-            == "7b6f7e8c7911a867c82e5be63ffcb330b3c8fff7528a58b83f74a1304fd05566"
-        )
-        assert (
-            calculate_checksum_from_localized_file(test_file_name, "sha384")
-            == "4b9d911363d3e5f1bcebe5490e813ace3de464c90e6f914473d146ce165a17f9515117ce5e2df0d0fef994a234a5364c"
-        )
-        assert (
-            calculate_checksum_from_localized_file(test_file_name, "sha512")
-            == "efc75d56682a615a61de8626075fbaa799fe57e991644fc1b4e6e9d0004b7239f32467aa20c7189f8e4827e189f30f755977fc6fa3464133fbd213d571d77e97"
-        )
+            with open(
+                test_file_name, "w"
+            ) as f:  # creating a test file with random stuff to md5 hash
+                f.write(test_string)
 
-        if sys.version_info[:2] >= (3, 0):
             assert (
-                calculate_checksum_from_localized_file(test_file_name, "sha3_224")
-                == "8374697d745e2a5155d04b28fb39910c923920ff7cc15219329c7f76"
+                calculate_checksum_from_localized_file(test_file_name, "md5")
+                == "5c9bee4c87b80170f57f1ef696fa1992"
             )
             assert (
-                calculate_checksum_from_localized_file(test_file_name, "sha3_256")
-                == "8317ca633d3f8a98cc2de2f9fb5b675d5afa8542031dc9040352d3668423bb56"
+                calculate_checksum_from_localized_file(test_file_name, "sha1")
+                == "89512ac8c5fa4e72773049beea2549c2dc3e8dd3"
             )
             assert (
-                calculate_checksum_from_localized_file(test_file_name, "sha3_384")
-                == "875b7bc1dcd7c26c66b58ee91aa37b83a3f086d709054d496eba9a75cd1d8f8c0b4f44ef8c7fd41f1ba0a87d5c4fcb92"
+                calculate_checksum_from_localized_file(test_file_name, "sha224")
+                == "1c8c0df757fb6915b89d468bb07d0df183722217a96b837cc1bdd485"
             )
             assert (
-                calculate_checksum_from_localized_file(test_file_name, "sha3_512")
-                == "5bb79282e3c8aabd5aa56c474bc16f43417961f2934c00c4062d2832848a19fe34d6e0d153b01c9f5809059a8ea24bb3c8d85948b10b19492ea1c4ac7b18a551"
+                calculate_checksum_from_localized_file(test_file_name, "sha256")
+                == "7b6f7e8c7911a867c82e5be63ffcb330b3c8fff7528a58b83f74a1304fd05566"
             )
             assert (
-                calculate_checksum_from_localized_file(test_file_name, "blake2b")
-                == "e0602b05f20ff6ec967dad2f7459f1c830f89becde8f51df8de6883833239ea211b59f71503ed46fe2161d2fbe3c9debb93826490d37fb209f9dc07442f5d60f"
+                calculate_checksum_from_localized_file(test_file_name, "sha384")
+                == "4b9d911363d3e5f1bcebe5490e813ace3de464c90e6f914473d146ce165a17f9515117ce5e2df0d0fef994a234a5364c"
             )
             assert (
-                calculate_checksum_from_localized_file(test_file_name, "blake2s")
-                == "735329022444d0bb427454ae66ef1f0479387b13af0100e53f59319491f1100a"
+                calculate_checksum_from_localized_file(test_file_name, "sha512")
+                == "efc75d56682a615a61de8626075fbaa799fe57e991644fc1b4e6e9d0004b7239f32467aa20c7189f8e4827e189f30f755977fc6fa3464133fbd213d571d77e97"
             )
-            assert (
-                calculate_checksum_from_localized_file(test_file_name, "shake_256")
-                == "1d52cf879f8cd17c6a9293d346c35bc1fdf9d67794d818ddffa5c3fa8221a4ab73ddb736cb3afc20843f0383bd4ee7336b0dd64dc9bc8999f68a24a8f39c65b58653474a40fed0143601c041f7f61a98f5f3611b88346233b5c8167bb88ad81fa7edac034f9eb03f132cd166d9feec779ca6d71e9a3e45eece962afa02ee17ab24de7cc4ca9a6be277323d9c71ed5804f8a98418972769ed57a309f266ff58d1be9c5b6517106cb98cf90881ab69d828446ffb9545f81d9f9c3caa70d85265005b3857d0b0ea164d9641a5e37ed3a347b010202b99115637f0921388d266e7dc79ceacfbcd074fff9bab5207f5bbc73e169f5843ab414a5615136f0f4988d5"
-            )
-            assert (
-                calculate_checksum_from_localized_file(test_file_name, "shake_128")
-                == "4e319ddc183f6753409d8c80f7524b17dd3b8754595648b8789cf507be31c7891502b347fb37243b8fc534d61bb27ddf3cc3ee3a3598449e532015509845e57bc7a3afa0133f70f86a2e6c7eb304b57f1ffe5b7105349a5a3238a7a34cae5e89ad0bb24d63757790f3340e4c520120e5ce587486f0a31342ce3e152299006d5d87c4bf6aac17d558a85061329feaf1575479111c5f229f8d8f72c6026d663ea1c8a952ffe9d289db769ab4a6cde6e14df78dd9c112ffbc3e49219f9aaa4db413666164c8c5132dafb1d4a65139a00b623903f8879cd77b1403c696c9fc49e4345da45c1af5d83bd03bf3309e28823d7388c44c7d05771c7bcf3d83a6e8d2c6"
-            )
-        os.remove(test_file_name)
+
+            if sys.version_info[:2] >= (3, 0):
+                assert (
+                    calculate_checksum_from_localized_file(test_file_name, "sha3_224")
+                    == "8374697d745e2a5155d04b28fb39910c923920ff7cc15219329c7f76"
+                )
+                assert (
+                    calculate_checksum_from_localized_file(test_file_name, "sha3_256")
+                    == "8317ca633d3f8a98cc2de2f9fb5b675d5afa8542031dc9040352d3668423bb56"
+                )
+                assert (
+                    calculate_checksum_from_localized_file(test_file_name, "sha3_384")
+                    == "875b7bc1dcd7c26c66b58ee91aa37b83a3f086d709054d496eba9a75cd1d8f8c0b4f44ef8c7fd41f1ba0a87d5c4fcb92"
+                )
+                assert (
+                    calculate_checksum_from_localized_file(test_file_name, "sha3_512")
+                    == "5bb79282e3c8aabd5aa56c474bc16f43417961f2934c00c4062d2832848a19fe34d6e0d153b01c9f5809059a8ea24bb3c8d85948b10b19492ea1c4ac7b18a551"
+                )
+                assert (
+                    calculate_checksum_from_localized_file(test_file_name, "blake2b")
+                    == "e0602b05f20ff6ec967dad2f7459f1c830f89becde8f51df8de6883833239ea211b59f71503ed46fe2161d2fbe3c9debb93826490d37fb209f9dc07442f5d60f"
+                )
+                assert (
+                    calculate_checksum_from_localized_file(test_file_name, "blake2s")
+                    == "735329022444d0bb427454ae66ef1f0479387b13af0100e53f59319491f1100a"
+                )
+                assert (
+                    calculate_checksum_from_localized_file(test_file_name, "shake_256")
+                    == "1d52cf879f8cd17c6a9293d346c35bc1fdf9d67794d818ddffa5c3fa8221a4ab73ddb736cb3afc20843f0383bd4ee7336b0dd64dc9bc8999f68a24a8f39c65b58653474a40fed0143601c041f7f61a98f5f3611b88346233b5c8167bb88ad81fa7edac034f9eb03f132cd166d9feec779ca6d71e9a3e45eece962afa02ee17ab24de7cc4ca9a6be277323d9c71ed5804f8a98418972769ed57a309f266ff58d1be9c5b6517106cb98cf90881ab69d828446ffb9545f81d9f9c3caa70d85265005b3857d0b0ea164d9641a5e37ed3a347b010202b99115637f0921388d266e7dc79ceacfbcd074fff9bab5207f5bbc73e169f5843ab414a5615136f0f4988d5"
+                )
+                assert (
+                    calculate_checksum_from_localized_file(test_file_name, "shake_128")
+                    == "4e319ddc183f6753409d8c80f7524b17dd3b8754595648b8789cf507be31c7891502b347fb37243b8fc534d61bb27ddf3cc3ee3a3598449e532015509845e57bc7a3afa0133f70f86a2e6c7eb304b57f1ffe5b7105349a5a3238a7a34cae5e89ad0bb24d63757790f3340e4c520120e5ce587486f0a31342ce3e152299006d5d87c4bf6aac17d558a85061329feaf1575479111c5f229f8d8f72c6026d663ea1c8a952ffe9d289db769ab4a6cde6e14df78dd9c112ffbc3e49219f9aaa4db413666164c8c5132dafb1d4a65139a00b623903f8879cd77b1403c696c9fc49e4345da45c1af5d83bd03bf3309e28823d7388c44c7d05771c7bcf3d83a6e8d2c6"
+                )
+            os.remove(test_file_name)
 
     def test_generate_list_checksum_files(self):
-        self.constructor()
-        self.create_test_directory_and_files()
-        list_checksums = generate_list_checksum_files(self.test_job_json)
-        self.clear_test_directory_and_files()
+        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
+            from hysds.utils import generate_list_checksum_files
 
-        assert len(list_checksums) == 4
+            self.constructor()
+            self.create_test_directory_and_files()
+            list_checksums = generate_list_checksum_files(self.test_job_json)
+            self.clear_test_directory_and_files()
 
-        algorithms_guaranteed = hashlib.algorithms_guaranteed
-        for checksum_file in list_checksums:
-            algo_type = checksum_file["algo"]
-            assert algo_type in algorithms_guaranteed
+            assert len(list_checksums) == 4
+
+            algorithms_guaranteed = hashlib.algorithms_guaranteed
+            for checksum_file in list_checksums:
+                algo_type = checksum_file["algo"]
+                assert algo_type in algorithms_guaranteed
 
     def test_validate_checksum_files(self):
-        self.constructor()
-        self.create_test_directory_and_files()
-        validate_checksum_files(self.test_job_json, {})
-        self.clear_test_directory_and_files()
+        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
+            from hysds.utils import validate_checksum_files
+
+            self.constructor()
+            self.create_test_directory_and_files()
+            validate_checksum_files(self.test_job_json, {})
+            self.clear_test_directory_and_files()
 
     def test_validate_checksum_files_error(self):
-        self.constructor()
-        self.create_test_directory_and_files()
+        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
+            from hysds.utils import validate_checksum_files
 
-        error_test_file = "/tmp/test_err.zip"
-        error_test_file_md5 = "/tmp/test_err.zip.md5"
+            self.constructor()
+            self.create_test_directory_and_files()
 
-        with open(error_test_file, "w") as f:
-            f.write("testing testing 123")
+            error_test_file = "/tmp/test_err.zip"
+            error_test_file_md5 = "/tmp/test_err.zip.md5"
 
-        with open(error_test_file_md5, "w") as f:
-            f.write("jfdslkfjdslkfdjsfljfdlsjfsjfl")
+            with open(error_test_file, "w") as f:
+                f.write("testing testing 123")
 
-        test_job_json = copy.deepcopy(self.test_job_json)
-        test_job_json["localize_urls"].append({"url": error_test_file})
-        test_job_json["localize_urls"].append({"url": error_test_file_md5})
+            with open(error_test_file_md5, "w") as f:
+                f.write("jfdslkfjdslkfdjsfljfdlsjfsjfl")
 
-        with pytest.raises(Exception):
-            self.validate_checksum_files(test_job_json)
+            test_job_json = copy.deepcopy(self.test_job_json)
+            test_job_json["localize_urls"].append({"url": error_test_file})
+            test_job_json["localize_urls"].append({"url": error_test_file_md5})
 
-        self.clear_test_directory_and_files()
-        os.remove(error_test_file_md5)
-        os.remove(error_test_file)
+            with pytest.raises(Exception):
+                validate_checksum_files(test_job_json)
+
+            self.clear_test_directory_and_files()
+            os.remove(error_test_file_md5)
+            os.remove(error_test_file)

--- a/test/test_triage.py
+++ b/test/test_triage.py
@@ -15,6 +15,8 @@ import os
 # hysds.celery searches for configuration on import. So we need to make sure we
 # mock it out before the first time it is imported
 sys.modules["hysds.celery"] = umock.MagicMock()
+sys.modules['opensearchpy'] = umock.Mock()
+sys.modules['opensearchpy.exceptions'] = umock.Mock()
 logging.basicConfig()
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,9 +5,7 @@ try:
     import unittest.mock as umock
 except ImportError:
     import mock as umock
-# import unittest
 from unittest import TestCase
-from unittest.mock import patch
 import logging
 import tempfile
 import shutil
@@ -61,29 +59,27 @@ class TestUtils(TestCase):
         return apparent_total_bytes
 
     def test_disk_usage(self):
-        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
-            import hysds.utils
+        import hysds.utils
 
-            size_bytes = 1024 * 1024  # 1 MB
-            with open(os.path.join(self.tmp_dir, "test.bin"), "wb") as f:
-                f.write(os.urandom(size_bytes))
-            size = hysds.utils.get_disk_usage(self.tmp_dir)
-            self.assertTrue(size == self.get_disk_usage(self.tmp_dir))
+        size_bytes = 1024 * 1024  # 1 MB
+        with open(os.path.join(self.tmp_dir, "test.bin"), "wb") as f:
+            f.write(os.urandom(size_bytes))
+        size = hysds.utils.get_disk_usage(self.tmp_dir)
+        self.assertTrue(size == self.get_disk_usage(self.tmp_dir))
 
     def test_disk_usage_with_symlink(self):
-        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
-            import hysds.utils
+        import hysds.utils
 
-            size_bytes = 1024 * 1024  # 1 MB
-            bin_file = os.path.join(self.tmp_dir, "test.bin")
-            with open(bin_file, "wb") as f:
-                f.write(os.urandom(size_bytes))
-            self.tmp_dir2 = tempfile.mkdtemp(prefix="tmp-")
-            sym_file = os.path.join(self.tmp_dir2, "test.bin")
-            os.symlink(bin_file, sym_file)
-            size = hysds.utils.get_disk_usage(self.tmp_dir2)
-            self.assertTrue(size == self.get_disk_usage(self.tmp_dir2))
-            shutil.rmtree(self.tmp_dir2)
+        size_bytes = 1024 * 1024  # 1 MB
+        bin_file = os.path.join(self.tmp_dir, "test.bin")
+        with open(bin_file, "wb") as f:
+            f.write(os.urandom(size_bytes))
+        self.tmp_dir2 = tempfile.mkdtemp(prefix="tmp-")
+        sym_file = os.path.join(self.tmp_dir2, "test.bin")
+        os.symlink(bin_file, sym_file)
+        size = hysds.utils.get_disk_usage(self.tmp_dir2)
+        self.assertTrue(size == self.get_disk_usage(self.tmp_dir2))
+        shutil.rmtree(self.tmp_dir2)
 
 
 class TestPublishDataset(TestCase):
@@ -149,55 +145,53 @@ class TestPublishDataset(TestCase):
         shutil.rmtree(self.job_dir)
 
     def test_publish_dataset(self):
-        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
-            import hysds.dataset_ingest
+        import hysds.dataset_ingest
 
-            job_context = {}
-            job_context_file = os.path.join(self.job_dir, "_context.json")
-            with open(job_context_file, 'w') as f:
-                json.dump(job_context, f, indent=2, sort_keys=True)
-            self.job["job_info"]["context_file"] = job_context_file
+        job_context = {}
+        job_context_file = os.path.join(self.job_dir, "_context.json")
+        with open(job_context_file, 'w') as f:
+            json.dump(job_context, f, indent=2, sort_keys=True)
+        self.job["job_info"]["context_file"] = job_context_file
 
-            # Mocked data
-            ingest_mock = umock.patch("hysds.dataset_ingest.ingest").start()
-            ingest_mock.return_value = (self.metrics, self.prod_json)
+        # Mocked data
+        ingest_mock = umock.patch("hysds.dataset_ingest.ingest").start()
+        ingest_mock.return_value = (self.metrics, self.prod_json)
 
-            self.assertTrue(hysds.dataset_ingest.publish_datasets(self.job, job_context))
+        self.assertTrue(hysds.dataset_ingest.publish_datasets(self.job, job_context))
 
-            # assert called args
-            ingest_mock.assert_called_with(
-                'AOI_sacramento_valley',
-                self.datasets_cfg_file,
-                umock.ANY,
-                umock.ANY,
-                self.prod_dir,
-                self.job_dir,
-                force=False
-            )
+        # assert called args
+        ingest_mock.assert_called_with(
+            'AOI_sacramento_valley',
+            self.datasets_cfg_file,
+            umock.ANY,
+            umock.ANY,
+            self.prod_dir,
+            self.job_dir,
+            force=False
+        )
 
     def test_force_ingest(self):
-        with patch("elasticsearch.Elasticsearch", return_value=None), patch("opensearchpy.OpenSearch", return_value=None):
-            import hysds.dataset_ingest
+        import hysds.dataset_ingest
 
-            job_context = {'_force_ingest': True}
-            job_context_file = os.path.join(self.job_dir, "_context.json")
-            with open(job_context_file, 'w') as f:
-                json.dump(job_context, f, indent=2, sort_keys=True)
-            self.job["job_info"]["context_file"] = job_context_file
+        job_context = {'_force_ingest': True}
+        job_context_file = os.path.join(self.job_dir, "_context.json")
+        with open(job_context_file, 'w') as f:
+            json.dump(job_context, f, indent=2, sort_keys=True)
+        self.job["job_info"]["context_file"] = job_context_file
 
-            # Mocked data
-            ingest_mock = umock.patch("hysds.dataset_ingest.ingest").start()
-            ingest_mock.return_value = (self.metrics, self.prod_json)
+        # Mocked data
+        ingest_mock = umock.patch("hysds.dataset_ingest.ingest").start()
+        ingest_mock.return_value = (self.metrics, self.prod_json)
 
-            self.assertTrue(hysds.dataset_ingest.publish_datasets(self.job, job_context))
+        self.assertTrue(hysds.dataset_ingest.publish_datasets(self.job, job_context))
 
-            # assert that ingest function was called with force=True
-            ingest_mock.assert_called_with(
-                'AOI_sacramento_valley',
-                self.datasets_cfg_file,
-                umock.ANY,
-                umock.ANY,
-                self.prod_dir,
-                self.job_dir,
-                force=True
-            )
+        # assert that ingest function was called with force=True
+        ingest_mock.assert_called_with(
+            'AOI_sacramento_valley',
+            self.datasets_cfg_file,
+            umock.ANY,
+            umock.ANY,
+            self.prod_dir,
+            self.job_dir,
+            force=True
+        )


### PR DESCRIPTION
related ticket(s):
- https://hysds-core.atlassian.net/browse/HC-483
- https://hysds-core.atlassian.net/browse/HC-490
- https://hysds-core.atlassian.net/browse/HC-484

change(s):
- bump minor version
- Jinja template files now supporting multiple nodes, depending on the value(s) in `~/.sds/config`:
  - `[MOZART|METRICS|GRQ]_ES_PVT_IP` not supporting YAML arrays or strings
  - files affected: `celeryconfig.py` and logstash indexers
- `celeryconfig.py` now has `JOBS_ES_ENGINE`, `GRQ_ES_ENGINE` & `METRICS_ES_ENGINE`; `elasticsearch` or `opensearch`
- `hysds/es_util.py` will use either `Elasticsearch` or `OpenSearch` python class depending on `*_ES_ENGINE` in `celeryconfig.py`
- added python scripts to install ILM or ISM, depending on opensearch or elasticsearch
- `scripts/clean_indices_from_alias.py` uses es/opensarch object instead of `requests`
- removed `aws-requests-auth`, instead opting for `opensearchpy`'s signature function
- supporting elasticsearch-oss's lack of features (no ILM/ISM, no SLM/SM)