### PR TITLE
HC-522-update: Updates to support moving away from OPS user

### DIFF
--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -134,6 +134,10 @@ PODMAN_CFG = {
   ]
 }
 
+# Use the PODMAN_SOCK setting if the UID in the container is expected to be different
+# than outside the container
+# PODMAN_SOCK = /run/user/01234/podman/podman.sock
+
 DATASET_PROCESSED_QUEUE = "dataset_processed"
 USER_RULES_DATASET_QUEUE = "user_rules_dataset"
 ON_DEMAND_DATASET_QUEUE = "on_demand_dataset"

--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -121,10 +121,6 @@ GRQ_ES_URL = "{{ 'https://'~GRQ_ES_PVT_IP if GRQ_AWS_ES == true or 'es.amazonaws
 
 CONTAINER_ENGINE = "{{ CONTAINER_ENGINE or 'docker' }}"
 
-# This is intended to be used for setting additional volume mount specifications
-# that can change depending on where the worker is running
-CONTAINER_VOLUME_MOUNTS = {}
-
 PODMAN_CFG = {
   "set_uid_gid": False,
   "set_passwd_entry": True,

--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -123,7 +123,7 @@ CONTAINER_ENGINE = "{{ CONTAINER_ENGINE or 'docker' }}"
 
 PODMAN_CFG = {
   "set_uid_gid": False,
-  "set_passwd_entry": True,
+  "set_passwd_entry": False,
   "cmd_base": {
     # Commenting the userns setting out, but leaving it in here in case it needs to be set
     # "userns": "keep-id",

--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -123,7 +123,7 @@ CONTAINER_ENGINE = "{{ CONTAINER_ENGINE or 'docker' }}"
 
 PODMAN_CFG = {
   "set_uid_gid": False,
-  "set_passwd_entry": False,
+  "set_passwd_entry": True,
   "cmd_base": {
     # Commenting the userns setting out, but leaving it in here in case it needs to be set
     # "userns": "keep-id",
@@ -201,6 +201,6 @@ ES_CLUSTER_MODE = {{ ES_CLUSTER_MODE or False }}
 
 TRIAGE_PARTITION_FORMAT = {{ TRIAGE_PARTITION_FORMAT or None }}
 
-VERDI_HOME = "{{ VERDI_HOME or '/home/ops' }}"
+VERDI_HOME = "{{ VERDI_HOME or '/root' }}"
 
 VERDI_SHELL = "{{ VERDI_SHELL or '/bin/bash' }}"

--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -123,7 +123,7 @@ CONTAINER_ENGINE = "{{ CONTAINER_ENGINE or 'docker' }}"
 
 # This is intended to be used for setting additional volume mount specifications
 # that can change depending on where the worker is running
-ADDITIONAL_CONTAINER_MOUNTS = {}
+CONTAINER_VOLUME_MOUNTS = {}
 
 PODMAN_CFG = {
   "set_uid_gid": False,

--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -121,6 +121,10 @@ GRQ_ES_URL = "{{ 'https://'~GRQ_ES_PVT_IP if GRQ_AWS_ES == true or 'es.amazonaws
 
 CONTAINER_ENGINE = "{{ CONTAINER_ENGINE or 'docker' }}"
 
+# This is intended to be used for setting additional volume mount specifications
+# that can change depending on where the worker is running
+ADDITIONAL_CONTAINER_MOUNTS = {}
+
 PODMAN_CFG = {
   "set_uid_gid": False,
   "set_passwd_entry": True,

--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -122,21 +122,19 @@ GRQ_ES_URL = "{{ 'https://'~GRQ_ES_PVT_IP if GRQ_AWS_ES == true or 'es.amazonaws
 CONTAINER_ENGINE = "{{ CONTAINER_ENGINE or 'docker' }}"
 
 PODMAN_CFG = {
-  "set_uid_gid": True,
+  "set_uid_gid": False,
   "set_passwd_entry": True,
   "cmd_base": {
-    "userns": "keep-id",
+    # Commenting the userns setting out, but leaving it in here in case it needs to be set
+    # "userns": "keep-id",
     "security-opt": "label=disable"
   },
   "environment": [
     "HOST_VERDI_HOME",
-    "HOST_USER"
+    "HOST_USER",
+    "HOST_UID"
   ]
 }
-
-# Use the PODMAN_SOCK setting if the UID in the container is expected to be different
-# than outside the container
-# PODMAN_SOCK = /run/user/01234/podman/podman.sock
 
 DATASET_PROCESSED_QUEUE = "dataset_processed"
 USER_RULES_DATASET_QUEUE = "user_rules_dataset"

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.3.4"
+__version__ = "1.3.3"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/containers/base.py
+++ b/hysds/containers/base.py
@@ -217,7 +217,7 @@ class Base(ABC):
             host_k = k
             if verdi_home and host_verdi_home:
                 logger.info(f"verdi_home={verdi_home}, host_home={host_verdi_home}")
-                if verdi_home in k:
+                if k.startswith(verdi_home):
                     host_k = k.replace(verdi_home, host_verdi_home)
                     logger.info(f"Replacing {k} with {host_k} in the volume mount")
                 else:

--- a/hysds/containers/base.py
+++ b/hysds/containers/base.py
@@ -138,7 +138,7 @@ class Base(ABC):
         return os.path.join(mnt_dir, os.path.basename(path))
 
     def create_container_params(self, image_name, image_url, image_mappings, root_work_dir, job_dir,
-                                runtime_options=None, verdi_home=None, host_verdi_home=None, volume_mounts=None):
+                                runtime_options=None, verdi_home=None, host_verdi_home=None):
         """
         Build container params for runtime.
         :param image_name: str
@@ -149,7 +149,6 @@ class Base(ABC):
         :param runtime_options: None/dict
         :param verdi_home: str
         :param host_verdi_home: str
-        :param volume_mounts: dict
         :return:
         """
         root_jobs_dir = os.path.join(root_work_dir, "jobs")
@@ -193,10 +192,6 @@ class Base(ABC):
                     image_mappings[f] = f
             blacklist = [i for i in blacklist if i != "/etc"]
             mnt_dir = mkdtemp(prefix=".container_mounts-", dir=job_dir)
-
-        # Add additional volume mounts if specified
-        if volume_mounts:
-            image_mappings.update(volume_mounts)
 
         # add user-defined image mappings
         for k, v in list(image_mappings.items()):

--- a/hysds/containers/base.py
+++ b/hysds/containers/base.py
@@ -138,7 +138,7 @@ class Base(ABC):
         return os.path.join(mnt_dir, os.path.basename(path))
 
     def create_container_params(self, image_name, image_url, image_mappings, root_work_dir, job_dir,
-                                runtime_options=None, verdi_home=None, host_verdi_home=None):
+                                runtime_options=None, verdi_home=None, host_verdi_home=None, volume_mounts=None):
         """
         Build container params for runtime.
         :param image_name: str
@@ -149,6 +149,7 @@ class Base(ABC):
         :param runtime_options: None/dict
         :param verdi_home: str
         :param host_verdi_home: str
+        :param volume_mounts: dict
         :return:
         """
         root_jobs_dir = os.path.join(root_work_dir, "jobs")
@@ -192,6 +193,10 @@ class Base(ABC):
                     image_mappings[f] = f
             blacklist = [i for i in blacklist if i != "/etc"]
             mnt_dir = mkdtemp(prefix=".container_mounts-", dir=job_dir)
+
+        # Add additional volume mounts if specified
+        if volume_mounts:
+            image_mappings.update(volume_mounts)
 
         # add user-defined image mappings
         for k, v in list(image_mappings.items()):

--- a/hysds/containers/docker.py
+++ b/hysds/containers/docker.py
@@ -79,7 +79,7 @@ class Docker(Base):
         return docker_cmd_base
 
     def create_container_params(self, image_name, image_url, image_mappings, root_work_dir, job_dir,
-                                runtime_options=None, verdi_home=None, host_verdi_home=None, volume_mounts=None):
+                                runtime_options=None, verdi_home=None, host_verdi_home=None):
         """
         Builds docker params
         :param image_name:
@@ -90,11 +90,10 @@ class Docker(Base):
         :param runtime_options:
         :param verdi_home:
         :param host_verdi_home:
-        :param volume_mounts:
         :return:
         """
         params = super().create_container_params(image_name, image_url, image_mappings, root_work_dir, job_dir,
-                                                 runtime_options, verdi_home, host_verdi_home, volume_mounts)
+                                                 runtime_options, verdi_home, host_verdi_home)
         docker_sock = "/var/run/docker.sock"
         params['volumes'].insert(0, (docker_sock, docker_sock, ))
         return params

--- a/hysds/containers/docker.py
+++ b/hysds/containers/docker.py
@@ -79,7 +79,7 @@ class Docker(Base):
         return docker_cmd_base
 
     def create_container_params(self, image_name, image_url, image_mappings, root_work_dir, job_dir,
-                                runtime_options=None, verdi_home=None, host_verdi_home=None):
+                                runtime_options=None, verdi_home=None, host_verdi_home=None, volume_mounts=None):
         """
         Builds docker params
         :param image_name:
@@ -90,10 +90,11 @@ class Docker(Base):
         :param runtime_options:
         :param verdi_home:
         :param host_verdi_home:
+        :param volume_mounts:
         :return:
         """
         params = super().create_container_params(image_name, image_url, image_mappings, root_work_dir, job_dir,
-                                                 runtime_options, verdi_home, host_verdi_home)
+                                                 runtime_options, verdi_home, host_verdi_home, volume_mounts)
         docker_sock = "/var/run/docker.sock"
         params['volumes'].insert(0, (docker_sock, docker_sock, ))
         return params

--- a/hysds/containers/podman.py
+++ b/hysds/containers/podman.py
@@ -131,7 +131,7 @@ class Podman(Base):
         return podman_cmd_base
 
     def create_container_params(self, image_name, image_url, image_mappings, root_work_dir, job_dir,
-                                runtime_options=None, verdi_home=None, host_verdi_home=None):
+                                runtime_options=None, verdi_home=None, host_verdi_home=None, volume_mounts=None):
         """
         Builds podman params
         :param image_name:
@@ -142,10 +142,11 @@ class Podman(Base):
         :param runtime_options: THe specific flags to run with
         :param verdi_home: The verdi home
         :param host_verdi_home: The home dir on the host
+        :param volume_mounts: Additional volume mounts to set that can't be hardcoded in the job spec
         :return:
         """
         params = super().create_container_params(image_name, image_url, image_mappings, root_work_dir, job_dir,
-                                                 runtime_options, verdi_home, host_verdi_home)
+                                                 runtime_options, verdi_home, host_verdi_home, volume_mounts)
         params['podman_sock'] = self.podman_sock
         params['volumes'].insert(0, (self.podman_sock, self.podman_sock, ))
         return params

