### PR TITLE
hot-fix: Update return from psutil.disk_partitions function call

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/scripts/log_instance_stats.py
+++ b/scripts/log_instance_stats.py
@@ -76,14 +76,12 @@ def daemon(redis_url, redis_key, interval):
             "disk_io": psutil.disk_io_counters()._asdict(),
             "net_io": psutil.net_io_counters()._asdict(),
         }
-        for device, mnt_point, fs_type, fs_opts, max_file, max_path, *other in psutil.disk_partitions():
+        for device, mnt_point, fs_type, fs_opts, *other in psutil.disk_partitions():
             disk_info = {
                 "device": device,
                 "mount_point": mnt_point,
                 "fs_type": fs_type,
-                "fs_opts": fs_opts,
-                "max_file": max_file,
-                "max_path": max_path
+                "fs_opts": fs_opts
             }
             try:
                 disk_info.update(psutil.disk_usage(mnt_point)._asdict())


### PR DESCRIPTION
Due to psutil 6.0.0 release, it is found that it broke the instance_stats service with the following error:

```
Traceback (most recent call last):
  File "/export/home/hysdsops/mozart/ops/hysds/scripts/log_instance_stats.py", line 119, in <module>
    daemon(args.redis_url, args.redis_key, args.interval)
  File "/export/home/hysdsops/mozart/ops/hysds/scripts/log_instance_stats.py", line 79, in daemon
    for device, mnt_point, fs_type, fs_opts, max_file, max_path, *other in psutil.disk_partitions():
ValueError: not enough values to unpack (expected at least 6, got 4)
```
According to the psutil pull request, https://github.com/giampaolo/psutil/pull/2405, max_file and max_path were removed because if there's a NFS (network filesystem) this function can potentially take a long time to complete.

After the fix, deployed the change to a development cluster and verified that the instance_stats service is running successfully again:

![image](https://github.com/hysds/hysds/assets/42812746/1ca3b4d0-718c-4921-99d6-8fdae3bcb3b1)

