### PR TITLE
HC-560: Enable SSL/TLS for gunicorn for Mozart and GRQ API endpoints

### DIFF
--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -65,7 +65,7 @@ PYMONITOREDRUNNER_CFG = {
 }
 
 MOZART_URL = "https://{{ MOZART_PVT_IP }}/mozart/"
-MOZART_REST_URL = "http://{{ MOZART_PVT_IP }}:8888/api/v0.1"
+MOZART_REST_URL = "https://{{ MOZART_PVT_IP }}:8888/api/v0.1"
 
 JOBS_ES_ENGINE = "{{ MOZART_ES_ENGINE or 'elasticsearch' }}"
 JOBS_AWS_ES = {{ MOZART_AWS_ES or False }}
@@ -95,9 +95,9 @@ STATUS_ALIAS = "job_status"
 
 TOSCA_URL = "https://{{ GRQ_PVT_IP }}/search/"
 GRQ_URL = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}"
-GRQ_REST_URL = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.1"
-GRQ_UPDATE_URL = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.1/grq/dataset/index"
-GRQ_UPDATE_URL_BULK = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.2/grq/dataset/index"
+GRQ_REST_URL = "https://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.1"
+GRQ_UPDATE_URL = "https://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.1/grq/dataset/index"
+GRQ_UPDATE_URL_BULK = "https://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.2/grq/dataset/index"
 
 GRQ_ES_ENGINE = "{{ GRQ_ES_ENGINE or 'elasticsearch' }}"
 GRQ_AWS_ES = {{ GRQ_AWS_ES or False }}

--- a/configs/supervisor/supervisord.conf.grq
+++ b/configs/supervisor/supervisord.conf.grq
@@ -25,6 +25,8 @@ serverurl=unix://%(here)s/../run/supervisor.sock
 [program:grq2]
 directory={{ OPS_HOME }}/sciflo/ops/grq2
 command=gunicorn -w4 -b 0.0.0.0:8878 -k gevent --log-level=debug
+        --keyfile=/etc/pki/tls/private/localhost.key
+        --certfile=/etc/pki/tls/certs/localhost.crt
         --limit-request-line=0 grq2:app
 process_name=%(program_name)s
 priority=1
@@ -52,6 +54,8 @@ startsecs=10
 [program:pele]
 directory={{ OPS_HOME }}/sciflo/ops/pele
 command=gunicorn -w4 -b 127.0.0.1:8877 -k gevent --timeout=3600
+        --keyfile=/etc/pki/tls/private/localhost.key
+        --certfile=/etc/pki/tls/certs/localhost.crt
         --graceful-timeout=3600 --log-level=debug
         --limit-request-line=0
         'pele:create_app("pele.settings.ProductionConfig")'

--- a/configs/supervisor/supervisord.conf.mozart
+++ b/configs/supervisor/supervisord.conf.mozart
@@ -121,6 +121,8 @@ startsecs=10
 [program:mozart_job_management]
 directory={{ OPS_HOME }}/mozart/ops/mozart
 command=gunicorn -w4 -b 0.0.0.0:8888 -k gevent --timeout=3600
+        --keyfile=/etc/pki/tls/private/localhost.key
+        --certfile=/etc/pki/tls/certs/localhost.crt
         --graceful-timeout=3600 --log-level=debug
         --limit-request-line=0 mozart:app
 process_name=%(program_name)s


### PR DESCRIPTION
This change requires updates to /etc/httpd/conf.d/00_mozart-ssl.conf which are managed by the SA team. Update http->https for Mozart/GRQ referenced endpoints in that config file