### PR TITLE
HC-581: Resolve issue where job fails due to .running file not found

### DIFF
--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -1481,9 +1481,15 @@ def run_job(job, queue_when_finished=True):
     # close up job execution
     try:
         # transition running file to done file
-        os.rename(job_running_file, job_done_file)
-        with open(job_done_file, "w") as f:
-            f.write(f"{datetime_iso_naive()}Z\n")
+        if os.path.exists(job_running_file):
+            os.rename(job_running_file, job_done_file)
+            with open(job_done_file, "w") as f:
+                f.write(f"{datetime_iso_naive()}Z\n")
+        elif not os.path.exists(job_done_file):
+            # This case handles a race condition where the file was not created by this task
+            # and not by the revoked handler either. It's a fallback.
+            with open(job_done_file, "w") as f:
+                f.write(f"{datetime_iso_naive()}Z\n")
 
         # log job info metrics
         log_job_info(job)


### PR DESCRIPTION
This PR addresses a known race condition in the `job_worker.py` where a job could be revoked or fail after the .done file is created by the `task_revoked_handler`, but before the `os.rename` call in `run_job()` attempts to move the .running file.

The `os.rename(job_running_file, job_done_file)` call can throw an Errno 2 (No such file or directory) error because the .running file may no longer exist, having been handled by the revocation signal.

This change introduces a check to ensure that the os.rename operation is only attempted if the job_running_file exists. If it doesn't, it checks for the existence of the .done file to avoid any redundant operations. This makes the job completion logic more resilient to race conditions and ensures that the .done file is always properly created without causing an error.

Changes:

- Modified the job completion logic in run_job() to check for the existence of job_running_file before attempting to rename it.
- Added an elif condition to check if job_done_file already exists, which would be the case if the task_revoked_handler has already run.
- Included a fallback to create the job_done_file directly if neither the .running nor the .done file exists, ensuring the job status is correctly logged.

Testing:

- Ran a dev-e2e smoke test on SWOT PCM in order to vett this change and the jenkins job successfully passed:
<img width="1788" height="740" alt="image" src="https://github.com/user-attachments/assets/8ad10d2c-3cf1-470d-b7e5-217898be9d19" />
