### PR TITLE
HC-630: ARM64/Graviton workers fail to update job status in ElasticSearch due to cgroups v2 memory stats exceeding long type range

### DIFF
--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -121,6 +121,7 @@ filter {
       "
     }
   }
+}
 
 output {
   #stdout { codec => rubydebug }

--- a/configs/logstash/indexer.conf.mozart
+++ b/configs/logstash/indexer.conf.mozart
@@ -83,7 +83,44 @@ filter {
   #   "
   #  }
   #}
-}
+
+  # Sanitize ARM64/cgroups v2 memory stats that exceed ES long range
+  # ARM64 reports UINT64_MAX-based sentinel values for unlimited/disabled limits
+  if [resource] == "job" {
+    ruby {
+      code => "
+        max_long = 9223372036854775807
+
+        # Helper to recursively sanitize numeric fields
+        def sanitize_value(obj, max_val)
+          case obj
+          when Hash
+            obj.each do |key, value|
+              obj[key] = sanitize_value(value, max_val)
+            end
+          when Array
+            obj.map! { |item| sanitize_value(item, max_val) }
+          when Numeric
+            # If value exceeds max long, set to -1 (convention for unlimited)
+            obj > max_val ? -1 : obj
+          else
+            obj
+          end
+        end
+
+        # Sanitize usage_stats if present
+        usage_stats = event.get('[job][job_info][metrics][usage_stats]')
+        if usage_stats.is_a?(Array)
+          usage_stats.each do |stat|
+            if stat.is_a?(Hash) && stat['cgroups'].is_a?(Hash)
+              stat['cgroups'] = sanitize_value(stat['cgroups'], max_long)
+            end
+          end
+          event.set('[job][job_info][metrics][usage_stats]', usage_stats)
+        end
+      "
+    }
+  }
 
 output {
   #stdout { codec => rubydebug }

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "3.2.1"
+__version__ = "3.2.2"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"


### PR DESCRIPTION
This PR fixes an issue where jobs would fail to get their status updated properly due to an issue when publishing job metrics to logstash. Specifically, errors such as the following is seen in the logstash_indexer.log on Mozart:

```
fwd-bporeh/container-iems-sds_nisar-pcm-nsds-5222-arm64.tar.gz\"}", "localize_urls"=>[], "task_id"=>"d20a1173-e51f-4123-a367-f80a0332b742", "tag"=>"trigger-send_cnm_notify_msg_L0B_L_RRSD_non_engg", "retry_count"=>1}, "msg"=>["CNM-S generated\n"]}], :response=>{"index"=>{"_index"=>"job_status-2026.05.12", "_id"=>"d5ee49ef-1c21-44ba-b002-6b715eee1756",
 "status"=>400, "error"=>{"type"=>"mapper_parsing_exception", "reason"=>"failed to parse field [job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_only_usage.usage] of type [long] in document with id 'd5ee49ef-1c21-44ba-b002-6b715eee1756'. Preview of field's value: '18446744073709486080'", "caused_by"=>{"type"=>"i_o_exception", "reason"=>"Num
eric value (18446744073709486080) out of range of long (-9223372036854775808 - 9223372036854775807)\n at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 103886]"}}}}}
```

**Root Cause**
ARM64 Linux kernels with cgroups v2 report memory statistics using unsigned 64-bit sentinel values (e.g., 18446744073709486080 = UINT64_MAX - 65536) to indicate "unlimited" or "disabled" limits. ElasticSearch's long data type has a maximum value of 9223372036854775807 (signed 64-bit). When Logstash attempts to index these values, ElasticSearch rejects the document with a mapper_parsing_exception.

**Specific failing field:**

`job.job_info.metrics.usage_stats.cgroups.memory_stats.swap_only_usage.usage`

Error from Logstash:

```
[WARN] Could not index event to OpenSearch. 
{:status=>400, :error=>{"type"=>"mapper_parsing_exception", 

"reason"=>"Numeric value (18446744073709486080) out of range of long"}}
```

**Why This Only Affects ARM64**
x86_64 instances typically report cgroups memory stats with values within the signed long range (often 0 for disabled swap)

ARM64 instances with modern kernels use cgroups v2 by default, which reports different sentinel values for unlimited/disabled resources