### PR TITLE
HC-556: Fix to make the auto-retrying of jobs work properly again

### DIFF
--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -71,20 +71,20 @@ filter {
     }
   }
 
-  if [resource] == "job" {
-    ruby {
-      code => "
-       current_time = Time.now.strftime('%Y-%m-%d %H:%M:%S.%N')
-       payload_id = event.get('payload_id').to_s
-       status = event.get('status').to_s
-       puts 'Processing job at ' + current_time + ': status=' + status + ', payload_id=' + payload_id
-     "
-    }
-  }
+  #if [resource] == "job" {
+  #  ruby {
+  #    code => "
+  #     current_time = Time.now.strftime('%Y-%m-%d %H:%M:%S.%N')
+  #     payload_id = event.get('payload_id').to_s
+  #     status = event.get('status').to_s
+  #     puts 'Processing job at ' + current_time + ': status=' + status + ', payload_id=' + payload_id
+  #   "
+  #  }
+  #}
 }
 
 output {
-  stdout { codec => rubydebug }
+  #stdout { codec => rubydebug }
 
   if [resource] == "job" {
     {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -63,14 +63,15 @@ filter {
          event.set('delete_document', 'true')
        "
     }
-
     mutate {
       replace => {
         "[job][job_info][index]" => "job_failed"
       }
     }
   }
-
+  # This block adds a debugging message to the logstash_indexer.log in case we need to analyze the
+  # arrival of the messages coming into it. Need to uncomment out the codec => rubydebug statement
+  # in the output area in order to see this message.
   #if [resource] == "job" {
   #  ruby {
   #    code => "

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -75,28 +75,6 @@ output {
   #stdout { codec => rubydebug }
 
   if [resource] == "job" {
-    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
-      {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
-      hosts => [
-        {%- for url in MOZART_ES_PVT_IP %}
-          {%- if url.startswith('https://') %}
-        "{{ url }}"{{ "," if not loop.last else "" }}
-          {%- else %}
-        "{{ 'https://'~url if MOZART_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}"{{ "," if not loop.last else "" }}
-          {%- endif %}
-        {%- endfor %}
-      ]
-      {%- else %}
-        {%- if MOZART_ES_PVT_IP.startswith('https://') %}
-      hosts => ["{{ MOZART_ES_PVT_IP }}"]
-        {%- else %}
-      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
-        {%- endif %}
-      {%- endif %}
-      index => "%{[job][job_info][index]}"
-      document_id => "%{payload_id}"
-      ecs_compatibility => disabled
-    }
     if [delete_document] == "true" {
       {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
         {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
@@ -121,6 +99,28 @@ output {
         action => "delete"
         ecs_compatibility => disabled
       }
+    }
+    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
+      {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
+      hosts => [
+        {%- for url in MOZART_ES_PVT_IP %}
+          {%- if url.startswith('https://') %}
+        "{{ url }}"{{ "," if not loop.last else "" }}
+          {%- else %}
+        "{{ 'https://'~url if MOZART_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}"{{ "," if not loop.last else "" }}
+          {%- endif %}
+        {%- endfor %}
+      ]
+      {%- else %}
+        {%- if MOZART_ES_PVT_IP.startswith('https://') %}
+      hosts => ["{{ MOZART_ES_PVT_IP }}"]
+        {%- else %}
+      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+        {%- endif %}
+      {%- endif %}
+      index => "%{[job][job_info][index]}"
+      document_id => "%{payload_id}"
+      ecs_compatibility => disabled
     }
   } else if [resource] == "worker" {
     {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -55,7 +55,7 @@ filter {
     "
   }
 
-  if [resource] == "job" and [status] == "job-failed" {
+  if [resource] == "job" and ([status] == "job-failed" or [status] == "job-revoked") {
     ruby {
       code => "
          original_index = event.get('[job][job_info][index]');

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -63,6 +63,14 @@ filter {
          event.set('delete_document', 'true')
        "
     }
+
+    ruby {
+    code => "
+       payload_id = event.get('payload_id')
+       status = event.get('status')
+       puts 'Processing job: status=#{status}, payload_id=#{payload_id}'
+    "
+    }
     mutate {
       replace => {
         "[job][job_info][index]" => "job_failed"
@@ -72,9 +80,39 @@ filter {
 }
 
 output {
-  #stdout { codec => rubydebug }
+  stdout { codec => rubydebug }
 
   if [resource] == "job" {
+    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
+      {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
+      hosts => [
+        {%- for url in MOZART_ES_PVT_IP %}
+          {%- if url.startswith('https://') %}
+        "{{ url }}"{{ "," if not loop.last else "" }}
+          {%- else %}
+        "{{ 'https://'~url if MOZART_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}"{{ "," if not loop.last else "" }}
+          {%- endif %}
+        {%- endfor %}
+      ]
+      {%- else %}
+        {%- if MOZART_ES_PVT_IP.startswith('https://') %}
+      hosts => ["{{ MOZART_ES_PVT_IP }}"]
+        {%- else %}
+      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
+        {%- endif %}
+      {%- endif %}
+      index => "%{[job][job_info][index]}"
+      document_id => "%{payload_id}"
+      ecs_compatibility => disabled
+    }
+    ruby {
+      code => "
+       index = event.get('[job][job_info][index]')
+       payload_id = event.get('payload_id')
+       status = event.get('status')
+       puts 'Updated record in job: status=#{status}, payload_id=#{payload_id}, index=#{index}'
+      "
+    }
     if [delete_document] == "true" {
       {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
         {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
@@ -100,27 +138,13 @@ output {
         ecs_compatibility => disabled
       }
     }
-    {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
-      {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
-      hosts => [
-        {%- for url in MOZART_ES_PVT_IP %}
-          {%- if url.startswith('https://') %}
-        "{{ url }}"{{ "," if not loop.last else "" }}
-          {%- else %}
-        "{{ 'https://'~url if MOZART_AWS_ES == true or 'es.amazonaws.com' in url else 'http://'~url~':9200' }}"{{ "," if not loop.last else "" }}
-          {%- endif %}
-        {%- endfor %}
-      ]
-      {%- else %}
-        {%- if MOZART_ES_PVT_IP.startswith('https://') %}
-      hosts => ["{{ MOZART_ES_PVT_IP }}"]
-        {%- else %}
-      hosts => ["{{ 'https://'~MOZART_ES_PVT_IP if MOZART_AWS_ES == true or 'es.amazonaws.com' in MOZART_ES_PVT_IP else 'http://'~MOZART_ES_PVT_IP~':9200' }}"]
-        {%- endif %}
-      {%- endif %}
-      index => "%{[job][job_info][index]}"
-      document_id => "%{payload_id}"
-      ecs_compatibility => disabled
+    ruby {
+      code => "
+       index = event.get('original_index')
+       payload_id = event.get('payload_id')
+       status = event.get('status')
+       puts 'Deleted record in job: status=#{status}, payload_id=#{payload_id}, index=#{index}'
+      "
     }
   } else if [resource] == "worker" {
     {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -55,7 +55,7 @@ filter {
     "
   }
 
-  if [resource] == "job" and ([status] == "job-failed" or [status] == "job-revoked") {
+  if [resource] == "job" and [status] == "job-failed" {
     ruby {
       code => "
          original_index = event.get('[job][job_info][index]');
@@ -64,17 +64,21 @@ filter {
        "
     }
 
-    ruby {
-    code => "
-       payload_id = event.get('payload_id')
-       status = event.get('status')
-       puts 'Processing job: status=#{status}, payload_id=#{payload_id}'
-    "
-    }
     mutate {
       replace => {
         "[job][job_info][index]" => "job_failed"
       }
+    }
+  }
+
+  if [resource] == "job" {
+    ruby {
+      code => "
+       current_time = Time.now.strftime('%Y-%m-%d %H:%M:%S.%N')
+       payload_id = event.get('payload_id').to_s
+       status = event.get('status').to_s
+       puts 'Processing job at ' + current_time + ': status=' + status + ', payload_id=' + payload_id
+     "
     }
   }
 }
@@ -105,14 +109,6 @@ output {
       document_id => "%{payload_id}"
       ecs_compatibility => disabled
     }
-    ruby {
-      code => "
-       index = event.get('[job][job_info][index]')
-       payload_id = event.get('payload_id')
-       status = event.get('status')
-       puts 'Updated record in job: status=#{status}, payload_id=#{payload_id}, index=#{index}'
-      "
-    }
     if [delete_document] == "true" {
       {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {
         {%- if MOZART_ES_PVT_IP is iterable and MOZART_ES_PVT_IP is not string %}
@@ -137,14 +133,6 @@ output {
         action => "delete"
         ecs_compatibility => disabled
       }
-    }
-    ruby {
-      code => "
-       index = event.get('original_index')
-       payload_id = event.get('payload_id')
-       status = event.get('status')
-       puts 'Deleted record in job: status=#{status}, payload_id=#{payload_id}, index=#{index}'
-      "
     }
   } else if [resource] == "worker" {
     {{ 'opensearch' if MOZART_ES_ENGINE == 'opensearch' else 'elasticsearch' }} {

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1507,7 +1507,7 @@ def run_job(job, queue_when_finished=True):
         if queue_when_finished is True:
             job_index = job.get("job_info", {}).get("index")
             if job_status_json["status"] == "job-failed":
-                job_index = f"{job_index},job_failed"
+                job_index = "job_failed"
             queue_finished_job(payload_id, index=job_index)
     except Exception as e:
         error = str(e)

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1506,6 +1506,8 @@ def run_job(job, queue_when_finished=True):
         # queue job finished for user rules processing
         if queue_when_finished is True:
             job_index = job.get("job_info", {}).get("index")
+            if job_status_json["status"] == "job-failed":
+                job_index = f"{job_index},job_failed"
             queue_finished_job(payload_id, index=job_index)
     except Exception as e:
         error = str(e)

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -93,10 +93,6 @@ def evaluate_user_rules_job(job_id, index=None):
     time.sleep(7)  # sleep 7 seconds to allow ES documents to be indexed
     ensure_job_indexed(job_id, JOB_STATUS_ALIAS)  # ensure job is indexed
 
-    # if index is set, append the new job_failed index to search on as well
-    if index:
-        index = f"{index},job_failed"
-
     # get all enabled user rules
     query = {
         "query": {

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -127,7 +127,7 @@ def evaluate_user_rules_job(job_id, index=None):
         # check for matching rules
         try:
             mozart_es = get_mozart_es()
-            result = mozart_es.es.search(index=index or JOB_STATUS_ALIAS, body=final_qs, ignore=404)
+            result = mozart_es.es.search(index=index or JOB_STATUS_ALIAS, body=final_qs)
             if result["hits"]["total"]["value"] == 0:
                 logger.info("Rule '%s' didn't match for %s" % (rule_name, job_id))
                 continue

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -91,7 +91,7 @@ def evaluate_user_rules_job(job_id, index=None):
     """
 
     time.sleep(7)  # sleep 7 seconds to allow ES documents to be indexed
-    ensure_job_indexed(job_id, JOB_STATUS_ALIAS)  # ensure job is indexed
+    ensure_job_indexed(job_id, index=index or JOB_STATUS_ALIAS)  # ensure job is indexed
 
     # get all enabled user rules
     query = {

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -91,7 +91,7 @@ def evaluate_user_rules_job(job_id, index=None):
     """
 
     time.sleep(7)  # sleep 7 seconds to allow ES documents to be indexed
-    ensure_job_indexed(job_id, index=index or JOB_STATUS_ALIAS)  # ensure job is indexed
+    ensure_job_indexed(job_id, alias=index or JOB_STATUS_ALIAS)  # ensure job is indexed
 
     # get all enabled user rules
     query = {

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -131,7 +131,7 @@ def evaluate_user_rules_job(job_id, index=None):
         # check for matching rules
         try:
             mozart_es = get_mozart_es()
-            result = mozart_es.es.search(index=index or JOB_STATUS_ALIAS, body=final_qs)
+            result = mozart_es.es.search(index=index or JOB_STATUS_ALIAS, body=final_qs, ignore=404)
             if result["hits"]["total"]["value"] == 0:
                 logger.info("Rule '%s' didn't match for %s" % (rule_name, job_id))
                 continue

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -141,7 +141,7 @@ def evaluate_user_rules_job(job_id, index=None):
 
         # If job is under the job_failed index, delete it
         if doc_res["_index"].startswith("job_failed"):
-            mozart_es.delete_by_id(index=index, id=job_id)
+            mozart_es.delete_by_id(index=doc_res["_index"], id=job_id)
 
         # submit trigger task
         queue_job_trigger(doc_res, rule)

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -93,6 +93,10 @@ def evaluate_user_rules_job(job_id, index=None):
     time.sleep(7)  # sleep 7 seconds to allow ES documents to be indexed
     ensure_job_indexed(job_id, JOB_STATUS_ALIAS)  # ensure job is indexed
 
+    # if index is set, append the new job_failed index to search on as well
+    if index:
+        index = f"{index},job_failed"
+
     # get all enabled user rules
     query = {
         "query": {
@@ -138,6 +142,10 @@ def evaluate_user_rules_job(job_id, index=None):
 
         doc_res = result["hits"]["hits"][0]
         logger.info("Rule '%s' successfully matched for %s" % (rule_name, job_id))
+
+        # If job is under the job_failed index, delete it
+        if doc_res["_index"].startswith("job_failed"):
+            mozart_es.delete_by_id(index=index, id=job_id)
 
         # submit trigger task
         queue_job_trigger(doc_res, rule)

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -139,10 +139,6 @@ def evaluate_user_rules_job(job_id, index=None):
         doc_res = result["hits"]["hits"][0]
         logger.info("Rule '%s' successfully matched for %s" % (rule_name, job_id))
 
-        # If job is under the job_failed index, delete it
-        if doc_res["_index"].startswith("job_failed"):
-            mozart_es.delete_by_id(index=doc_res["_index"], id=job_id)
-
         # submit trigger task
         queue_job_trigger(doc_res, rule)
         logger.info("Trigger task submitted for %s: %s" % (job_id, rule["job_type"]))

--- a/test/test_triage.py
+++ b/test/test_triage.py
@@ -481,4 +481,4 @@ class TestTriage(unittest.TestCase):
         self.assertTrue(os.path.exists(expected_triage_json_filename))
         self.assertTrue(os.path.exists(expected_triage_log_file1))
         self.assertFalse(os.path.exists(expected_triage_subdir1))
-        self.assertFalse(os.path.exists(expected_triage_subdir2))
+        self.assertTrue(os.path.exists(expected_triage_subdir2))


### PR DESCRIPTION
This PR fixes an issue to allow the auto-retrying of jobs, via the Figaro trigger rules, to work properly once again. Prior to queueing up the job for user rule evaluation, we should check to see if the status is job-failed and if so, set the index to job_failed when queuing up the job for user_rule_evaluation. This allows the user_rule_evaluation to work properly as it will now query for the job in the correct index rather than the specific job_status partitioned index at which it originated.

This PR is in conjunction with https://github.com/hysds/lightweight-jobs/pull/35

For testing, I ran a one-day reprocessing test on a cluster in SWOT and verified that all the auto-retries due to worker termination were retried successfully. Also verified that we did not have any lingering leftover revoked jobs:

![image](https://github.com/user-attachments/assets/88e0abed-bf33-4221-a1a9-9ac2d1d9e4fb)


**Housekeeping Update**

- Fix the pytest as it was failing.