--- a/hysds/containers/podman.py
+++ b/hysds/containers/podman.py
@@ -131,7 +131,7 @@ class Podman(Base):
         return podman_cmd_base
 
     def create_container_params(self, image_name, image_url, image_mappings, root_work_dir, job_dir,
-                                runtime_options=None, verdi_home=None, host_verdi_home=None, volume_mounts=None):
+                                runtime_options=None, verdi_home=None, host_verdi_home=None):
         """
         Builds podman params
         :param image_name:
@@ -142,11 +142,10 @@ class Podman(Base):
         :param runtime_options: THe specific flags to run with
         :param verdi_home: The verdi home
         :param host_verdi_home: The home dir on the host
-        :param volume_mounts: Additional volume mounts to set that can't be hardcoded in the job spec
         :return:
         """
         params = super().create_container_params(image_name, image_url, image_mappings, root_work_dir, job_dir,
-                                                 runtime_options, verdi_home, host_verdi_home, volume_mounts)
+                                                 runtime_options, verdi_home, host_verdi_home)
         params['podman_sock'] = self.podman_sock
         params['volumes'].insert(0, (self.podman_sock, self.podman_sock, ))
         return params

--- a/hysds/containers/podman.py
+++ b/hysds/containers/podman.py
@@ -15,7 +15,7 @@ class Podman(Base):
         self.podman_sock = f"/run/user/{self._uid}/podman/podman.sock"
 
         cfg = app.conf.get('PODMAN_CFG', {})
