### PR TITLE
Merge develop into develop-dit

### DIFF
--- a/configs/celery/celeryconfig.py.tmpl
+++ b/configs/celery/celeryconfig.py.tmpl
@@ -133,7 +133,8 @@ PODMAN_CFG = {
   "environment": [
     "HOST_VERDI_HOME",
     "HOST_USER",
-    "HOST_UID"
+    "HOST_UID",
+    "HYSDS_ROOT_WORK_DIR"
   ]
 }
 
@@ -205,3 +206,7 @@ TRIAGE_PARTITION_FORMAT = {{ TRIAGE_PARTITION_FORMAT or None }}
 VERDI_HOME = "{{ VERDI_HOME or '/root' }}"
 
 VERDI_SHELL = "{{ VERDI_SHELL or '/bin/bash' }}"
+
+CACHE_READ_ONLY = {{ CACHE_READ_ONLY | default(true, boolean=False) }}
+
+EVICT_CACHE = {{ EVICT_CACHE | default(true, boolean=False) }}

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/containers/base.py
+++ b/hysds/containers/base.py
@@ -167,9 +167,14 @@ class Base(ABC):
                 (root_jobs_dir, root_jobs_dir),
                 (root_tasks_dir, root_tasks_dir),
                 (root_workers_dir, root_workers_dir),
-                (root_cache_dir, "{}:ro".format(root_cache_dir)),
             ],
         }
+
+        if app.conf.get("CACHE_READ_ONLY", True) is True:
+            params["volumes"].append((root_cache_dir, f"{root_cache_dir}:ro"))
+        else:
+            logger.info(f"CACHE_READ_ONLY set to false. Making it writable: {root_cache_dir}")
+            params["volumes"].append((root_cache_dir, f"{root_cache_dir}"))
 
         # add default image mappings
         celery_cfg_file = os.environ.get("HYSDS_CELERY_CFG", app.conf.__file__)

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -241,7 +241,12 @@ def cleanup(work_path, jobs_path, tasks_path, cache_path, threshold=10.0):
 
     # cleanup cached products if free disk space not met
     if percent_free <= threshold:
-        evict_localize_cache(work_path, cache_path, percent_free, threshold)
+        if app.conf.get("EVICT_CACHE", True) is True:
+            evict_localize_cache(work_path, cache_path, percent_free, threshold)
+        else:
+            logger.info(
+                f"EVICT_CACHE is set to false. Will not try to clean up the cache directory: {cache_path}"
+            )
 
     # log final disk stats
     capacity, free, used, percent_free = disk_space_info(work_path)

--- a/hysds/utils.py
+++ b/hysds/utils.py
@@ -120,18 +120,22 @@ def get_download_params(url):
     return params
 
 
-def download_file(url, path, cache=False):
+def download_file(url, path, cache=False, root_work_dir=None):
     """
     Download file/dir for input
     @param url: Str
     @param path: Str
     @param cache: Bool (default False) pull from cache
+    @param root_work_dir: Str Use a different root work dir for the cache
     """
 
     params = get_download_params(url)
     if cache:
         url_hash = hashlib.md5(url.encode()).hexdigest()
-        hash_dir = os.path.join(app.conf.ROOT_WORK_DIR, "cache", *url_hash[0:4])
+        if root_work_dir:
+            hash_dir = os.path.join(os.path.abspath(root_work_dir), "cache", *url_hash[0:4])
+        else:
+            hash_dir = os.path.join(os.environ.get("HYSDS_ROOT_WORK_DIR", app.conf.ROOT_WORK_DIR), "cache", *url_hash[0:4])
         cache_dir = os.path.join(hash_dir, url_hash)
         makedirs(cache_dir)
         signal_file = os.path.join(cache_dir, ".localized")

--- a/test/test_docker_container_utils.py
+++ b/test/test_docker_container_utils.py
@@ -70,6 +70,10 @@ class TestContainerUtils(unittest.TestCase):
                 return 0
             elif args[0] == "CONTAINER_REGISTRY":
                 return None
+            elif args[0] == "CACHE_READ_ONLY":
+                return True
+            elif args[0] == "EVICT_CACHE":
+                return True
             else:
                 raise RuntimeError("Handling {} not implemented yet.".format(args[0]))
 


### PR DESCRIPTION
… cache eviction; use HYSDS_ROOT_WORK_DIR for cache base (#201)

* HC-571: Add capability to set a custom cache base directory when downloading files

* Update name to be more clear

* update doc

* Add capability to make the cache dir read-write access

* Update

* Add capability to disable eviction of cache

* Add logging messages

* Make the default the HYSDS_ROOT_WORK_DIR directory, but fallback to the ROOT_WORK_DIR setting in celeryconfig

* persist HYSDS_ROOT_WORK_DIR

* update unit test

---------