### PR TITLE
hot-fix: Pin lxml to less than 5.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "flower>=1.0.0",
         "eventlet>=0.17.2",
         "easywebdav>=1.2.0",
-        "lxml>=3.4.0",
+        "lxml>=3.4.0,<5.1.0",
         "httplib2>=0.9",
         "gevent>=1.0.1",
         "psutil>=5.8.0",


### PR DESCRIPTION
This hot fix pins lxml to less than 5.1.0 as 5.1.0 introduced the following error:

```
Traceback (most recent call last):
  File "/home/ops/verdi/bin/sflExec.py", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/ops/verdi/ops/sciflo/scripts/sflExec.py", line 261, in <module>
    results, resStrList = main()
  File "/home/ops/verdi/ops/sciflo/scripts/sflExec.py", line 206, in main
    results = sciflo.grid.executor.runSciflo(xml, argsDict, timeout=timeout,
  File "/home/ops/verdi/ops/sciflo/sciflo/grid/executor.py", line 1079, in runSciflo
    raise res
  File "/home/ops/verdi/ops/sciflo/sciflo/grid/executor.py", line 1049, in _runSciflo
    s = ScifloExecutor(sflStr, args=args, workers=workers,
  File "/home/ops/verdi/ops/sciflo/sciflo/grid/executor.py", line 217, in __init__
    self.sciflo.writeGraph(self.svgFile)
  File "/home/ops/verdi/ops/sciflo/sciflo/grid/doc.py", line 1235, in writeGraph
    f.write(self.getSvg())
  File "/home/ops/verdi/ops/sciflo/sciflo/grid/doc.py", line 1215, in getSvg
    self.svg = self._annotateSvg(
  File "/home/ops/verdi/ops/sciflo/sciflo/grid/doc.py", line 1184, in _annotateSvg
    svgElt, svgNsDict = getXmlEtree(svgStr)
  File "/home/ops/verdi/ops/sciflo/sciflo/utils/xmlUtils.py", line 75, in getXmlEtree
    return (lxml.etree.parse(StringIO(xml), parser).getroot(), getNamespacePrefixDict(xml))
  File "src/lxml/etree.pyx", line 3547, in lxml.etree.parse
  File "src/lxml/parser.pxi", line 1969, in lxml.etree._parseDocument
  File "src/lxml/parser.pxi", line 1989, in lxml.etree._parseMemoryDocument
  File "src/lxml/parser.pxi", line 1869, in lxml.etree._parseDoc
  File "src/lxml/parser.pxi", line 1105, in lxml.etree._BaseParser._parseUnicodeDoc
  File "src/lxml/parser.pxi", line 633, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 743, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 672, in lxml.etree._raiseParseError
  File "<string>", line 1
lxml.etree.XMLSyntaxError: Blank needed here, line 1, column 21
Running sflExec.py command:
/home/ops/verdi/bin/sflExec.py -s -f -o sfl_output --args "sf_context=/data/work/jobs/2024/01/09/20/40/SCIFLO_RSLC__NSDS-3321-track_frame_034_080_010_full_individual_L_20_DV_05_DV_0_state-config-20240109T193107.846043Z/_context.json" /home/ops/verdi/ops/nisar-pcm/nisar_chimera/wf_xml/RSLC.sf.xml
Exit status is: 256
```