-        self._environment = cfg.get("environment", {})
+        self._environment = cfg.get("environment", [])
         self._set_uid_gid = cfg.get("set_uid_gid", False)
         self._set_passwd_entry = cfg.get("set_passwd_entry", False)
         self._verdi_home = app.conf.get('VERDI_HOME', '/home/ops')
@@ -99,7 +99,7 @@ class Podman(Base):
         # Persist any environment variables defined in the celery config
         for env_var in self._environment:
             if env_var in os.environ:
-                podman_cmd_base.append(f"-e {env_var}=${env_var}")
+                podman_cmd_base.append(f"-e {env_var}={os.environ.get(env_var)}")
             else:
                 logger.warning(f"{env_var} does not exist. Won't include in podman command.")
         # set the -u if set

--- a/hysds/containers/podman.py
+++ b/hysds/containers/podman.py
@@ -10,7 +10,9 @@ from hysds.log_utils import logger
 class Podman(Base):
     def __init__(self):
         super().__init__()
-        self.podman_sock = app.conf.get('PODMAN_SOCK', f"/run/user/{self._uid}/podman/podman.sock")
+        # Get the podman sock from the host environment. Otherwise, fallback to this default.
+        self._uid = os.environ.get("HOST_UID", self._uid)
+        self.podman_sock = f"/run/user/{self._uid}/podman/podman.sock"
 
         cfg = app.conf.get('PODMAN_CFG', {})
         self._environment = cfg.get("environment", {})

