### PR TITLE
HC-565: Increase timeout thresholds in the RabbitMQ configuration file

### DIFF
--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -22,7 +22,8 @@ broker_heartbeat = 30
 broker_heartbeat_checkrate = 2
 
 broker_pool_limit = None
-broker_transport_options = { "confirm_publish": True }
+broker_transport_options = { "confirm_publish": True,  "read_timeout": 30, "write_timeout": 30}
+broker_connection_timeout = 30
 
 redis_socket_keepalive = True
 redis_backend_healh_check_interval = 30

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"


### PR DESCRIPTION
The RabbitMQ timeout thresholds were updated to 30 seconds from the default 4 second threshold. This update was shown to improve the performance, especially during heavy processing loads. See the screenshot of the before and after in https://hysds-core.atlassian.net/browse/HC-565

Kudos to @stirlingalgermissen for the great find.

