### PR TITLE
HC-502: Enable clobbering when publishing triage datasets

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/triage.py
+++ b/hysds/triage.py
@@ -135,6 +135,8 @@ def triage(job, ctx):
                 )
 
     # publish
+    # HC-502: It's ok to clobber triage
+    ctx["_force_ingest"] = True
     prod_json = publish_dataset(triage_dir, ds_file, job, ctx)
 
     # write published triage to file

--- a/hysds/triage.py
+++ b/hysds/triage.py
@@ -144,7 +144,6 @@ def triage(job, ctx):
     pub_triage_file = os.path.join(job_dir, "_triaged.json")
     with open(pub_triage_file, "w") as f:
         json.dump(prod_json, f, indent=2, sort_keys=True)
-    # Temporary kludge to test
-    time.sleep(120)
+
     # signal run_job() to continue
     return True

--- a/hysds/triage.py
+++ b/hysds/triage.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
 
+import time
 from builtins import str
 from builtins import open
 from future import standard_library
@@ -143,6 +144,7 @@ def triage(job, ctx):
     pub_triage_file = os.path.join(job_dir, "_triaged.json")
     with open(pub_triage_file, "w") as f:
         json.dump(prod_json, f, indent=2, sort_keys=True)
-
+    # Temporary kludge to test
+    time.sleep(120)
     # signal run_job() to continue
     return True


### PR DESCRIPTION
This PR turns on clobbering when publishing triage datasets. This fixes an issue that was seen where jobs would be occasionally re-queued due to spot termination, but would result in a no-clobber when trying to re-publish the triage dataset.

To test, I put in a kludge so that I could essentially force the re-queued scenario. I then submitted a job to factotum and forced the re-queued scenario by restarting the factotum job worker in the middle of the job. As a result, it is verified that a redelivery of a job no longer results in a triage no-clobber:

![image](https://github.com/hysds/hysds/assets/42812746/592482e2-6697-4c82-a163-c8a6ef46eda2)