--- a/hysds/containers/podman.py
+++ b/hysds/containers/podman.py
@@ -10,7 +10,7 @@ from hysds.log_utils import logger
 class Podman(Base):
     def __init__(self):
         super().__init__()
-        self.podman_sock = f"/run/user/{self._uid}/podman/podman.sock"
+        self.podman_sock = app.conf.get('PODMAN_SOCK', f"/run/user/{self._uid}/podman/podman.sock")
 
         cfg = app.conf.get('PODMAN_CFG', {})
         self._environment = cfg.get("environment", {})

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1142,8 +1142,8 @@ def run_job(job, queue_when_finished=True):
                 root_work_dir,
                 job_dir,
                 runtime_options=dep_img.get("runtime_options", {}),
-                verdi_home=app.conf.get("VERDI_HOME", "/home/ops"),
-                host_verdi_home=os.environ.get("HOST_VERDI_HOME", "/home/ops")
+                verdi_home=app.conf.get("VERDI_HOME", "/root"),
+                host_verdi_home=os.environ.get("HOST_VERDI_HOME", "/home/ops"),
 
             )
 

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1125,8 +1125,7 @@ def run_job(job, queue_when_finished=True):
                 job_dir,
                 runtime_options=runtime_options,
                 verdi_home=app.conf.get("VERDI_HOME", "/home/ops"),
-                host_verdi_home=os.environ.get("HOST_VERDI_HOME", "/home/ops"),
-                volume_mounts=app.conf.get("CONTAINER_VOLUME_MOUNTS", {})
+                host_verdi_home=os.environ.get("HOST_VERDI_HOME", "/home/ops")
             )
 
             # get command-line list
@@ -1144,8 +1143,7 @@ def run_job(job, queue_when_finished=True):
                 job_dir,
                 runtime_options=dep_img.get("runtime_options", {}),
                 verdi_home=app.conf.get("VERDI_HOME", "/home/ops"),
