### PR TITLE
HC-540: Cache the function objects being returned by orchestrator.py get_function method

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/orchestrator.py
+++ b/hysds/orchestrator.py
@@ -24,6 +24,7 @@ from datetime import datetime
 from string import Template
 from inspect import getargspec
 from celery import uuid
+from functools import lru_cache
 
 from hysds.celery import app
 from hysds.log_utils import (
@@ -81,7 +82,7 @@ def get_timestamp(fraction=True):
         )
     return s
 
-
+@lru_cache(maxsize=32)
 def get_function(func_str, add_to_sys_path=None):
     """Automatically parse a function call string to import any libraries
     and return a pointer to the function.  Define add_to_sys_path to prepend a


### PR DESCRIPTION
 instead of having to exec import every time. This seems to improve CPU performance 3x.

Testing performed:

- I ran a single orchestrator celery worker on a Mozart machine in foreground and disabled all that are normally started by supervisord. I ran it using the same command that was in supervisord.conf.
- I queued 2000 jobs using the existing code without the caching change. It took about 42 seconds. Average CPU utilization was ~70% eyeballing using top over those 42 seconds.
- I stopped the process; change the code to add caching; restarted. Stopped and then reset Mozart to clear out mozart_es. Queued up the same 2000 jobs again. It took about 22 seconds with average CPU utilization of ~40%
- Restored supervisord.conf to start the orchestrator celery workers nominally and ran the OPERA hySDS cluster in forward mode for a few PGE jobs. The system performed nominally.