### PR TITLE
HC-546: Update logstash to move a failed job over to a new job_failed index

### DIFF
--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -58,7 +58,6 @@ filter {
   if [resource] == "job" and [status] == "job-failed" {
     ruby {
       code => "
-         logger.info('Processing event for job-failed status: ' + event.get('payload_id').to_s);
          original_index = event.get('[job][job_info][index]');
          event.set('original_index', original_index)
          event.set('delete_document', 'true')
@@ -66,45 +65,10 @@ filter {
     }
     mutate {
       update_field => {
-        "[job][job_info][index]" => "job_failed-%{+YYYY.MM}"
+        "[job][job_info][index]" => "job_failed"
       }
     }
   }
-  #if [resource] == "job" {
-  # if [status] == "job-failed" and [job][job_info][index] =~ "^job_status-" {
-  #   ruby {
-  #     code => "
-  #       logger.info('Processing event for job-failed status);
-  #       logger.info('Resource: ' + event.get('resource').to_s);
-  #       logger.info('Status: ' + event.get('status').to_s);
-  #       original_index = event.get('[job][job_info][index]');
-  #       event.set('original_index', original_index)
-  #       event.set('delete_document', 'true')
-  #     "
-  #   }
-  #   mutate {
-  #     gsub => [
-  #       "[job][job_info][index]", "job_status-", "job_failed-"
-  #     ]
-  #   }
-  #  } else if [status] == "job-started" and [job][job_info][index] =~ "^job_failed-" {
-  #    ruby {
-  #      code => "
-  #        logger.info('Processing event for job queued/started status and it's in the job-failed index);
-  #        logger.info('Resource: ' + event.get('resource').to_s);
-  #        logger.info('Status: ' + event.get('status').to_s);
-  #        original_index = event.get('[job][job_info][index]');
-  #        event.set('original_index', original_index)
-  #        event.set('delete_document', 'true')
-  #      "
-  #    }
-  #    mutate {
-  #      gsub => [
-  #        "[job][job_info][index]", "job_failed-", "job_status-"
-  #      ]
-  #    }
-  #  }
-  #}
 }
 
 output {

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -65,9 +65,9 @@ filter {
        "
     }
     mutate {
-      gsub => [
-        "[job][job_info][index]", "job_status-", "job_failed-"
-      ]
+      update_field => {
+        "[job][job_info][index]" => "job_failed-%{+YYYY.MM}"
+      }
     }
   }
   #if [resource] == "job" {

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -46,6 +46,65 @@ filter {
       add_field => { "id" => "%{celery_hostname}" }
     }
   }
+
+  # Sets a flag to tell logstash to delete the original document
+  # if we move from job_status to job_failed
+  ruby {
+    code => "
+      event.set('delete_document', 'false')
+    "
+  }
+
+  if [resource] == "job" and [status] == "job-failed" {
+    ruby {
+      code => "
+         logger.info('Processing event for job-failed status: ' + event.get('payload_id').to_s);
+         original_index = event.get('[job][job_info][index]');
+         event.set('original_index', original_index)
+         event.set('delete_document', 'true')
+       "
+    }
+    mutate {
+      gsub => [
+        "[job][job_info][index]", "job_status-", "job_failed-"
+      ]
+    }
+  }
+  #if [resource] == "job" {
+  # if [status] == "job-failed" and [job][job_info][index] =~ "^job_status-" {
+  #   ruby {
+  #     code => "
+  #       logger.info('Processing event for job-failed status);
+  #       logger.info('Resource: ' + event.get('resource').to_s);
+  #       logger.info('Status: ' + event.get('status').to_s);
+  #       original_index = event.get('[job][job_info][index]');
+  #       event.set('original_index', original_index)
+  #       event.set('delete_document', 'true')
+  #     "
+  #   }
+  #   mutate {
+  #     gsub => [
+  #       "[job][job_info][index]", "job_status-", "job_failed-"
+  #     ]
+  #   }
+  #  } else if [status] == "job-started" and [job][job_info][index] =~ "^job_failed-" {
+  #    ruby {
+  #      code => "
+  #        logger.info('Processing event for job queued/started status and it's in the job-failed index);
+  #        logger.info('Resource: ' + event.get('resource').to_s);
+  #        logger.info('Status: ' + event.get('status').to_s);
+  #        original_index = event.get('[job][job_info][index]');
+  #        event.set('original_index', original_index)
+  #        event.set('delete_document', 'true')
+  #      "
+  #    }
+  #    mutate {
+  #      gsub => [
+  #        "[job][job_info][index]", "job_failed-", "job_status-"
+  #      ]
+  #    }
+  #  }
+  #}
 }
 
 output {
@@ -73,6 +132,31 @@ output {
       index => "%{[job][job_info][index]}"
       document_id => "%{payload_id}"
       ecs_compatibility => disabled
+    }
+    if [delete_document] == "true" {
+      {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
+        {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
+        hosts => [
+          {%- for url in MOZART_ES_PVT_IP %}
+            {%- if url.startswith('https://') %}
+              "{{ url }}"{{ "," if not loop.last else "" }}
+            {%- else %}
+            "{{ 'https://'~url if MOZART_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}"{{ "," if not loop.last else "" }}
+            {%- endif %}
+          {%- endfor %}
+        ]
+        {%- else %}
+          {%- if MOZART_ES_PVT_IP.startswith('https://') %}
+            hosts => ["{{ MOZART_ES_PVT_IP }}"]
+          {%- else %}
+            hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+          {%- endif %}
+        {%- endif %}
+        index => "%{[original_index]}"
+        document_id => "%{payload_id}"
+        action => "delete"
+        ecs_compatibility => disabled
+      }
     }
   } else if [resource] == "worker" {
     {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -64,7 +64,7 @@ filter {
        "
     }
     mutate {
-      update_field => {
+      replace => {
         "[job][job_info][index]" => "job_failed"
       }
     }


### PR DESCRIPTION
This PR is in conjunction with the following other PRs:

- sdscli: https://github.com/sdskit/sdscli/pull/109
- lightweight jobs: https://github.com/hysds/lightweight-jobs/pull/34

This PR updates the logstash configuration such that when it sees a failed job, it will make sure to move it from `job_status` to `job_failed`. Note that we don't want to introduce any rollover since the intent is to preserve this failed jobs for further analysis and put the onus on the end user to purge this failed jobs eventually.

**Testing**
See comments in https://hysds-core.atlassian.net/browse/HC-546