-                host_verdi_home=os.environ.get("HOST_VERDI_HOME", "/home/ops"),
-                volume_mounts=app.conf.get("CONTAINER_VOLUME_MOUNTS", {})
+                host_verdi_home=os.environ.get("HOST_VERDI_HOME", "/home/ops")
 
             )
 

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1144,6 +1144,7 @@ def run_job(job, queue_when_finished=True):
                 runtime_options=dep_img.get("runtime_options", {}),
                 verdi_home=app.conf.get("VERDI_HOME", "/home/ops"),
                 host_verdi_home=os.environ.get("HOST_VERDI_HOME", "/home/ops"),
+
             )
 
         # TODO: Change to _container_params.json since we want to support

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1124,8 +1124,8 @@ def run_job(job, queue_when_finished=True):
                 root_work_dir,
                 job_dir,
                 runtime_options=runtime_options,
-                verdi_home=app.conf.get("VERDI_HOME", "/home/ops"),
-                host_verdi_home=os.environ.get("HOST_VERDI_HOME", "/home/ops")
+                verdi_home=app.conf.get("VERDI_HOME", "/root"),
+                host_verdi_home=os.environ.get("HOST_VERDI_HOME", "/home/ops"),
             )
 
             # get command-line list

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1126,6 +1126,7 @@ def run_job(job, queue_when_finished=True):
                 runtime_options=runtime_options,
                 verdi_home=app.conf.get("VERDI_HOME", "/home/ops"),
                 host_verdi_home=os.environ.get("HOST_VERDI_HOME", "/home/ops"),
+                volume_mounts=app.conf.get("CONTAINER_VOLUME_MOUNTS", {})
             )
 
             # get command-line list
@@ -1144,6 +1145,7 @@ def run_job(job, queue_when_finished=True):
                 runtime_options=dep_img.get("runtime_options", {}),
                 verdi_home=app.conf.get("VERDI_HOME", "/home/ops"),
                 host_verdi_home=os.environ.get("HOST_VERDI_HOME", "/home/ops"),
+                volume_mounts=app.conf.get("CONTAINER_VOLUME_MOUNTS", {})
 
             )
 

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1144,7 +1144,6 @@ def run_job(job, queue_when_finished=True):
                 runtime_options=dep_img.get("runtime_options", {}),
                 verdi_home=app.conf.get("VERDI_HOME", "/root"),
                 host_verdi_home=os.environ.get("HOST_VERDI_HOME", "/home/ops"),
-
             )
 
         # TODO: Change to _container_params.json since we want to support


### PR DESCRIPTION
This PR makes the following updates to support the latest container changes in moving away from having the Verdi container default to the OPS user. In addition, these updates/bug fixes are due to the latest testing efforts that were done within the HECC environment:

- The default `PODMAN_CFG` in the celeryconfig.py no longer sets the `--userns=keep-id` flag or the setting of the `-u` flag option by default. Therefore, `root` is the default user when running podman now, which means the host user in the podman world due to our rootless podman mode set up.
- `VERDI_HOME` defaults to `/root` now since the Verdi container now moves away from defaulting to an OPS user. `/root` is also now where the HySDS Core code resides in now.
- celeryconfig.py passes in the `HOST_USER` environment variable now because we need that in order to properly set the PODMAN user socket file now. This is due to the default user in podman being root now, where UID=0, but we start up the socket server with a socket file pertaining to the actual UID of the host. 
- When updating the volume source mounts, check if the beginning string matches the `verdi_home` argument instead of a general `if verdi_home in k`
- Fixed the code to default a missing `environment` area in `PODMAN_CFG` to a list instead of a dictionary.
- When persisting environment variables in the podman run command, use the actual environment variable value instead 


Housekeeping Update:
- Version was downgraded to 1.3.3 since PR https://github.com/hysds/hysds/pull/189 set it to this value already and that was the first commit since V5.2.1 release of HySDS Core

