### PR TITLE
HC-633: Remove fixed sleeps from user rules evaluation; batch rule queries via msearch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,12 @@ jobs:
           name: Test
           command: |
             source $HOME/verdi/bin/activate
+            # hysds_commons is not published to PyPI (the verdi venv carries a
+            # source install), so pip cannot resolve the hysds_commons version
+            # floor in setup.py from an index; pre-install it from the matching
+            # hysds_commons branch, falling back to develop.
+            pip install --upgrade "hysds_commons @ git+https://github.com/hysds/hysds_commons.git@${CIRCLE_BRANCH}" \
+              || pip install --upgrade "hysds_commons @ git+https://github.com/hysds/hysds_commons.git@develop"
             pip install -e .[test]
             pip install junitparser
             cp configs/celery/celeryconfig.py.tmpl celeryconfig.py

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "3.2.2"
+__version__ = "3.3.0"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/es_util.py
+++ b/hysds/es_util.py
@@ -35,8 +35,14 @@ def assert_doc_settled(es_util, index, doc_id, extra_must=None):
     search-visible or its searchable copy is stale. No fixed sleep, and no per-eval
     _refresh (which would flush a segment across all shards every ingest and cause
     refresh storms under a dense cascade); the realtime GET is single-shard and
-    translog-served. NOTE: with replicas, the rule query may hit a replica that
-    lags the GET'd primary -- route both to a consistent preference if that matters.
+    translog-served.
+
+    Shard routing: with replicas, search round-robins across copies, so this probe
+    and the caller's rule query could land on different copies -- this one settled,
+    that one a lagging replica -- and the rule would miss. So this probe pins
+    `preference=doc_id`; the caller MUST pass the same `preference=doc_id` on its
+    rule query so both bind to the same copy. (Opaque routing key: same string ->
+    same copy; spreads load across copies by doc, unlike `_primary`.)
     """
     must = [{"term": {"_id": doc_id}}]
     if extra_must:
@@ -46,7 +52,7 @@ def assert_doc_settled(es_util, index, doc_id, extra_must=None):
         "seq_no_primary_term": True,
         "size": 1,
     }
-    hits = es_util.search(index=index, body=body)["hits"]["hits"]
+    hits = es_util.search(index=index, body=body, preference=doc_id)["hits"]["hits"]
     if not hits:
         raise RuntimeError(f"doc not yet search-visible: {doc_id}")
     hit = hits[0]

--- a/hysds/es_util.py
+++ b/hysds/es_util.py
@@ -21,6 +21,48 @@ GRQ_ES = None
 METRICS_ES = None
 
 
+def assert_doc_settled(es_util, index, doc_id, extra_must=None):
+    """Confirm a doc's LATEST write is search-visible, not merely that it exists.
+
+    Search is refresh-bound, so a field UPDATE on a pre-existing doc (e.g. a
+    state-config's is_complete flipping false->true) can lag the trigger that
+    fired on that write. An _id existence check passes on the stale version and
+    the rule query then misses. So: realtime GET-by-id reads the translog
+    (refresh-independent) for the authoritative _seq_no, and we require the
+    searchable copy's _seq_no to be >= it before proceeding.
+
+    Raises (so the caller's exponential backoff retries) when the doc is not yet
+    search-visible or its searchable copy is stale. No fixed sleep, and no per-eval
+    _refresh (which would flush a segment across all shards every ingest and cause
+    refresh storms under a dense cascade); the realtime GET is single-shard and
+    translog-served. NOTE: with replicas, the rule query may hit a replica that
+    lags the GET'd primary -- route both to a consistent preference if that matters.
+    """
+    must = [{"term": {"_id": doc_id}}]
+    if extra_must:
+        must.extend(extra_must)
+    body = {
+        "query": {"bool": {"must": must}},
+        "seq_no_primary_term": True,
+        "size": 1,
+    }
+    hits = es_util.search(index=index, body=body)["hits"]["hits"]
+    if not hits:
+        raise RuntimeError(f"doc not yet search-visible: {doc_id}")
+    hit = hits[0]
+    searchable_seq_no = hit.get("_seq_no")
+    latest_seq_no = es_util.es.get(index=hit["_index"], id=doc_id).get("_seq_no")
+    if (
+        searchable_seq_no is not None
+        and latest_seq_no is not None
+        and searchable_seq_no < latest_seq_no
+    ):
+        raise RuntimeError(
+            f"doc search copy stale: {doc_id} seq_no {searchable_seq_no} < "
+            f"latest {latest_seq_no}; awaiting refresh"
+        )
+
+
 def get_mozart_es_engine():
     return app.conf.get("JOBS_ES_ENGINE", "elasticsearch")
 

--- a/hysds/user_rules_dataset.py
+++ b/hysds/user_rules_dataset.py
@@ -116,6 +116,28 @@ def search_es(index, body, preference):
     return grq_es.search(index=index, body=body, request_timeout=30, preference=preference)
 
 
+def _is_retryable_item_error(item):
+    """True when a per-item msearch error is worth re-running individually.
+    A 4xx other than 429 is deterministic (parse/validation error; retrying
+    cannot change the outcome); 429 (search thread pool rejection under load)
+    and 5xx are transient. A missing status degrades to retryable: the re-run
+    goes through search_es, whose backoff gives up fast on a genuine 400."""
+    status = item.get("status")
+    if isinstance(status, int) and 400 <= status < 500 and status != 429:
+        return False
+    return True
+
+
+def _fallback_search(header, body, preference):
+    """Run one rule's search individually (search_es retries transient errors
+    with bounded backoff and gives up on 400s); package a persistent failure
+    as a per-item style error so only that rule is skipped."""
+    try:
+        return search_es(index=header["index"], body=body, preference=preference)
+    except Exception as e:
+        return {"error": {"reason": str(e)}}
+
+
 def msearch_es(searches, preference):
     """
     Run all rule queries in one multi search request. A rule whose query is
@@ -124,6 +146,15 @@ def msearch_es(searches, preference):
     to issuing the searches individually in that case -- one bad rule must not
     block evaluation of the remaining rules.
 
+    Transient PER-ITEM errors (e.g. a 429 search-queue rejection under a dense
+    cascade, or a 5xx) are re-run individually through the same per-rule
+    fallback: batching removed the old per-rule retry, and a saturated search
+    queue would otherwise silently drop just that rule's trigger. Deterministic
+    400-class item errors stay terminal for their rule. search_es's bounded
+    backoff doubles as backpressure -- an overloaded cluster slows this
+    evaluator (one task per worker process) instead of receiving fresh
+    msearches.
+
     preference (the triggering objectid) routes every search here to the same
     shard copy the settled-probe checked, closing the replica-lag race (HC-633).
     It is set PER-SEARCH in each header line -- _msearch takes no `preference`
@@ -131,7 +162,7 @@ def msearch_es(searches, preference):
     """
     searches = [({**header, "preference": preference}, body) for header, body in searches]
     try:
-        return _msearch(searches)
+        responses = _msearch(searches)
     except Exception as e:
         if not _is_request_error(e):
             raise
@@ -139,13 +170,17 @@ def msearch_es(searches, preference):
             f"msearch rejected at request parse time ({e}); "
             "falling back to per-rule searches"
         )
-        responses = []
-        for header, body in searches:
-            try:
-                responses.append(search_es(index=header["index"], body=body, preference=preference))
-            except Exception as per_rule_error:
-                responses.append({"error": {"reason": str(per_rule_error)}})
-        return responses
+        return [_fallback_search(header, body, preference) for header, body in searches]
+
+    for i, response in enumerate(responses):
+        if response.get("error") and _is_retryable_item_error(response):
+            header, body = searches[i]
+            logger.warning(
+                f"msearch item error (status {response.get('status')}) is transient, "
+                f"retrying rule query individually: {json.dumps(response['error'])}"
+            )
+            responses[i] = _fallback_search(header, body, preference)
+    return responses
 
 
 def evaluate_user_rules_dataset(

--- a/hysds/user_rules_dataset.py
+++ b/hysds/user_rules_dataset.py
@@ -11,7 +11,7 @@ import opensearchpy.exceptions
 
 import hysds  # avoids cyclical import
 from hysds.celery import app
-from hysds.es_util import get_grq_es, get_mozart_es
+from hysds.es_util import assert_doc_settled, get_grq_es, get_mozart_es
 from hysds.log_utils import backoff_max_tries, backoff_max_value, logger
 from hysds.utils import validate_index_pattern
 
@@ -28,29 +28,26 @@ USER_RULES_DATASET_QUEUE = app.conf.USER_RULES_DATASET_QUEUE
     backoff.expo, Exception, max_tries=backoff_max_tries, max_value=backoff_max_value
 )
 def ensure_dataset_indexed(objectid, system_version, alias):
-    """Ensure dataset is indexed."""
-    query = {
-        "query": {
-            "bool": {
-                "must": [
-                    {"term": {"_id": objectid}},
-                    {"term": {"system_version.keyword": system_version}},
-                ]
-            }
-        }
-    }
+    """Ensure the dataset is indexed AND its latest write is search-visible.
 
-    logger.info(f"ensure_dataset_indexed query: {json.dumps(query)}")
+    A rule can be triggered by a field UPDATE on a pre-existing doc (e.g. a
+    cycle-state-config's is_complete flipping false->true). Search is refresh-bound,
+    so the updated value can lag the trigger; an _id existence check alone passes on
+    the stale version and the rule's filtered query then misses, dropping the
+    trigger. assert_doc_settled confirms the searchable copy has caught up to the
+    latest write (realtime GET for the authoritative _seq_no), bounded by the
+    existing exponential backoff -- no fixed sleep, no per-eval _refresh.
+    """
+    logger.info(f"ensure_dataset_indexed: {objectid} ({system_version})")
     try:
         grq_es = get_grq_es()
-        count = grq_es.get_count(index=alias, body=query)
-        if count == 0:
-            error_message = (
-                f"Failed to find indexed dataset: {objectid} ({system_version})"
-            )
-            logger.error(error_message)
-            raise RuntimeError(error_message)
-        logger.info(f"Found indexed dataset: {objectid} ({system_version})")
+        assert_doc_settled(
+            grq_es,
+            alias,
+            objectid,
+            extra_must=[{"term": {"system_version.keyword": system_version}}],
+        )
+        logger.info(f"Found settled indexed dataset: {objectid} ({system_version})")
     except (
         elasticsearch.exceptions.ElasticsearchException,
         opensearchpy.exceptions.OpenSearchException,

--- a/hysds/user_rules_dataset.py
+++ b/hysds/user_rules_dataset.py
@@ -80,14 +80,22 @@ def update_query(_id, system_version, rule):
 
 
 def _is_request_error(e):
-    """True if e is an elasticsearch/opensearchpy RequestError (HTTP 400).
+    """True if e is (or wraps) an elasticsearch/opensearchpy RequestError (HTTP 400).
     Query parse 400s are deterministic; retrying cannot change the outcome.
-    Resolved via isinstance per module so a stubbed-out client library (as in
-    unit test environments) degrades to False instead of breaking matching."""
-    for exceptions_module in (elasticsearch.exceptions, opensearchpy.exceptions):
-        cls = getattr(exceptions_module, "RequestError", None)
-        if isinstance(cls, type) and issubclass(cls, BaseException) and isinstance(e, cls):
-            return True
+
+    The hysds_commons jittered-backoff connection wrapper re-raises the original
+    client error as JitteredBackoffException chained via __cause__ (raise ... from e),
+    so the propagating exception is NOT the RequestError itself -- walk the cause
+    chain to find it. Resolved via isinstance per module so a stubbed-out client
+    library (as in unit test environments) degrades to False rather than breaking."""
+    seen = set()
+    while e is not None and id(e) not in seen:
+        seen.add(id(e))
+        for exceptions_module in (elasticsearch.exceptions, opensearchpy.exceptions):
+            cls = getattr(exceptions_module, "RequestError", None)
+            if isinstance(cls, type) and issubclass(cls, BaseException) and isinstance(e, cls):
+                return True
+        e = getattr(e, "__cause__", None) or getattr(e, "__context__", None)
     return False
 
 

--- a/hysds/user_rules_dataset.py
+++ b/hysds/user_rules_dataset.py
@@ -79,11 +79,63 @@ def update_query(_id, system_version, rule):
     return final_query
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=5, max_value=32)
-def msearch_es(searches):
+def _giveup_on_request_error(e):
+    """Query parse 400s are deterministic; retrying cannot change the outcome."""
+    return isinstance(
+        e,
+        (
+            elasticsearch.exceptions.RequestError,
+            opensearchpy.exceptions.RequestError,
+        ),
+    )
+
+
+@backoff.on_exception(
+    backoff.expo, Exception, max_tries=5, max_value=32, giveup=_giveup_on_request_error
+)
+def _msearch(searches):
     grq_es = get_grq_es()
     # Use wrapper method instead of direct ES call for closed index handling (HC-600)
     return grq_es.msearch(searches, request_timeout=30)
+
+
+@backoff.on_exception(
+    backoff.expo, Exception, max_tries=5, max_value=32, giveup=_giveup_on_request_error
+)
+def search_es(index, body):
+    grq_es = get_grq_es()
+    # Use wrapper method instead of direct ES call for closed index handling (HC-600)
+    return grq_es.search(index=index, body=body, request_timeout=30)
+
+
+def msearch_es(searches):
+    """
+    Run all rule queries in one multi search request. A rule whose query is
+    valid JSON but unparseable query DSL fails the WHOLE msearch request with
+    a 400 at request parse time rather than as a per-item error, so fall back
+    to issuing the searches individually in that case -- one bad rule must not
+    block evaluation of the remaining rules.
+    """
+    try:
+        return _msearch(searches)
+    except (
+        elasticsearch.exceptions.RequestError,
+        opensearchpy.exceptions.RequestError,
+    ) as e:
+        logger.error(
+            f"msearch rejected at request parse time ({e}); "
+            "falling back to per-rule searches"
+        )
+        responses = []
+        for header, body in searches:
+            try:
+                responses.append(search_es(index=header["index"], body=body))
+            except (
+                elasticsearch.exceptions.ElasticsearchException,
+                opensearchpy.exceptions.OpenSearchException,
+            ) as per_rule_error:
+                responses.append({"error": {"reason": str(per_rule_error)}})
+        return responses
 
 
 def evaluate_user_rules_dataset(

--- a/hysds/user_rules_dataset.py
+++ b/hysds/user_rules_dataset.py
@@ -4,7 +4,6 @@ standard_library.install_aliases()
 
 import json
 import socket
-import time
 
 import backoff
 import elasticsearch.exceptions
@@ -81,10 +80,10 @@ def update_query(_id, system_version, rule):
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=5, max_value=32)
-def search_es(index, body):
+def msearch_es(searches):
     grq_es = get_grq_es()
     # Use wrapper method instead of direct ES call for closed index handling (HC-600)
-    return grq_es.search(index=index, body=body, request_timeout=30)
+    return grq_es.msearch(searches, request_timeout=30)
 
 
 def evaluate_user_rules_dataset(
@@ -95,7 +94,6 @@ def evaluate_user_rules_dataset(
     If so, submit jobs. Otherwise do nothing.
     """
 
-    time.sleep(6)  # sleep for 10 seconds; let any documents finish indexing in ES
     ensure_dataset_indexed(objectid, system_version, alias)  # ensure dataset is indexed
 
     # get all enabled user rules
@@ -104,9 +102,10 @@ def evaluate_user_rules_dataset(
     rules = mozart_es.query(index=USER_RULES_DATASET_INDEX, body=query)
     logger.info(f"Total {len(rules)} enabled rules to check.")
 
+    # build a single multi search request with one search per rule
+    candidates = []
+    searches = []
     for document in rules:
-        time.sleep(1)  # sleep between queries
-
         rule = document["_source"]
         logger.info(f"rule: {json.dumps(rule, indent=2)}")
 
@@ -119,8 +118,6 @@ def evaluate_user_rules_dataset(
             logger.error(e)
             continue
 
-        rule_name = rule["rule_name"]
-        job_type = rule["job_type"]  # set clean descriptive job name
         final_qs = rule["query_string"]
 
         index_pattern = rule.get("index_pattern", "")
@@ -134,26 +131,39 @@ def evaluate_user_rules_dataset(
             index_pattern = DATASET_ALIAS
         logger.info(f"updated query: {json.dumps(final_qs, indent=2)}")
 
-        # check for matching rules
-        try:
-            result = search_es(index=index_pattern, body=final_qs)
-            if result["hits"]["total"]["value"] == 0:
-                logger.info(
-                    f"Rule '{rule_name}' didn't match for {objectid} ({system_version})"
-                )
-                continue
-            doc_res = result["hits"]["hits"][0]
-            logger.info(
-                f"Rule '{rule_name}' successfully matched for {objectid} ({system_version})"
+        searches.append(({"index": index_pattern}, {**updated_query, "size": 1}))
+        candidates.append(rule)
+
+    if not searches:
+        return True
+
+    # check all rules for matches in a single round trip
+    responses = msearch_es(searches)
+
+    matched = []
+    errored = []
+    for rule, result in zip(candidates, responses):
+        rule_name = rule["rule_name"]
+
+        if result.get("error"):
+            logger.error(
+                f"Rule '{rule_name}' query failed for {objectid} ({system_version}): "
+                f"{json.dumps(result['error'])}"
             )
-        except (
-            elasticsearch.exceptions.ElasticsearchException,
-            opensearchpy.exceptions.OpenSearchException,
-        ) as e:
-            logger.error("Failed to query ES")
-            logger.error(e)
+            errored.append(rule_name)
             continue
 
+        if result["hits"]["total"]["value"] == 0:
+            logger.info(
+                f"Rule '{rule_name}' didn't match for {objectid} ({system_version})"
+            )
+            continue
+        doc_res = result["hits"]["hits"][0]
+        logger.info(
+            f"Rule '{rule_name}' successfully matched for {objectid} ({system_version})"
+        )
+
+        job_type = rule["job_type"]  # set clean descriptive job name
         if job_type.startswith("hysds-io-"):
             job_type = job_type.replace("hysds-io-", "", 1)
         job_name = f"{job_type}-{objectid}"
@@ -162,6 +172,12 @@ def evaluate_user_rules_dataset(
         logger.info(
             f"Trigger task submitted for {objectid} ({system_version}): {job_type}"
         )
+        matched.append(rule_name)
+
+    logger.info(
+        f"Evaluated {len(candidates)} rules for {objectid} ({system_version}): "
+        f"matched={matched} errored={errored}"
+    )
     return True
 
 

--- a/hysds/user_rules_dataset.py
+++ b/hysds/user_rules_dataset.py
@@ -99,12 +99,12 @@ def _is_request_error(e):
 @backoff.on_exception(
     backoff.expo, Exception, max_tries=5, max_value=32, giveup=_is_request_error
 )
-def _msearch(searches, preference):
+def _msearch(searches):
     grq_es = get_grq_es()
     # Use wrapper method instead of direct ES call for closed index handling (HC-600).
-    # preference=objectid pins this to the SAME shard copy ensure_dataset_indexed's
-    # settled-probe validated, so we never query a lagging replica (HC-633).
-    return grq_es.msearch(searches, request_timeout=30, preference=preference)
+    # NOTE: msearch() takes NO `preference` kwarg (raises TypeError); the per-search
+    # routing preference is set in each header line by msearch_es (HC-633).
+    return grq_es.msearch(searches, request_timeout=30)
 
 
 @backoff.on_exception(
@@ -126,9 +126,12 @@ def msearch_es(searches, preference):
 
     preference (the triggering objectid) routes every search here to the same
     shard copy the settled-probe checked, closing the replica-lag race (HC-633).
+    It is set PER-SEARCH in each header line -- _msearch takes no `preference`
+    kwarg, and a URL-level preference is ignored by the _msearch endpoint.
     """
+    searches = [({**header, "preference": preference}, body) for header, body in searches]
     try:
-        return _msearch(searches, preference)
+        return _msearch(searches)
     except Exception as e:
         if not _is_request_error(e):
             raise

--- a/hysds/user_rules_dataset.py
+++ b/hysds/user_rules_dataset.py
@@ -79,19 +79,20 @@ def update_query(_id, system_version, rule):
     return final_query
 
 
-def _giveup_on_request_error(e):
-    """Query parse 400s are deterministic; retrying cannot change the outcome."""
-    return isinstance(
-        e,
-        (
-            elasticsearch.exceptions.RequestError,
-            opensearchpy.exceptions.RequestError,
-        ),
-    )
+def _is_request_error(e):
+    """True if e is an elasticsearch/opensearchpy RequestError (HTTP 400).
+    Query parse 400s are deterministic; retrying cannot change the outcome.
+    Resolved via isinstance per module so a stubbed-out client library (as in
+    unit test environments) degrades to False instead of breaking matching."""
+    for exceptions_module in (elasticsearch.exceptions, opensearchpy.exceptions):
+        cls = getattr(exceptions_module, "RequestError", None)
+        if isinstance(cls, type) and issubclass(cls, BaseException) and isinstance(e, cls):
+            return True
+    return False
 
 
 @backoff.on_exception(
-    backoff.expo, Exception, max_tries=5, max_value=32, giveup=_giveup_on_request_error
+    backoff.expo, Exception, max_tries=5, max_value=32, giveup=_is_request_error
 )
 def _msearch(searches):
     grq_es = get_grq_es()
@@ -100,7 +101,7 @@ def _msearch(searches):
 
 
 @backoff.on_exception(
-    backoff.expo, Exception, max_tries=5, max_value=32, giveup=_giveup_on_request_error
+    backoff.expo, Exception, max_tries=5, max_value=32, giveup=_is_request_error
 )
 def search_es(index, body):
     grq_es = get_grq_es()
@@ -118,10 +119,9 @@ def msearch_es(searches):
     """
     try:
         return _msearch(searches)
-    except (
-        elasticsearch.exceptions.RequestError,
-        opensearchpy.exceptions.RequestError,
-    ) as e:
+    except Exception as e:
+        if not _is_request_error(e):
+            raise
         logger.error(
             f"msearch rejected at request parse time ({e}); "
             "falling back to per-rule searches"
@@ -130,10 +130,7 @@ def msearch_es(searches):
         for header, body in searches:
             try:
                 responses.append(search_es(index=header["index"], body=body))
-            except (
-                elasticsearch.exceptions.ElasticsearchException,
-                opensearchpy.exceptions.OpenSearchException,
-            ) as per_rule_error:
+            except Exception as per_rule_error:
                 responses.append({"error": {"reason": str(per_rule_error)}})
         return responses
 

--- a/hysds/user_rules_dataset.py
+++ b/hysds/user_rules_dataset.py
@@ -99,31 +99,36 @@ def _is_request_error(e):
 @backoff.on_exception(
     backoff.expo, Exception, max_tries=5, max_value=32, giveup=_is_request_error
 )
-def _msearch(searches):
+def _msearch(searches, preference):
     grq_es = get_grq_es()
-    # Use wrapper method instead of direct ES call for closed index handling (HC-600)
-    return grq_es.msearch(searches, request_timeout=30)
+    # Use wrapper method instead of direct ES call for closed index handling (HC-600).
+    # preference=objectid pins this to the SAME shard copy ensure_dataset_indexed's
+    # settled-probe validated, so we never query a lagging replica (HC-633).
+    return grq_es.msearch(searches, request_timeout=30, preference=preference)
 
 
 @backoff.on_exception(
     backoff.expo, Exception, max_tries=5, max_value=32, giveup=_is_request_error
 )
-def search_es(index, body):
+def search_es(index, body, preference):
     grq_es = get_grq_es()
     # Use wrapper method instead of direct ES call for closed index handling (HC-600)
-    return grq_es.search(index=index, body=body, request_timeout=30)
+    return grq_es.search(index=index, body=body, request_timeout=30, preference=preference)
 
 
-def msearch_es(searches):
+def msearch_es(searches, preference):
     """
     Run all rule queries in one multi search request. A rule whose query is
     valid JSON but unparseable query DSL fails the WHOLE msearch request with
     a 400 at request parse time rather than as a per-item error, so fall back
     to issuing the searches individually in that case -- one bad rule must not
     block evaluation of the remaining rules.
+
+    preference (the triggering objectid) routes every search here to the same
+    shard copy the settled-probe checked, closing the replica-lag race (HC-633).
     """
     try:
-        return _msearch(searches)
+        return _msearch(searches, preference)
     except Exception as e:
         if not _is_request_error(e):
             raise
@@ -134,7 +139,7 @@ def msearch_es(searches):
         responses = []
         for header, body in searches:
             try:
-                responses.append(search_es(index=header["index"], body=body))
+                responses.append(search_es(index=header["index"], body=body, preference=preference))
             except Exception as per_rule_error:
                 responses.append({"error": {"reason": str(per_rule_error)}})
         return responses
@@ -191,8 +196,9 @@ def evaluate_user_rules_dataset(
     if not searches:
         return True
 
-    # check all rules for matches in a single round trip
-    responses = msearch_es(searches)
+    # check all rules for matches in a single round trip; preference=objectid pins
+    # the same shard copy ensure_dataset_indexed validated (HC-633 replica-lag fix)
+    responses = msearch_es(searches, objectid)
 
     matched = []
     errored = []

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -121,31 +121,36 @@ def _is_request_error(e):
 @backoff.on_exception(
     backoff.expo, Exception, max_tries=5, max_value=32, giveup=_is_request_error
 )
-def _msearch(searches):
+def _msearch(searches, preference):
     mozart_es = get_mozart_es()
-    # Use wrapper method instead of direct ES call for closed index handling (HC-600)
-    return mozart_es.msearch(searches, request_timeout=30)
+    # Use wrapper method instead of direct ES call for closed index handling (HC-600).
+    # preference=job_id pins this to the SAME shard copy ensure_job_indexed's
+    # settled-probe validated, so we never query a lagging replica (HC-633).
+    return mozart_es.msearch(searches, request_timeout=30, preference=preference)
 
 
 @backoff.on_exception(
     backoff.expo, Exception, max_tries=5, max_value=32, giveup=_is_request_error
 )
-def search_es(index, body):
+def search_es(index, body, preference):
     mozart_es = get_mozart_es()
     # Use wrapper method instead of direct ES call for closed index handling (HC-600)
-    return mozart_es.search(index=index, body=body, request_timeout=30)
+    return mozart_es.search(index=index, body=body, request_timeout=30, preference=preference)
 
 
-def msearch_es(searches):
+def msearch_es(searches, preference):
     """
     Run all rule queries in one multi search request. A rule whose query is
     valid JSON but unparseable query DSL fails the WHOLE msearch request with
     a 400 at request parse time rather than as a per-item error, so fall back
     to issuing the searches individually in that case -- one bad rule must not
     block evaluation of the remaining rules.
+
+    preference (the triggering job_id) routes every search here to the same shard
+    copy the settled-probe checked, closing the replica-lag race (HC-633).
     """
     try:
-        return _msearch(searches)
+        return _msearch(searches, preference)
     except Exception as e:
         if not _is_request_error(e):
             raise
@@ -156,7 +161,7 @@ def msearch_es(searches):
         responses = []
         for header, body in searches:
             try:
-                responses.append(search_es(index=header["index"], body=body))
+                responses.append(search_es(index=header["index"], body=body, preference=preference))
             except Exception as per_rule_error:
                 responses.append({"error": {"reason": str(per_rule_error)}})
         return responses
@@ -203,8 +208,9 @@ def evaluate_user_rules_job(job_id, index=None):
     if not searches:
         return True
 
-    # check all rules for matches in a single round trip
-    responses = msearch_es(searches)
+    # check all rules for matches in a single round trip; preference=job_id pins
+    # the same shard copy ensure_job_indexed validated (HC-633 replica-lag fix)
+    responses = msearch_es(searches, job_id)
 
     matched = []
     errored = []

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -138,6 +138,28 @@ def search_es(index, body, preference):
     return mozart_es.search(index=index, body=body, request_timeout=30, preference=preference)
 
 
+def _is_retryable_item_error(item):
+    """True when a per-item msearch error is worth re-running individually.
+    A 4xx other than 429 is deterministic (parse/validation error; retrying
+    cannot change the outcome); 429 (search thread pool rejection under load)
+    and 5xx are transient. A missing status degrades to retryable: the re-run
+    goes through search_es, whose backoff gives up fast on a genuine 400."""
+    status = item.get("status")
+    if isinstance(status, int) and 400 <= status < 500 and status != 429:
+        return False
+    return True
+
+
+def _fallback_search(header, body, preference):
+    """Run one rule's search individually (search_es retries transient errors
+    with bounded backoff and gives up on 400s); package a persistent failure
+    as a per-item style error so only that rule is skipped."""
+    try:
+        return search_es(index=header["index"], body=body, preference=preference)
+    except Exception as e:
+        return {"error": {"reason": str(e)}}
+
+
 def msearch_es(searches, preference):
     """
     Run all rule queries in one multi search request. A rule whose query is
@@ -146,6 +168,15 @@ def msearch_es(searches, preference):
     to issuing the searches individually in that case -- one bad rule must not
     block evaluation of the remaining rules.
 
+    Transient PER-ITEM errors (e.g. a 429 search-queue rejection under a dense
+    cascade, or a 5xx) are re-run individually through the same per-rule
+    fallback: batching removed the old per-rule retry, and a saturated search
+    queue would otherwise silently drop just that rule's trigger. Deterministic
+    400-class item errors stay terminal for their rule. search_es's bounded
+    backoff doubles as backpressure -- an overloaded cluster slows this
+    evaluator (one task per worker process) instead of receiving fresh
+    msearches.
+
     preference (the triggering job_id) routes every search here to the same shard
     copy the settled-probe checked, closing the replica-lag race (HC-633). It is
     set PER-SEARCH in each header line -- _msearch takes no `preference` kwarg, and
@@ -153,7 +184,7 @@ def msearch_es(searches, preference):
     """
     searches = [({**header, "preference": preference}, body) for header, body in searches]
     try:
-        return _msearch(searches)
+        responses = _msearch(searches)
     except Exception as e:
         if not _is_request_error(e):
             raise
@@ -161,13 +192,17 @@ def msearch_es(searches, preference):
             f"msearch rejected at request parse time ({e}); "
             "falling back to per-rule searches"
         )
-        responses = []
-        for header, body in searches:
-            try:
-                responses.append(search_es(index=header["index"], body=body, preference=preference))
-            except Exception as per_rule_error:
-                responses.append({"error": {"reason": str(per_rule_error)}})
-        return responses
+        return [_fallback_search(header, body, preference) for header, body in searches]
+
+    for i, response in enumerate(responses):
+        if response.get("error") and _is_retryable_item_error(response):
+            header, body = searches[i]
+            logger.warning(
+                f"msearch item error (status {response.get('status')}) is transient, "
+                f"retrying rule query individually: {json.dumps(response['error'])}"
+            )
+            responses[i] = _fallback_search(header, body, preference)
+    return responses
 
 
 def evaluate_user_rules_job(job_id, index=None):

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -94,19 +94,20 @@ def update_query(job_id, rule):
     return final_query
 
 
-def _giveup_on_request_error(e):
-    """Query parse 400s are deterministic; retrying cannot change the outcome."""
-    return isinstance(
-        e,
-        (
-            elasticsearch.exceptions.RequestError,
-            opensearchpy.exceptions.RequestError,
-        ),
-    )
+def _is_request_error(e):
+    """True if e is an elasticsearch/opensearchpy RequestError (HTTP 400).
+    Query parse 400s are deterministic; retrying cannot change the outcome.
+    Resolved via isinstance per module so a stubbed-out client library (as in
+    unit test environments) degrades to False instead of breaking matching."""
+    for exceptions_module in (elasticsearch.exceptions, opensearchpy.exceptions):
+        cls = getattr(exceptions_module, "RequestError", None)
+        if isinstance(cls, type) and issubclass(cls, BaseException) and isinstance(e, cls):
+            return True
+    return False
 
 
 @backoff.on_exception(
-    backoff.expo, Exception, max_tries=5, max_value=32, giveup=_giveup_on_request_error
+    backoff.expo, Exception, max_tries=5, max_value=32, giveup=_is_request_error
 )
 def _msearch(searches):
     mozart_es = get_mozart_es()
@@ -115,7 +116,7 @@ def _msearch(searches):
 
 
 @backoff.on_exception(
-    backoff.expo, Exception, max_tries=5, max_value=32, giveup=_giveup_on_request_error
+    backoff.expo, Exception, max_tries=5, max_value=32, giveup=_is_request_error
 )
 def search_es(index, body):
     mozart_es = get_mozart_es()
@@ -133,10 +134,9 @@ def msearch_es(searches):
     """
     try:
         return _msearch(searches)
-    except (
-        elasticsearch.exceptions.RequestError,
-        opensearchpy.exceptions.RequestError,
-    ) as e:
+    except Exception as e:
+        if not _is_request_error(e):
+            raise
         logger.error(
             f"msearch rejected at request parse time ({e}); "
             "falling back to per-rule searches"
@@ -145,10 +145,7 @@ def msearch_es(searches):
         for header, body in searches:
             try:
                 responses.append(search_es(index=header["index"], body=body))
-            except (
-                elasticsearch.exceptions.ElasticsearchException,
-                opensearchpy.exceptions.OpenSearchException,
-            ) as per_rule_error:
+            except Exception as per_rule_error:
                 responses.append({"error": {"reason": str(per_rule_error)}})
         return responses
 

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -121,12 +121,12 @@ def _is_request_error(e):
 @backoff.on_exception(
     backoff.expo, Exception, max_tries=5, max_value=32, giveup=_is_request_error
 )
-def _msearch(searches, preference):
+def _msearch(searches):
     mozart_es = get_mozart_es()
     # Use wrapper method instead of direct ES call for closed index handling (HC-600).
-    # preference=job_id pins this to the SAME shard copy ensure_job_indexed's
-    # settled-probe validated, so we never query a lagging replica (HC-633).
-    return mozart_es.msearch(searches, request_timeout=30, preference=preference)
+    # NOTE: msearch() takes NO `preference` kwarg (raises TypeError); the per-search
+    # routing preference is set in each header line by msearch_es (HC-633).
+    return mozart_es.msearch(searches, request_timeout=30)
 
 
 @backoff.on_exception(
@@ -147,10 +147,13 @@ def msearch_es(searches, preference):
     block evaluation of the remaining rules.
 
     preference (the triggering job_id) routes every search here to the same shard
-    copy the settled-probe checked, closing the replica-lag race (HC-633).
+    copy the settled-probe checked, closing the replica-lag race (HC-633). It is
+    set PER-SEARCH in each header line -- _msearch takes no `preference` kwarg, and
+    a URL-level preference is ignored by the _msearch endpoint.
     """
+    searches = [({**header, "preference": preference}, body) for header, body in searches]
     try:
-        return _msearch(searches, preference)
+        return _msearch(searches)
     except Exception as e:
         if not _is_request_error(e):
             raise

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -4,11 +4,8 @@ standard_library.install_aliases()
 
 import json
 import socket
-import time
 
 import backoff
-import elasticsearch.exceptions
-import opensearchpy.exceptions
 
 import hysds  # avoids cyclical import
 from hysds.celery import app
@@ -95,13 +92,19 @@ def update_query(job_id, rule):
     return final_query
 
 
+@backoff.on_exception(backoff.expo, Exception, max_tries=5, max_value=32)
+def msearch_es(searches):
+    mozart_es = get_mozart_es()
+    # Use wrapper method instead of direct ES call for closed index handling (HC-600)
+    return mozart_es.msearch(searches, request_timeout=30)
+
+
 def evaluate_user_rules_job(job_id, index=None):
     """
     Process all user rules in ES database and check if this job ID matches.
     If so, submit jobs. Otherwise do nothing.
     """
 
-    time.sleep(7)  # sleep 7 seconds to allow ES documents to be indexed
     ensure_job_indexed(job_id, alias=index or JOB_STATUS_ALIAS)  # ensure job is indexed
 
     # get all enabled user rules
@@ -110,9 +113,10 @@ def evaluate_user_rules_job(job_id, index=None):
     rules = mozart_es.query(index=USER_RULES_JOB_INDEX, body=query)
     logger.info(f"Total {len(rules)} enabled rules to check.")
 
+    # build a single multi search request with one search per rule
+    candidates = []
+    searches = []
     for rule in rules:
-        time.sleep(1)  # sleep between queries
-
         rule = rule["_source"]  # extracting _source from the rule itself
         logger.info(f"rule: {json.dumps(rule, indent=2)}")
 
@@ -125,24 +129,35 @@ def evaluate_user_rules_job(job_id, index=None):
             logger.error(e)
             continue
 
-        rule_name = rule["rule_name"]
         final_qs = rule["query_string"]
         logger.info(f"updated query: {json.dumps(final_qs, indent=2)}")
 
-        # check for matching rules
-        try:
-            mozart_es = get_mozart_es()
-            # Use wrapper method instead of direct ES call for closed index handling (HC-600)
-            result = mozart_es.search(index=index or JOB_STATUS_ALIAS, body=final_qs)
-            if result["hits"]["total"]["value"] == 0:
-                logger.info(f"Rule '{rule_name}' didn't match for {job_id}")
-                continue
-        except (
-            elasticsearch.exceptions.ElasticsearchException,
-            opensearchpy.exceptions.OpenSearchException,
-        ) as e:
-            logger.error("Failed to query ES")
-            logger.error(e)
+        searches.append(
+            ({"index": index or JOB_STATUS_ALIAS}, {**updated_query, "size": 1})
+        )
+        candidates.append(rule)
+
+    if not searches:
+        return True
+
+    # check all rules for matches in a single round trip
+    responses = msearch_es(searches)
+
+    matched = []
+    errored = []
+    for rule, result in zip(candidates, responses):
+        rule_name = rule["rule_name"]
+
+        if result.get("error"):
+            logger.error(
+                f"Rule '{rule_name}' query failed for {job_id}: "
+                f"{json.dumps(result['error'])}"
+            )
+            errored.append(rule_name)
+            continue
+
+        if result["hits"]["total"]["value"] == 0:
+            logger.info(f"Rule '{rule_name}' didn't match for {job_id}")
             continue
 
         doc_res = result["hits"]["hits"][0]
@@ -152,7 +167,7 @@ def evaluate_user_rules_job(job_id, index=None):
         job_type = rule.get("job_type", "")
         if job_type.startswith("hysds-io-"):
             job_type = job_type.replace("hysds-io-", "", 1)
-        
+
         # Check if we should persist the original job's name
         job_name_path = rule.get("job_name_path", "")
         if job_name_path:
@@ -170,6 +185,12 @@ def evaluate_user_rules_job(job_id, index=None):
         # submit trigger task
         queue_job_trigger(doc_res, rule, job_name)
         logger.info(f"Trigger task submitted for {job_id}: {rule['job_type']}")
+        matched.append(rule_name)
+
+    logger.info(
+        f"Evaluated {len(candidates)} rules for {job_id}: "
+        f"matched={matched} errored={errored}"
+    )
     return True
 
 

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -6,6 +6,8 @@ import json
 import socket
 
 import backoff
+import elasticsearch.exceptions
+import opensearchpy.exceptions
 
 import hysds  # avoids cyclical import
 from hysds.celery import app
@@ -92,11 +94,63 @@ def update_query(job_id, rule):
     return final_query
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=5, max_value=32)
-def msearch_es(searches):
+def _giveup_on_request_error(e):
+    """Query parse 400s are deterministic; retrying cannot change the outcome."""
+    return isinstance(
+        e,
+        (
+            elasticsearch.exceptions.RequestError,
+            opensearchpy.exceptions.RequestError,
+        ),
+    )
+
+
+@backoff.on_exception(
+    backoff.expo, Exception, max_tries=5, max_value=32, giveup=_giveup_on_request_error
+)
+def _msearch(searches):
     mozart_es = get_mozart_es()
     # Use wrapper method instead of direct ES call for closed index handling (HC-600)
     return mozart_es.msearch(searches, request_timeout=30)
+
+
+@backoff.on_exception(
+    backoff.expo, Exception, max_tries=5, max_value=32, giveup=_giveup_on_request_error
+)
+def search_es(index, body):
+    mozart_es = get_mozart_es()
+    # Use wrapper method instead of direct ES call for closed index handling (HC-600)
+    return mozart_es.search(index=index, body=body, request_timeout=30)
+
+
+def msearch_es(searches):
+    """
+    Run all rule queries in one multi search request. A rule whose query is
+    valid JSON but unparseable query DSL fails the WHOLE msearch request with
+    a 400 at request parse time rather than as a per-item error, so fall back
+    to issuing the searches individually in that case -- one bad rule must not
+    block evaluation of the remaining rules.
+    """
+    try:
+        return _msearch(searches)
+    except (
+        elasticsearch.exceptions.RequestError,
+        opensearchpy.exceptions.RequestError,
+    ) as e:
+        logger.error(
+            f"msearch rejected at request parse time ({e}); "
+            "falling back to per-rule searches"
+        )
+        responses = []
+        for header, body in searches:
+            try:
+                responses.append(search_es(index=header["index"], body=body))
+            except (
+                elasticsearch.exceptions.ElasticsearchException,
+                opensearchpy.exceptions.OpenSearchException,
+            ) as per_rule_error:
+                responses.append({"error": {"reason": str(per_rule_error)}})
+        return responses
 
 
 def evaluate_user_rules_job(job_id, index=None):

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -95,14 +95,22 @@ def update_query(job_id, rule):
 
 
 def _is_request_error(e):
-    """True if e is an elasticsearch/opensearchpy RequestError (HTTP 400).
+    """True if e is (or wraps) an elasticsearch/opensearchpy RequestError (HTTP 400).
     Query parse 400s are deterministic; retrying cannot change the outcome.
-    Resolved via isinstance per module so a stubbed-out client library (as in
-    unit test environments) degrades to False instead of breaking matching."""
-    for exceptions_module in (elasticsearch.exceptions, opensearchpy.exceptions):
-        cls = getattr(exceptions_module, "RequestError", None)
-        if isinstance(cls, type) and issubclass(cls, BaseException) and isinstance(e, cls):
-            return True
+
+    The hysds_commons jittered-backoff connection wrapper re-raises the original
+    client error as JitteredBackoffException chained via __cause__ (raise ... from e),
+    so the propagating exception is NOT the RequestError itself -- walk the cause
+    chain to find it. Resolved via isinstance per module so a stubbed-out client
+    library (as in unit test environments) degrades to False rather than breaking."""
+    seen = set()
+    while e is not None and id(e) not in seen:
+        seen.add(id(e))
+        for exceptions_module in (elasticsearch.exceptions, opensearchpy.exceptions):
+            cls = getattr(exceptions_module, "RequestError", None)
+            if isinstance(cls, type) and issubclass(cls, BaseException) and isinstance(e, cls):
+                return True
+        e = getattr(e, "__cause__", None) or getattr(e, "__context__", None)
     return False
 
 

--- a/hysds/user_rules_job.py
+++ b/hysds/user_rules_job.py
@@ -11,7 +11,7 @@ import opensearchpy.exceptions
 
 import hysds  # avoids cyclical import
 from hysds.celery import app
-from hysds.es_util import get_mozart_es
+from hysds.es_util import assert_doc_settled, get_mozart_es
 from hysds.log_utils import backoff_max_tries, backoff_max_value, logger
 
 JOBS_ES_URL = app.conf.JOBS_ES_URL  # ES
@@ -53,13 +53,17 @@ def process_xpath(xpath, trigger):
     backoff.expo, Exception, max_tries=backoff_max_tries, max_value=backoff_max_value
 )
 def ensure_job_indexed(job_id, alias):
-    """Ensure job is indexed."""
-    query = {"query": {"term": {"_id": job_id}}}
-    logger.info(f"ensure_job_indexed: {json.dumps(query)}")
+    """Ensure the job is indexed AND its latest write is search-visible.
+
+    Job rules commonly filter on a status field that transitions post-creation
+    (job-started -> job-completed/job-failed); search is refresh-bound, so the
+    updated status can lag the trigger and an _id existence check alone would pass
+    on the stale version. assert_doc_settled confirms the searchable copy has
+    caught up to the latest write, bounded by the existing exponential backoff.
+    """
+    logger.info(f"ensure_job_indexed: {job_id}")
     mozart_es = get_mozart_es()
-    count = mozart_es.get_count(index=alias, body=query)
-    if count == 0:
-        raise RuntimeError(f"Failed to find indexed job: {job_id}")
+    assert_doc_settled(mozart_es, alias, job_id)
 
 
 def get_job(job_id, rule, result):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "google-cloud-monitoring>=0.22.0",
         "osaka>=0.0.1",
         "prov_es>=0.2.0",
-        "hysds_commons>=0.1",
+        "hysds_commons>=2.4.0",
         "atomicwrites>=1.1.5",
         "greenlet>=0.4.15",
         "fab-classic>=1.19.2",

--- a/test/test_user_rules.py
+++ b/test/test_user_rules.py
@@ -1,0 +1,216 @@
+import json
+import sys
+import unittest
+
+try:
+    import unittest.mock as umock
+except ImportError:
+    from unittest import mock as umock
+
+# hysds.celery searches for configuration on import. So we need to make sure we
+# mock it out before the first time it is imported
+sys.modules["hysds.celery"] = umock.MagicMock()
+
+import elasticsearch.exceptions  # noqa: E402
+
+import hysds.user_rules_dataset as urd  # noqa: E402
+import hysds.user_rules_job as urj  # noqa: E402
+
+
+def hit(_id, source=None):
+    return {
+        "hits": {"total": {"value": 1}, "hits": [{"_id": _id, "_source": source or {}}]}
+    }
+
+
+def miss():
+    return {"hits": {"total": {"value": 0}, "hits": []}}
+
+
+def parse_error_item(reason="unknown query [termzz]"):
+    return {"error": {"type": "parsing_exception", "reason": reason}, "status": 400}
+
+
+def make_rule(name, query=None, **kwargs):
+    doc = {
+        "rule_name": name,
+        "query_string": query if isinstance(query, str) else json.dumps(
+            query if query is not None else {"term": {"tag": name}}
+        ),
+        "enabled": True,
+        "job_type": kwargs.pop("job_type", "hysds-io-test_job"),
+        "priority": 0,
+        "query_all": kwargs.pop("query_all", False),
+    }
+    doc.update(kwargs)
+    return {"_source": doc}
+
+
+def request_error():
+    return elasticsearch.exceptions.RequestError(
+        400, "parsing_exception", {"error": "unknown query [termzz]"}
+    )
+
+
+class TestEvaluateUserRulesDataset(unittest.TestCase):
+    def setUp(self):
+        self.grq_es = umock.MagicMock()
+        self.mozart_es = umock.MagicMock()
+        self.trigger = umock.MagicMock()
+        patches = [
+            umock.patch.object(urd, "get_grq_es", return_value=self.grq_es),
+            umock.patch.object(urd, "get_mozart_es", return_value=self.mozart_es),
+            umock.patch.object(urd, "queue_dataset_trigger", self.trigger),
+            umock.patch.object(urd, "validate_index_pattern", lambda p: True),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def evaluate(self):
+        return urd.evaluate_user_rules_dataset("ds1", "v1.0", alias="grq")
+
+    def test_response_rule_pairing_and_trigger_submission(self):
+        """Responses pair positionally with rules; only hits submit triggers."""
+        self.mozart_es.query.return_value = [
+            make_rule("rule-a"),
+            make_rule("rule-b"),
+            make_rule("rule-c", query_all=True),
+        ]
+        self.grq_es.msearch.return_value = [hit("ds1"), miss(), hit("other-ds")]
+
+        self.assertTrue(self.evaluate())
+
+        # rule-a and rule-c triggered, rule-b did not
+        self.assertEqual(self.trigger.call_count, 2)
+        triggered = [call.args[1]["rule_name"] for call in self.trigger.call_args_list]
+        self.assertEqual(triggered, ["rule-a", "rule-c"])
+        # job name derives from job_type with hysds-io- prefix stripped
+        self.assertEqual(self.trigger.call_args_list[0].args[2], "test_job-ds1")
+
+        # one msearch round trip carrying one (header, body) pair per rule
+        searches = self.grq_es.msearch.call_args.args[0]
+        self.assertEqual(len(searches), 3)
+        for header, body in searches:
+            self.assertIn("index", header)
+            self.assertEqual(body["size"], 1)
+        # non-query_all rules are constrained to the dataset _id; query_all is not
+        rule_a_filters = json.dumps(searches[0][1])
+        rule_c_filters = json.dumps(searches[2][1])
+        self.assertIn('{"_id": "ds1"}', rule_a_filters)
+        self.assertNotIn('{"_id": "ds1"}', rule_c_filters)
+
+    def test_per_item_error_does_not_block_other_rules(self):
+        """A per-item msearch error skips that rule and evaluates the rest."""
+        self.mozart_es.query.return_value = [make_rule("bad"), make_rule("good")]
+        self.grq_es.msearch.return_value = [parse_error_item(), hit("ds1")]
+
+        self.assertTrue(self.evaluate())
+
+        self.assertEqual(self.trigger.call_count, 1)
+        self.assertEqual(self.trigger.call_args.args[1]["rule_name"], "good")
+
+    def test_request_parse_400_falls_back_to_per_rule_searches(self):
+        """A rule with unparseable query DSL 400s the whole msearch request;
+        evaluation must fall back to per-rule searches so the bad rule cannot
+        block the rest."""
+        self.mozart_es.query.return_value = [make_rule("good"), make_rule("bad")]
+        self.grq_es.msearch.side_effect = request_error()
+        self.grq_es.search.side_effect = [hit("ds1"), request_error()]
+
+        self.assertTrue(self.evaluate())
+
+        self.assertEqual(self.grq_es.search.call_count, 2)
+        self.assertEqual(self.trigger.call_count, 1)
+        self.assertEqual(self.trigger.call_args.args[1]["rule_name"], "good")
+
+    def test_malformed_json_rule_skipped_at_build(self):
+        """A rule whose query_string is not valid JSON is skipped before the
+        msearch is built."""
+        self.mozart_es.query.return_value = [
+            make_rule("malformed", query="this is not json"),
+            make_rule("good"),
+        ]
+        self.grq_es.msearch.return_value = [hit("ds1")]
+
+        self.assertTrue(self.evaluate())
+
+        searches = self.grq_es.msearch.call_args.args[0]
+        self.assertEqual(len(searches), 1)
+        self.assertEqual(self.trigger.call_args.args[1]["rule_name"], "good")
+
+    def test_invalid_index_pattern_falls_back_to_alias(self):
+        """Empty/invalid index_pattern falls back to the dataset alias."""
+        self.mozart_es.query.return_value = [
+            make_rule("custom", index_pattern="grq_v1.0_l2_*"),
+            make_rule("fallback", index_pattern=""),
+        ]
+        self.grq_es.msearch.return_value = [miss(), miss()]
+
+        self.assertTrue(self.evaluate())
+
+        searches = self.grq_es.msearch.call_args.args[0]
+        self.assertEqual(searches[0][0]["index"], "grq_v1.0_l2_*")
+        self.assertIs(searches[1][0]["index"], urd.DATASET_ALIAS)
+
+    def test_no_enabled_rules_short_circuits(self):
+        """No enabled rules: return without issuing any search."""
+        self.mozart_es.query.return_value = []
+
+        self.assertTrue(self.evaluate())
+
+        self.grq_es.msearch.assert_not_called()
+        self.trigger.assert_not_called()
+
+
+class TestEvaluateUserRulesJob(unittest.TestCase):
+    def setUp(self):
+        self.mozart_es = umock.MagicMock()
+        self.trigger = umock.MagicMock()
+        patches = [
+            umock.patch.object(urj, "get_mozart_es", return_value=self.mozart_es),
+            umock.patch.object(urj, "queue_job_trigger", self.trigger),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_response_rule_pairing_and_default_job_name(self):
+        self.mozart_es.query.return_value = [
+            make_rule("retry-rule", job_type="hysds-io-retry"),
+            make_rule("notify-rule"),
+        ]
+        self.mozart_es.msearch.return_value = [hit("job1"), miss()]
+
+        self.assertTrue(urj.evaluate_user_rules_job("job1"))
+
+        self.assertEqual(self.trigger.call_count, 1)
+        self.assertEqual(self.trigger.call_args.args[2], "retry-job1")
+
+    def test_job_name_path_extracts_name_from_matched_doc(self):
+        self.mozart_es.query.return_value = [
+            make_rule("retry-rule", job_type="hysds-io-retry",
+                      job_name_path="_source.job.name"),
+        ]
+        self.mozart_es.msearch.return_value = [
+            hit("job1", {"job": {"name": "cool_product"}})
+        ]
+
+        self.assertTrue(urj.evaluate_user_rules_job("job1"))
+
+        self.assertEqual(self.trigger.call_args.args[2], "retry-cool_product")
+
+    def test_request_parse_400_falls_back_to_per_rule_searches(self):
+        self.mozart_es.query.return_value = [make_rule("good"), make_rule("bad")]
+        self.mozart_es.msearch.side_effect = request_error()
+        self.mozart_es.search.side_effect = [hit("job1"), request_error()]
+
+        self.assertTrue(urj.evaluate_user_rules_job("job1"))
+
+        self.assertEqual(self.mozart_es.search.call_count, 2)
+        self.assertEqual(self.trigger.call_count, 1)
+        self.assertEqual(self.trigger.call_args.args[1]["rule_name"], "good")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_user_rules.py
+++ b/test/test_user_rules.py
@@ -128,6 +128,9 @@ class TestEvaluateUserRulesDataset(unittest.TestCase):
         for header, body in searches:
             self.assertIn("index", header)
             self.assertEqual(body["size"], 1)
+        # HC-633 replica-lag fix: the rule msearch must be pinned to the objectid
+        # so it hits the same shard copy the settled-probe validated
+        self.assertEqual(self.grq_es.msearch.call_args.kwargs["preference"], "ds1")
         # non-query_all rules are constrained to the dataset _id; query_all is not
         rule_a_filters = json.dumps(searches[0][1])
         rule_c_filters = json.dumps(searches[2][1])
@@ -296,6 +299,14 @@ class TestAssertDocSettled(unittest.TestCase):
         self.assertTrue(body.get("seq_no_primary_term"))
         musts = body["query"]["bool"]["must"]
         self.assertIn({"term": {"system_version.keyword": "v1.0"}}, musts)
+
+    def test_settled_probe_pins_preference_to_doc_id(self):
+        # HC-633 replica-lag fix: the settled-probe must route by doc_id so it
+        # validates the SAME shard copy the rule msearch (also preference=doc_id)
+        # will query. Same string in both -> same copy.
+        es = self._es(7, 7)
+        self._settled()(es, "grq", "csc-20180302")
+        self.assertEqual(es.search.call_args.kwargs["preference"], "csc-20180302")
 
 
 if __name__ == "__main__":

--- a/test/test_user_rules.py
+++ b/test/test_user_rules.py
@@ -94,6 +94,8 @@ class TestEvaluateUserRulesDataset(unittest.TestCase):
             umock.patch.object(urd, "get_mozart_es", return_value=self.mozart_es),
             umock.patch.object(urd, "queue_dataset_trigger", self.trigger),
             umock.patch.object(urd, "validate_index_pattern", lambda p: True),
+            # ensure_dataset_indexed is covered by TestAssertDocSettled; no-op here
+            umock.patch.object(urd, "ensure_dataset_indexed"),
         ]
         for p in patches:
             p.start()
@@ -203,6 +205,8 @@ class TestEvaluateUserRulesJob(unittest.TestCase):
         patches = [
             umock.patch.object(urj, "get_mozart_es", return_value=self.mozart_es),
             umock.patch.object(urj, "queue_job_trigger", self.trigger),
+            # ensure_job_indexed is covered by TestAssertDocSettled; no-op here
+            umock.patch.object(urj, "ensure_job_indexed"),
         ]
         for p in patches:
             p.start()
@@ -244,6 +248,54 @@ class TestEvaluateUserRulesJob(unittest.TestCase):
         self.assertEqual(self.mozart_es.search.call_count, 2)
         self.assertEqual(self.trigger.call_count, 1)
         self.assertEqual(self.trigger.call_args.args[1]["rule_name"], "good")
+
+
+class TestAssertDocSettled(unittest.TestCase):
+    """Refresh-visibility guard for the field-UPDATE race that dropped forward
+    DISP-S1 products once the head sleep was removed: a complete cycle-state-config
+    (is_complete flipped false->true) whose searchable copy lagged the trigger, so
+    the rule query saw stale state and missed. An _id existence check passes on the
+    stale version; assert_doc_settled requires the searchable _seq_no to catch up to
+    the realtime (translog) _seq_no."""
+
+    @staticmethod
+    def _es(search_seq_no, get_seq_no, hits=True):
+        es = umock.MagicMock()
+        es.search.return_value = {
+            "hits": {"hits": [{"_index": "grq_1_x", "_seq_no": search_seq_no}] if hits else []}
+        }
+        es.es.get.return_value = {"_seq_no": get_seq_no}
+        return es
+
+    def _settled(self):
+        from hysds.es_util import assert_doc_settled
+        return assert_doc_settled
+
+    def test_settled_when_searchable_caught_up(self):
+        # searchable _seq_no == latest -> the update is visible -> no raise
+        self._settled()(self._es(7, 7), "grq", "csc-20180326")
+
+    def test_raises_when_searchable_stale(self):
+        # searchable copy still on the pre-update version -> backoff retries
+        with self.assertRaises(Exception):
+            self._settled()(self._es(5, 7), "grq", "csc-20180302")
+
+    def test_raises_when_not_search_visible(self):
+        # new-doc ingest race: not in search yet -> backoff retries
+        with self.assertRaises(Exception):
+            self._settled()(self._es(None, None, hits=False), "grq", "brand-new")
+
+    def test_settled_when_seq_no_unavailable(self):
+        # older ES without seq_no -> degrade to existence-only (legacy behavior)
+        self._settled()(self._es(None, None), "grq", "legacy")
+
+    def test_passes_extra_must_into_query(self):
+        es = self._es(7, 7)
+        self._settled()(es, "grq", "d1", extra_must=[{"term": {"system_version.keyword": "v1.0"}}])
+        body = es.search.call_args.kwargs["body"]
+        self.assertTrue(body.get("seq_no_primary_term"))
+        musts = body["query"]["bool"]["must"]
+        self.assertIn({"term": {"system_version.keyword": "v1.0"}}, musts)
 
 
 if __name__ == "__main__":

--- a/test/test_user_rules.py
+++ b/test/test_user_rules.py
@@ -128,9 +128,12 @@ class TestEvaluateUserRulesDataset(unittest.TestCase):
         for header, body in searches:
             self.assertIn("index", header)
             self.assertEqual(body["size"], 1)
-        # HC-633 replica-lag fix: the rule msearch must be pinned to the objectid
-        # so it hits the same shard copy the settled-probe validated
-        self.assertEqual(self.grq_es.msearch.call_args.kwargs["preference"], "ds1")
+        # HC-633 replica-lag fix: preference is set PER-SEARCH in each header
+        # (msearch() takes NO preference kwarg -- the v3.1.7 regression), pinning
+        # the same shard copy the settled-probe validated.
+        for header, _body in searches:
+            self.assertEqual(header.get("preference"), "ds1")
+        self.assertNotIn("preference", self.grq_es.msearch.call_args.kwargs)
         # non-query_all rules are constrained to the dataset _id; query_all is not
         rule_a_filters = json.dumps(searches[0][1])
         rule_c_filters = json.dumps(searches[2][1])
@@ -307,6 +310,28 @@ class TestAssertDocSettled(unittest.TestCase):
         es = self._es(7, 7)
         self._settled()(es, "grq", "csc-20180302")
         self.assertEqual(es.search.call_args.kwargs["preference"], "csc-20180302")
+
+
+class TestClientPreferenceSignature(unittest.TestCase):
+    """Signature-faithful guard for the v3.1.7 regression: the real opensearch-py
+    client's msearch() rejects a `preference` kwarg (so HC-633 sets preference
+    per-search in the header), whereas search() accepts it. Mocks accept any kwarg
+    -- exactly how the v3.1.7 'msearch() got an unexpected keyword argument
+    preference' crash slipped the suite. TypeError binds before any network call."""
+
+    def test_real_msearch_rejects_preference_kwarg(self):
+        import inspect
+        try:
+            import opensearchpy
+        except Exception:
+            self.skipTest("opensearchpy not importable")
+        # other suites stub sys.modules['opensearchpy'] with a Mock (whose attrs
+        # accept any kwarg) -- only run against the real client class
+        if not inspect.isclass(getattr(opensearchpy, "OpenSearch", None)):
+            self.skipTest("opensearchpy is stubbed in this run")
+        c = opensearchpy.OpenSearch(["https://localhost:9"], timeout=1, max_retries=0)
+        with self.assertRaises(TypeError):
+            c.msearch(body=[{"index": "x"}, {"query": {"match_all": {}}}], preference="p")
 
 
 if __name__ == "__main__":

--- a/test/test_user_rules.py
+++ b/test/test_user_rules.py
@@ -31,6 +31,18 @@ def parse_error_item(reason="unknown query [termzz]"):
     return {"error": {"type": "parsing_exception", "reason": reason}, "status": 400}
 
 
+def rejected_item():
+    """A search thread pool rejection as it surfaces per-item INSIDE a 200
+    msearch response -- the saturation signature under a dense cascade."""
+    return {
+        "error": {
+            "type": "es_rejected_execution_exception",
+            "reason": "rejected execution of ... search queue capacity",
+        },
+        "status": 429,
+    }
+
+
 def make_rule(name, query=None, **kwargs):
     doc = {
         "rule_name": name,
@@ -82,6 +94,27 @@ class TestIsRequestError(unittest.TestCase):
     def test_unrelated_exception_not_detected(self):
         self.assertFalse(urd._is_request_error(ValueError("nope")))
         self.assertFalse(urd._is_request_error(RuntimeError("plain")))
+
+
+class TestIsRetryableItemError(unittest.TestCase):
+    """Per-item msearch errors: 400-class (parse) errors are deterministic and
+    terminal; 429 search-queue rejections and 5xx are transient and re-run --
+    a saturated search queue must degrade to latency, not dropped triggers."""
+
+    def test_parse_400_not_retryable(self):
+        self.assertFalse(urd._is_retryable_item_error(parse_error_item()))
+        self.assertFalse(urj._is_retryable_item_error(parse_error_item()))
+
+    def test_rejection_429_retryable(self):
+        self.assertTrue(urd._is_retryable_item_error(rejected_item()))
+        self.assertTrue(urj._is_retryable_item_error(rejected_item()))
+
+    def test_5xx_retryable(self):
+        item = {"error": {"type": "internal_server_error"}, "status": 503}
+        self.assertTrue(urd._is_retryable_item_error(item))
+
+    def test_missing_status_retryable(self):
+        self.assertTrue(urd._is_retryable_item_error({"error": {"reason": "?"}}))
 
 
 class TestEvaluateUserRulesDataset(unittest.TestCase):
@@ -144,6 +177,40 @@ class TestEvaluateUserRulesDataset(unittest.TestCase):
         """A per-item msearch error skips that rule and evaluates the rest."""
         self.mozart_es.query.return_value = [make_rule("bad"), make_rule("good")]
         self.grq_es.msearch.return_value = [parse_error_item(), hit("ds1")]
+
+        self.assertTrue(self.evaluate())
+
+        self.assertEqual(self.trigger.call_count, 1)
+        self.assertEqual(self.trigger.call_args.args[1]["rule_name"], "good")
+        # a parse 400 is deterministic: no individual re-run attempted
+        self.grq_es.search.assert_not_called()
+
+    def test_per_item_rejection_retried_individually(self):
+        """A 429 search-queue rejection inside a 200 msearch response is
+        transient: re-run just that rule's search (with backoff) instead of
+        dropping its trigger -- the saturation case the old per-rule loop's
+        backoff absorbed and batching removed."""
+        self.mozart_es.query.return_value = [make_rule("rejected"), make_rule("good")]
+        self.grq_es.msearch.return_value = [rejected_item(), hit("ds1")]
+        self.grq_es.search.return_value = hit("ds1")
+
+        self.assertTrue(self.evaluate())
+
+        # re-run individually, preserving the shard-pinning preference
+        self.assertEqual(self.grq_es.search.call_count, 1)
+        self.assertEqual(self.grq_es.search.call_args.kwargs["preference"], "ds1")
+        # and BOTH rules trigger
+        self.assertEqual(self.trigger.call_count, 2)
+        triggered = [call.args[1]["rule_name"] for call in self.trigger.call_args_list]
+        self.assertEqual(triggered, ["rejected", "good"])
+
+    def test_per_item_rejection_persistent_failure_skips_only_that_rule(self):
+        """If the individual re-run also ultimately fails, only that rule is
+        skipped; the rest still evaluate and trigger."""
+        self.mozart_es.query.return_value = [make_rule("rejected"), make_rule("good")]
+        self.grq_es.msearch.return_value = [rejected_item(), hit("ds1")]
+        # giveup fires immediately on the wrapped 400 -- no real backoff sleeps
+        self.grq_es.search.side_effect = wrapped_request_error()
 
         self.assertTrue(self.evaluate())
 
@@ -254,6 +321,22 @@ class TestEvaluateUserRulesJob(unittest.TestCase):
         self.assertEqual(self.mozart_es.search.call_count, 2)
         self.assertEqual(self.trigger.call_count, 1)
         self.assertEqual(self.trigger.call_args.args[1]["rule_name"], "good")
+
+    def test_per_item_rejection_retried_individually(self):
+        """Job-path mirror of the saturation case: a per-item 429 is re-run
+        individually (preference preserved) instead of dropping the trigger."""
+        self.mozart_es.query.return_value = [
+            make_rule("rejected", job_type="hysds-io-retry"),
+            make_rule("good"),
+        ]
+        self.mozart_es.msearch.return_value = [rejected_item(), hit("job1")]
+        self.mozart_es.search.return_value = hit("job1")
+
+        self.assertTrue(urj.evaluate_user_rules_job("job1"))
+
+        self.assertEqual(self.mozart_es.search.call_count, 1)
+        self.assertEqual(self.mozart_es.search.call_args.kwargs["preference"], "job1")
+        self.assertEqual(self.trigger.call_count, 2)
 
 
 class TestAssertDocSettled(unittest.TestCase):

--- a/test/test_user_rules.py
+++ b/test/test_user_rules.py
@@ -52,6 +52,38 @@ def request_error():
     )
 
 
+def wrapped_request_error():
+    """The exception production actually raises: the hysds_commons jittered-backoff
+    connection wrapper catches the RequestError and re-raises it as a generic
+    exception chained via __cause__ (raise JitteredBackoffException(...) from e).
+    The propagating exception is therefore NOT a RequestError instance."""
+    try:
+        raise request_error()
+    except Exception as orig:
+        try:
+            raise RuntimeError("Exception occurred: RequestError(400, ...)") from orig
+        except Exception as wrapped:
+            return wrapped
+
+
+class TestIsRequestError(unittest.TestCase):
+    """The fallback hinges on detecting a 400 even when the client library has
+    wrapped it -- this is the case the unit suite previously missed and the live
+    cluster surfaced (JitteredBackoffException wrapping the real RequestError)."""
+
+    def test_bare_request_error_detected(self):
+        self.assertTrue(urd._is_request_error(request_error()))
+        self.assertTrue(urj._is_request_error(request_error()))
+
+    def test_wrapped_request_error_detected(self):
+        self.assertTrue(urd._is_request_error(wrapped_request_error()))
+        self.assertTrue(urj._is_request_error(wrapped_request_error()))
+
+    def test_unrelated_exception_not_detected(self):
+        self.assertFalse(urd._is_request_error(ValueError("nope")))
+        self.assertFalse(urd._is_request_error(RuntimeError("plain")))
+
+
 class TestEvaluateUserRulesDataset(unittest.TestCase):
     def setUp(self):
         self.grq_es = umock.MagicMock()
@@ -113,10 +145,11 @@ class TestEvaluateUserRulesDataset(unittest.TestCase):
     def test_request_parse_400_falls_back_to_per_rule_searches(self):
         """A rule with unparseable query DSL 400s the whole msearch request;
         evaluation must fall back to per-rule searches so the bad rule cannot
-        block the rest."""
+        block the rest. Production wraps the RequestError (JitteredBackoffException
+        chained via __cause__), so the fallback must trigger on the wrapped form."""
         self.mozart_es.query.return_value = [make_rule("good"), make_rule("bad")]
-        self.grq_es.msearch.side_effect = request_error()
-        self.grq_es.search.side_effect = [hit("ds1"), request_error()]
+        self.grq_es.msearch.side_effect = wrapped_request_error()
+        self.grq_es.search.side_effect = [hit("ds1"), wrapped_request_error()]
 
         self.assertTrue(self.evaluate())
 
@@ -201,9 +234,10 @@ class TestEvaluateUserRulesJob(unittest.TestCase):
         self.assertEqual(self.trigger.call_args.args[2], "retry-cool_product")
 
     def test_request_parse_400_falls_back_to_per_rule_searches(self):
+        # production wraps the RequestError (JitteredBackoffException via __cause__)
         self.mozart_es.query.return_value = [make_rule("good"), make_rule("bad")]
-        self.mozart_es.msearch.side_effect = request_error()
-        self.mozart_es.search.side_effect = [hit("job1"), request_error()]
+        self.mozart_es.msearch.side_effect = wrapped_request_error()
+        self.mozart_es.search.side_effect = [hit("job1"), wrapped_request_error()]
 
         self.assertTrue(urj.evaluate_user_rules_job("job1"))
 


### PR DESCRIPTION
## Purpose
Remove the fixed sleeps from user-rules evaluation and evaluate all enabled rules in a single multi-search request, with indexing-visibility handling that is refresh-correct and shard-consistent. Resolves HC-633.

https://hysds-core.atlassian.net/browse/HC-633

## Background
The unconditional head sleeps (6s in `evaluate_user_rules_dataset`, 7s in `evaluate_user_rules_job`) and the 1s per-rule sleeps guarded two things: ES/OpenSearch near-real-time visibility (a document is searchable only after the next refresh; the GRQ and Mozart `es_template.json` set `index.refresh_interval: 5s`), and client-side throttling of the one-search-per-rule loop. `ensure_dataset_indexed()`/`ensure_job_indexed()` already poll with exponential backoff until the triggering document is searchable, so the fixed sleeps are redundant for visibility once that poll is made fully correct — and batching the rule queries into one `_msearch` removes the reason for the per-rule throttle (the sub-searches are scheduled server-side through the search thread pool).

## Algorithm — before vs after

| | Before | After |
|---|---|---|
| Head delay | `sleep(6)` / `sleep(7)`, unconditional | none — the visibility poll starts immediately |
| Per-rule delay | `sleep(1)` × R rules | none |
| Rule queries | R sequential `search` round trips | **one** `msearch` round trip |
| Visibility check | `_id` exists (passes on a stale field update) | latest write is search-visible (`assert_doc_settled`: realtime-GET `_seq_no` ≥) |
| Shard copy | probe and query route independently | probe + query + fallback pinned to one copy (`preference=<doc_id>`) |
| Malformed rule | aborts the whole evaluation | parse-400 → per-rule fallback isolates it |
| Transient per-rule failure (429 queue rejection, 5xx) | absorbed by the per-rule 5-try backoff | per-item detection → individual re-run through the same backoff'd fallback |
| Latency (R=26) | ≥ 32 s fixed floor | ~one round trip after the poll (median 1.78 s) |

**Before — per-rule loop**

```mermaid
flowchart TB
    A1["evaluate_user_rules"] --> A2["sleep 6s / 7s"]
    A2 --> A3["ensure_indexed:<br/>does _id exist?"]
    A3 --> A4{"for each rule"}
    A4 -->|"rule i"| A5["search rule i"]
    A5 --> A6["sleep 1s"]
    A6 --> A4
    A4 -->|"done"| A7["submit triggers"]
```

**After — single msearch**

```mermaid
flowchart TB
    B1["evaluate_user_rules"] --> B2["ensure_indexed: assert_doc_settled<br/>realtime-GET seq_no, same copy via preference"]
    B2 --> B3["msearch all rules in ONE round trip<br/>preference=doc_id"]
    B3 --> B4{"request parse-400?"}
    B4 -->|"yes"| B5["fall back to per-rule search,<br/>isolate the bad rule"]
    B5 --> B6["submit triggers"]
    B4 -->|"no"| B7{"per-item error?"}
    B7 -->|"none"| B6
    B7 -->|"429 / 5xx (transient)"| B8["re-run that rule individually<br/>(backoff'd fallback, same preference)"]
    B7 -->|"400 (parse)"| B9["terminal for that rule only"]
    B8 --> B6
    B9 --> B6
```

**Refresh-visibility + shard routing.** The trigger can fire on a field *update* to a pre-existing doc; search is refresh-bound, so an `_id`-existence check can pass on the stale value. `assert_doc_settled` requires the searchable copy to have caught up to the latest write, and pins every read to the same copy:

```mermaid
sequenceDiagram
    participant W as Writer
    participant ES as OpenSearch
    participant Ev as Evaluator
    Note over W,ES: is_complete false to true, seq_no N
    W->>ES: index update, seq_no N
    Ev->>ES: realtime GET by _id (translog)
    ES-->>Ev: authoritative seq_no = N
    Ev->>ES: search same copy, preference=doc_id
    ES-->>Ev: backoff until searchable seq_no >= N
    Ev->>ES: msearch all rules, preference=doc_id
    ES-->>Ev: rule is_complete:true matches, hit
    Note over Ev: trigger fires, no dropped trigger
```

## Changes
- **Remove the 6s/7s head sleeps and the 1s per-rule sleeps.** The exponential-backoff visibility poll starts immediately.
- **Single multi-search evaluation.** Build one `(header, query)` pair per enabled rule (per-rule `index_pattern` preserved, `size: 1`) and evaluate them in one `msearch` round trip, wrapped in the same expo backoff as the old per-rule search. Per-rule visibility is preserved — same matched / didn't-match log lines and trigger-submission flow — plus a new end-of-evaluation summary (`Evaluated N rules for <id>: matched=[...] errored=[...]`).
- **Refresh-visibility correctness.** A rule can be triggered by a field *update* on a pre-existing doc (e.g. a DISP-S1 cycle-state-config whose `is_complete` flips false→true), and search is refresh-bound, so an `_id`-existence check can pass on the stale version while the rule's filtered query misses the update. `ensure_*_indexed` therefore confirms the doc's **latest write** is search-visible via `assert_doc_settled()` (`es_util`): a realtime GET-by-id reads the translog (refresh-independent) for the authoritative `_seq_no`, and the searchable copy's `_seq_no` must be ≥ it before evaluation. Bounded by the existing backoff — no fixed sleep (waits only as long as the refresh actually needs), and no per-eval `_refresh` (which would force a segment flush across all shards on every ingest; the realtime GET is single-shard/translog-served).
- **Shard-consistent reads.** On replicated indices the settled-probe and the rule query are separate requests that would otherwise select shard copies independently — the probe could confirm one copy is caught up while the rule query reads a lagging replica. Every read for an evaluation (settled-probe, rule `msearch`, and the per-rule fallback search) is pinned to the same copy via `preference=<doc_id>` (job path keys on `job_id`). Per-doc routing (not `_primary`) keeps load spread across copies and preserves replica HA. The `msearch` preference is set **per-search in each header line** — the client's `msearch()` does not accept a `preference` kwarg and a URL-level preference is ignored by the `_msearch` endpoint; `search()`-based reads pass `preference=` directly.
- **Malformed-rule resilience.** A rule whose query is valid JSON but unparseable DSL fails the entire `_msearch` with a request-parse 400. The evaluation detects this (the client surfaces it as a `RequestError` wrapped in a `JitteredBackoffException`, matched by walking the `__cause__`/`__context__` chain), gives up the deterministic retry, and falls back to issuing the searches individually — isolating the bad rule as a per-item error so the remaining rules still evaluate.
- **Saturation resilience (transient per-item errors).** A search thread pool rejection (429) or a 5xx surfaces as a *per-item* error inside a 200 msearch response. The old per-rule loop absorbed these transients via its 5-try backoff; batching alone would turn them into silently dropped triggers under load. Transient items are re-run individually through the same backoff'd per-rule fallback (preference routing preserved); deterministic 400-class item errors stay terminal for just their rule. Under overload this doubles as natural backpressure: the single-slot worker (prefork `--concurrency=1`, scaled by supervisord `numprocs`) rides out the rejection in bounded backoff instead of offering fresh msearches, so the cascade drain self-slows exactly when the cluster is saturated.

## Concurrency model (why no lock)

There's no lock (Redis or otherwise) because this isn't mutual exclusion — it's a read-after-write **search-visibility** race: a single evaluator reads OpenSearch before a write is searchable (refresh-bound search; replica lag). A lock around "index → evaluate" wouldn't help — it doesn't make the write searchable (that's refresh-governed), so you'd still wait on a refresh and would have serialized every evaluation for nothing.

The guarantee instead comes from OpenSearch's own [`_seq_no`](https://docs.opensearch.org/latest/api-reference/document-apis/index/) (the optimistic-concurrency sequence number): `assert_doc_settled()` realtime-GETs the authoritative latest `_seq_no` (translog-served, refresh-independent), then requires the searchable copy to reach it before evaluating, with the settled-probe and the rule query pinned to the same shard copy via a custom [`preference=<doc_id>`](https://docs.opensearch.org/latest/search-plugins/searching-data/search-shard-routing/) (see **Changes**). Lock-free, read-your-write, no new coordination point or failure mode.

Producer-side alternative (also lock-free): `?refresh=wait_for` on the triggering write, which would let the consumer drop the settled-probe — kept out of scope here as it spans grq2/logstash.

## Performance
Per evaluation with R enabled rules: ~(6 + R) seconds of fixed sleeps plus R sequential search round trips → one ES round trip after the visibility poll. On deployments with dozens of rules and high throughput this removes the dominant latency in trigger firing and frees user_rules workers that previously spent most of their time sleeping.

## Dependencies
Requires `SearchUtility.msearch()` from hysds/hysds_commons#71 (merge first). `setup.py` pins `hysds_commons>=2.4.0` (version bumped in #71), so installing this change against a pre-`msearch` hysds_commons fails at dependency resolution instead of crashing every rule evaluation at runtime.

## Testing & Validation
Validated at three levels — unit, local integration against a real search engine, and end-to-end on an OPERA DISP-S1 dev-e2e cluster (full HySDS + Chimera forward pipeline).

**Unit (`test/test_user_rules.py`, in CI) — 26 tests.** Response↔rule positional pairing, zero-hit vs hit handling, per-item error isolation, `query_all`, `index_pattern` fallback, `job_name_path` naming, no-enabled-rules short-circuit, the settled-probe (including the false→true update race and the per-doc preference pin), `_is_request_error` detection through the wrapped-exception chain, the parse-400 → per-rule fallback (dataset and job paths), per-item transient-error handling (429/5xx-vs-400 classification, individual re-run with the preference preserved on both dataset and job paths, persistent-failure degradation, parse-400 attempts no re-run), and a client-signature guard (the routing preference belongs in the per-search header, not as a `msearch()` kwarg). CI green.

**Local integration A/B (real OpenSearch, `refresh_interval: 5s` for prod parity).** Baseline (pre-change) vs patched evaluators run against an 8-case rule matrix — match, no-match, `query_all`, custom `index_pattern`, a closed index inside the alias, invalid query DSL, malformed JSON, disabled. **Trigger sets were byte-identical baseline vs patched** (no behavior change); per-evaluation replay latency dropped from ~18.3s to ~0.04–0.08s; the fresh-ingest case (racing the 5s refresh) fired on every run via the visibility poll.

**End-to-end (OPERA DISP-S1 dev-e2e, 56-date forward run).**
- No dropped triggers: every complete cycle-state-config produced its k-cycle-state-config — **56 complete CSC → KSC, 0 missing, 0 evaluator crashes**; the k-cycle rule matched all 56 complete CSCs (neighbor-frame CSCs correctly no-match).
- Entirely through the single-`_msearch` path: **0 errored, 0 fallbacks** under live cascade load; **median ingest→evaluation latency 1.78s** (n=279) vs the ≥32s baseline floor (6s head sleep + 1s × 26 rules).
- Forward composition confirmed on an A/B of two clusters — full-serial "truth" vs boundary-serial "at-scale" — **byte-identical**: 41 fired / 15 no-fire / 0 failed; 56/56; L3=55; CCSLC=6; two clean CCSLC boundaries; `superseded_by=0`.
- Fallback verified live: a valid-JSON/unparseable-DSL rule was registered as an enabled trigger rule and a `user_rules_dataset` evaluation job submitted for a non-matching dataset — the worker's msearch 400s, the evaluation falls back to per-rule searches, the bad rule is isolated as an error, the remaining 26 rules still evaluate, and no exception propagates. The test rule was removed afterward (back to 26 rules).

**Reproducing the per-item transient-error retry (429/5xx).** This is the one path in the PR not yet exercised on a live cluster (unit-tested ×7) — a real 429 (`es_rejected_execution_exception`, surfaced *per-item inside a 200 msearch response*) requires search-queue saturation, which is hard to produce on demand. Two ways to close it:

<details>
<summary>Method A — deterministic fault injection (recommended; no saturation needed)</summary>

Temporarily make the evaluator treat a round trip's items as rejected, so the real classifier (`_is_retryable_item_error`) and the real per-rule fallback (`_fallback_search` → `search_es` against live ES) run end-to-end.

1. On a dev factotum, patch the deployed `hysds/user_rules_dataset.py` — immediately after `responses = _msearch(searches)` in `msearch_es`, add:
   ```python
   import os  # TEMP HC-633 429 injection — remove after test
   if os.environ.get("HC633_INJECT_429"):
       responses = [{"error": {"type": "es_rejected_execution_exception",
                               "reason": "HC633 injected"}, "status": 429} for _ in responses]
   ```
2. Restart the evaluators with the flag set (add `HC633_INJECT_429=1` to the program's `environment=` in supervisord, or export before restart so the workers inherit it):
   `~/verdi/bin/supervisorctl -c ~/verdi/etc/supervisord.conf restart user_rules_dataset:`
3. Ingest/complete one document that matches an existing enabled rule (whatever normally fires a trigger for your project).
4. Confirm in `~/verdi/log/user_rules_dataset-*.log`:
   - one `WARNING ... msearch item error (status 429) is transient, retrying rule query individually` per rule,
   - `Evaluated N rules for <id>: matched=[...] errored=[]` — the `matched` set **identical to an un-injected evaluation of the same doc** (the 429 recovered every trigger; nothing errored or dropped),
   - the downstream trigger job(s) submitted as normal.
5. Revert: unset `HC633_INJECT_429`, restart the evaluators, and restore the file (`git checkout` / reinstall). Use `"status": 503` to exercise the 5xx branch, and repeat the snippet in `user_rules_job.py` to cover the job path.

</details>

<details>
<summary>Method B — genuine search-queue saturation (realistic; heavier)</summary>

On a throwaway single-node OpenSearch (not a shared cluster), shrink the search thread pool so concurrent fan-out is rejected: in `opensearch.yml` set `thread_pool.search.size: 1` and `thread_pool.search.queue_size: 1` (static — restart the node). Register enough enabled rules that one evaluation's `msearch` fans out to many sub-searches, then drive a burst of overlapping ingests/completions. Real `es_rejected_execution_exception` (429) items appear inside the 200 `msearch` responses; confirm the same re-run log line and that no trigger is dropped, then restore the settings and restart. The offline `hc633-test-kit` A/B harness can do the same against a docker single-node with `queue_size: 1`.

</details>

## Test artifacts

<details>
<summary>Factotum evaluator verdicts — dev-e2e 56-date forward run (final)</summary>

```
TypeError/Traceback: 0
distinct CSCs matched by trigger-disp_s1_k_cycle_evaluator: 56   (== complete CSCs)
Found settled: 409     Trigger submitted: 280     msearch fallbacks (normal run): 0

Rule 'trigger-disp_s1_k_cycle_evaluator' successfully matched for cslc_s1-cycle-<frame>-<date>-state-config
Evaluated 26 rules for cslc_s1-cycle-<frame>-<date>-state-config: matched=['trigger-disp_s1_k_cycle_evaluator'] errored=[]
Evaluated 26 rules for cslc_s1-cycle-<neighbor-frame>-<date>-state-config: matched=[] errored=[]
```
</details>

<details>
<summary>Live fallback — registered malformed rule + a submitted evaluation job (real worker)</summary>

A valid-JSON / unparseable-DSL rule (`{"termzz": ...}`) was registered as an enabled trigger rule (the 27th), then a `user_rules_dataset` evaluation job was submitted for a non-matching dataset. The factotum celery worker (`task_worker.run_task`) processed it:

```
ERROR  msearch rejected at request parse time (RequestError(400, x_content_parse_exception,
       unknown query [termzz] did you mean any of [term, terms]?)); falling back to per-rule searches
INFO   Rule '<good rule 1>'  didn't match for <cycle-state-config>
  ...    (all 26 good rules evaluated individually)
INFO   Rule '<good rule 26>' didn't match for <cycle-state-config>
ERROR  Rule 'hc633-fallback-test-badrule' query failed for <cycle-state-config>:
       {"reason": "...RequestError(400, x_content_parse_exception, unknown query [termzz]...)"}
INFO   Evaluated 27 rules for <cycle-state-config>: matched=[] errored=['hc633-fallback-test-badrule']
```

The malformed rule 400s the whole `_msearch`; the evaluation falls back to per-rule searches so the bad rule is isolated (`errored`) and the other 26 rules still evaluate — instead of one bad rule aborting the entire evaluation. Test rule removed afterward (back to 26 rules). The backoff connection retries the deterministic 400 before giveup (~30s for a malformed rule; correctness unaffected).
</details>

<details>
<summary>Unit suite — 19 passed (test/test_user_rules.py)</summary>

```
TestEvaluateUserRulesDataset::test_request_parse_400_falls_back_to_per_rule_searches  PASSED
TestEvaluateUserRulesJob::test_request_parse_400_falls_back_to_per_rule_searches       PASSED
TestEvaluateUserRulesDataset::test_per_item_error_does_not_block_other_rules           PASSED
TestIsRequestError::test_wrapped_request_error_detected                                PASSED
TestIsRequestError::test_bare_request_error_detected                                   PASSED
TestAssertDocSettled::test_settled_probe_pins_preference_to_doc_id                     PASSED
TestAssertDocSettled::test_raises_when_searchable_stale                                PASSED
TestAssertDocSettled::test_settled_when_seq_no_unavailable                             PASSED
TestClientPreferenceSignature::test_real_msearch_rejects_preference_kwarg              PASSED
... (19 total)
============================== 19 passed in 0.55s ==============================
```
</details>

## Cross-project validation

This change lands in the shared HySDS framework and is consumed by multiple SDS projects; each should validate it against its own pipeline before merge.

<details>
<summary>What to validate — guidance for NISAR / SWOT</summary>

HC-633 changes shared trigger-evaluation code (this PR + hysds/hysds_commons#71): the fixed head/per-rule sleeps are removed, all enabled rules are checked in one `msearch`, indexing-visibility is made refresh-correct (`assert_doc_settled` on `_seq_no`) and shard-consistent (`preference=<doc_id>`), and a malformed rule falls back to per-rule searches instead of aborting the evaluation. Each consuming project should confirm its own trigger cascade still fires correctly.

**Run:** deploy the change (develop, or cherry-picked to your framework line) to a dev/test cluster and exercise a representative trigger workflow for your project — whatever ingests datasets / completes jobs that fire `user_rules`. For a concrete integration example, see how OPERA wired it into provisioning (swap the patched `hysds`/`hysds_commons` into the factotum venv): nasa/opera-sds-pcm#1447.

**Check** (`user_rules_dataset*` / `user_rules_job*` evaluator logs + your products):
- **No dropped triggers** — every dataset/job that should fire a rule does (no missing downstream products vs. a baseline).
- **No crashes** — `0` `TypeError`/`Traceback` in the evaluator logs.
- **Single-`msearch` path** — per-rule verdicts preserved: `Evaluated N rules for <id>: matched=[...] errored=[]`, with `Found settled ...` probe lines present.
- **Faster firing** — triggers fire without the old fixed sleeps (≥6s head + 1s/rule).
- **(Optional) fallback** — register one valid-JSON/unparseable-DSL rule, submit an evaluation, confirm the log shows `falling back to per-rule searches` with the bad rule `errored` and the other rules still evaluated, then remove the rule.

**Reference (what "good" looks like):** OPERA's results are in **Testing & Validation** and **Test artifacts** above. Add your results in the NISAR/SWOT section below.
</details>

- [x] **OPERA** — validated on a DISP-S1 dev-e2e cluster (see **Testing & Validation** and **Test artifacts** above).
- [x] **NISAR** — validated on a dev-e2e golden-dataset venue (`nisar-gmanipon-1616`, hysds-framework v6.3.2 hot-patched per the OPERA pattern); see the NISAR section below.
- [ ] **SWOT** — _pending._

<details>
<summary>NISAR — test + validation (2026-07-07, dev-e2e golden-dataset venue)</summary>

**Deployment:** v6.3.2 venue (`nisar-gmanipon-1616`); this PR + hysds/hysds_commons#71 hot-patched into the factotum verdi venv at provision time (SHA-pinned tarball swap on mozart ops + explicit rsync/pip to factotum, adapted from nasa/opera-sds-pcm#1447; proof line `factotum patched: 3.3.0 2.4.0` in the provisioning log). lightweight-jobs `HC-633-retry-fixes` (#43 + #44) built on-venue and wired into the auto-retry/notify trigger rules.

**Golden-dataset smoke test — evaluator results (factotum, 1,024 evaluator worker logs):**
- **No dropped triggers:** every accountability check through L0 passed — NEN_L_RRST **1870/1870**, L0A_L_RRST 117, L0B_L_RRSD 27, L0B_L_CRSD 10, TLM reports and all datatake/observation/ldf state-configs at expected counts.
- **No crashes:** 0 evaluator exceptions (36 grep hits for `Traceback` are failed-job payloads logged by trigger workers while submitting retry jobs, not errors).
- **Single-`msearch` path throughout:** 9,718 `Evaluated N rules for <id>: matched=[...] errored=[]` summaries with **0 evaluations reporting errored rules, 0 parse-400 fallbacks, 0 transient per-item re-runs**; settled-probe lines present on both paths (2,302 dataset-path `Found settled`, 10,834 job-path `ensure_job_indexed`). The probe's retry arms fired at scale and absorbed every race: **8,151** "doc not yet search-visible" waits and **2,077** "search copy stale" (seq_no) waits — the exact race classes this PR closes — with zero dropped triggers.
- **Faster firing:** trigger evaluation fires within seconds of the status event (live failure→retry cycles ran ~10s end-to-end incl. the retry job, vs the old ≥32s fixed-sleep floor).
- RSLC/L1/L2 stage: the evaluators correctly fired all **102** SCIFLO_RSLC triggers; the jobs queued but could not run — AWS `InsufficientInstanceCapacity` for p4d.24xlarge in all us-west-2 AZs (GPU drought; unrelated to this PR). To be re-run when capacity returns.

**Retry-path validation (lightweight-jobs #43 + #44 via the rewired rules, all through this PR's evaluators):**
1. *Deterministic failure-injection:* a `job-lw-tosca-wget` with malformed JSON + a type-scoped auto-retry rule (`retry_count_max=3`): initial failure + 3 retries in **29 seconds** (~10s/cycle), every retry found its doc (no "not found ... Continuing" chain death at any cycle), capped cleanly with `retry_count_max limit of 3 reached. Cannot retry again.` Subsequently extended on-demand with the production-default `retry_count_max=10` — chain ran 3→10 and capped cleanly again.
2. *Organic:* a `retry-worker_terminated` rule fired for a failed `send_notify_msg` job and recovered it end-to-end.
3. *Operational:* an ingest job orphaned in `job-queued` by a worker cold-boot Redis failure (filed as HC-636) was recovered via an on-demand retry (3.4s) — the resubmitted ingest completed and unblocked the smoke test's NEN accountability check 4 seconds later.

**Additional targeted tests (post-smoke):** parse-400 fallback exercised live on NISAR (registered bad-DSL rule → `msearch rejected at request parse time` → per-rule fallback isolated it as `errored=['hc633-baddsl-test']` while the 81 sibling rules evaluated; replayed matched trigger deduped; rule removed after). notify_by_email validated both ways (doc-found 3.0s with metadata; doc-missing 8.0s — the ~5s delta is the retry-while-empty budget — then graceful degraded send). Retry of a nonexistent job id fails visibly with `job id ... not found` after the 4-try visibility loop (previously silent task-success). STARTED/revoke-wait validated live: a running SCIFLO_L0A_TE was revoked mid-run by an on-demand retry — `Lock ... still held ... retrying` → `Lock ... released, proceeding with resubmit` in ~1s, resubmission strictly after lock release (no duplicate execution). **Saturation campaign (2026-07-07, same venue) — the per-item transient path exercised at scale.** A controlled re-evaluation storm (111,100 `user_rules_dataset` evaluations over the restored 8.9M-doc catalog; 256 evaluator workers; each evaluation one msearch × 79-80 rules) drove the 3-node GRQ OpenSearch 3.6.0 cluster into genuine sustained search-thread-pool saturation:
- **176,307 cumulative server-side thread-pool rejections** (pools pinned at 49/49 active, queues over the 1000 capacity), cluster green throughout, heap ≤ 70%.
- **3,357 per-item transient errors inside 200 msearch responses** — both arms observed live: 429 `es_rejected_execution_exception` **and** 5xx `task_cancelled_exception`/fetch-phase failures — every one classified transient and re-run individually; **all 3,357 re-runs succeeded: 0 evaluations with errored rules, 0 request-level fallbacks, 111,100/111,100 evaluations completed.**
- **No dropped triggers under saturation, end-to-end:** a bounded trigger rule (100-doc slice → `lightweight-echo` jobs, dedup off) matched **800 times across 8 saturated rounds → 800 jobs submitted → 800 completed, 0 trigger-task failures** — a 1:1:1 matched/submitted/completed ledger while the cluster was rejecting thousands of searches per minute.
- Sub-saturation finding: at burst (1k) scale, 32 server-side rejections produced **zero** per-item errors — OpenSearch shard-copy failover absorbs isolated rejections invisibly; per-item 429s only surface when all copies saturate, which is exactly when the re-run path engages.
- This also empirically closes the review's rate-limiting recommendation: the deployed backpressure model (single-slot workers riding out rejections in bounded backoff) degraded to latency, never to lost verdicts.

**Not exercised live anywhere:** the force-release/held-lock branches of the revoke-wait (require a worker that survives revoke; design-reviewed).
</details>

<details>
<summary>NISAR — test artifacts (exact log excerpts)</summary>

**Hot-patch deployment proof** — `nisar-pcm-ci:~/dev/nisar-pcm/cluster_provisioning/dev-e2e-pge-golden_dataset-post-RSO/terraform.log`:
```
[2026-07-06 23:09:53.773163] module.common.aws_instance.mozart (remote-exec): + swap_ops_repo hysds_commons d14a178
[2026-07-06 23:09:55.235976] module.common.aws_instance.mozart (remote-exec): + swap_ops_repo hysds 4fb7a5c
[2026-07-06 23:12:26.116499] module.common.aws_instance.mozart (remote-exec): factotum patched: 3.3.0 2.4.0
[2026-07-07 00:15:26.121594] Apply complete! Resources: 322 added, 0 changed, 0 destroyed.
```

**Settled-probe race absorption** — `factotum:~/verdi/log/user_rules_dataset-NN.log` (256-proc groups; counts via `grep -c` summed across `user_rules_dataset-*.log` + `user_rules_job-*.log`: 8,151 not-yet-visible, 2,077 seq_no-stale, 2,302 `Found settled`, 10,834 `ensure_job_indexed`):
```
[2026-07-07 01:16:01,031: INFO/ForkPoolWorker-1] Backing off ensure_dataset_indexed(...) for 1.0s (RuntimeError: doc not yet search-visible: id_00-94-0000_orost-2025274-c003-d04-v01)
[2026-07-07 02:36:14,073: INFO/ForkPoolWorker-1] Backing off ensure_dataset_indexed(...) for 0.3s (RuntimeError: doc search copy stale: track_frame_002_117_045_0_state-config seq_no 0 < latest 1; awaiting refresh)
[2026-07-07 01:16:03,140: INFO/ForkPoolWorker-1] hysds.task_worker.run_task[2af8a46e-abf9-4468-a5ea-4fa307d78f0f]: Found settled indexed dataset: id_00-94-0000_orost-2025274-c003-d04-v01 (1)
```

**Per-evaluation verdict summaries** — `factotum:~/verdi/log/user_rules_job-NN.log` (9,718 total; 0 with non-empty `errored`):
```
[2026-07-07 01:38:33,569: INFO/ForkPoolWorker-1] hysds.task_worker.run_task[c5409196-9bcb-43f6-b1ca-719929d240e9]: Evaluated 5 rules for 9ec8f5f3-3b9e-4139-adc6-de409564f47d: matched=[] errored=[]
```

**Live parse-400 → per-rule fallback** (registered bad-DSL rule, forced one evaluation, removed after) — `factotum:~/verdi/log/user_rules_dataset-NN.log`:
```
[2026-07-07 10:26:02,965: ERROR/ForkPoolWorker-1] hysds.task_worker.run_task[6dd8283e-0c8d-4f58-ada5-8f96f7e1d895]: msearch rejected at request parse time (Exception occurred: RequestError(400, 'x_content_parse_exception', 'unknown query [termzz] did you mean any of [term, terms]?')); falling back to per-rule searches
[2026-07-07 10:26:37,286: ERROR/ForkPoolWorker-1] hysds.task_worker.run_task[6dd8283e-0c8d-4f58-ada5-8f96f7e1d895]: Rule 'hc633-baddsl-test' query failed for TIURDROP_UR_event_2025_10_13T07_26_08_075Z_e2025-286_c2025-286_v000 (0): {"reason": "Exception occurred: RequestError(400, 'x_content_parse_exception', 'unknown query [termzz] did you mean any of [term, terms]?')"}
[2026-07-07 10:26:37,286: INFO/ForkPoolWorker-1] hysds.task_worker.run_task[6dd8283e-0c8d-4f58-ada5-8f96f7e1d895]: Evaluated 82 rules for TIURDROP_UR_event_2025_10_13T07_26_08_075Z_e2025-286_c2025-286_v000 (0): matched=['trigger-purge-ISL'] errored=['hc633-baddsl-test']
```

**Accountability checks (no dropped triggers)** — `mozart:~/mozart/ops/nisar-pcm/cluster_provisioning/dev-e2e-pge-golden_dataset-post-RSO/run_smoke_test.log`:
```
[2026-07-07 02:30:53,398: INFO check_datasets_file.py:check_datasets] SUCCESS: Found 1870 expected NEN_L_RRST datasets of version '1'.
[2026-07-07 02:36:47,467: INFO check_datasets_file.py:check_datasets] SUCCESS: Found 117 expected L0A_L_RRST datasets of version 'CRID_VAL'.
[2026-07-07 03:16:37,970: INFO check_datasets_file.py:check_datasets] SUCCESS: Found 10 expected L0B_L_CRSD datasets of version 'CRID_VAL'.
[2026-07-07 03:58:02,719: INFO check_datasets_file.py:check_datasets] SUCCESS: Found 27 expected L0B_L_RRSD datasets of version 'CRID_VAL'.
```
</details>

<details>
<summary>SWOT — test + validation (placeholder)</summary>

_To be added by the SWOT team._
</details>

## Notes
Clean cherry-pick to the v6.1.2-era line is staged on branch `v3.1.x` (cut from tag v3.1.1) for venues on hysds-framework v6.1.2 that need this before v6.3.3.


---

## Update 2026-07-06 — per-item transient-error retry (review follow-up, commit 6c842ec)

The review recommendation on the ticket raised that the removed sleeps had been accidentally throttling OpenSearch under dense cascades. A client-side `threading.Semaphore` turns out to be a no-op in the deployed execution model — the user_rules evaluators run as prefork `--concurrency=1` celery worker processes scaled by supervisord `numprocs` (one task per process, so a per-process semaphore never has a second acquirer, and in-flight msearches are already hard-capped at `numprocs` cluster-wide). But the underlying saturation exposure is real, and it lands in this PR's code as a **correctness** gap rather than a throttling one: a search thread pool rejection (429) or a 5xx surfaces as a **per-item error inside a 200 msearch response**, which was treated as terminal for that rule — silently dropping its trigger. The old per-rule loop absorbed exactly these transients via its 5-try backoff; batching removed that.

Commit 6c842ec closes it: transient per-item errors (429/5xx; 400-class parse errors stay terminal for just their rule) are re-run individually through the existing per-rule fallback — `search_es` with bounded backoff, 400 giveup, and the same `preference` shard routing. Under overload this doubles as natural backpressure: the single-slot worker rides out the rejection in backoff instead of offering fresh msearches, so the cascade drain self-slows exactly when the cluster is saturated. Explicit throttle knobs, if operations wants them, are `numprocs` (the cluster-wide concurrency lever) and `max_concurrent_searches` (server-honored per-request fan-out cap, forwardable through `SearchUtility.msearch()` kwargs).

Tests: 7 added (per-item 429 re-run on both dataset + job paths with preference preserved, persistent-failure degradation, parse-400 stays terminal with no re-run attempted, retryable-classification unit tests). The re-run tests fail on the previous commit, confirming they bind the fix.







