### PR TITLE
HC-639, HC-638: prevent process_events and watchdog scripts from clobbering finalized job docs; make worker exceptions picklable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.3.1] - 2026-07-23
+
 ### Added
 - Python 3.12 compatibility updates
 - CHANGELOG.md file to track changes
@@ -17,6 +19,25 @@ All notable changes to this project will be documented in this file.
 - Updated test cases to work with Python 3.12
 
 ### Fixed
+- Failed job documents no longer lose their triage link (`products_staged`),
+  exit code, and duration to a stale overwrite by `event_processors.fail_job`
+  or the timeout watchdog (HC-639). Supervisory writers now consult the
+  synchronous redis status key (`is_job_finalized()`) immediately before
+  writing; the watchdog additionally waits a `-g/--grace-secs` grace period
+  (default 300s) measured from the task-failed event; `TASK_FAILED_RE` no
+  longer false-matches `SoftTimeLimitExceeded` as `TimeLimitExceeded`; and the
+  redis status-key TTL is derived from the job's own `time_limit`. The
+  watchdog also emits a per-sweep `divergence_count` WARNING (terminal redis
+  status with a stale non-terminal ES doc) as the health signal for lost
+  terminal writes. Behavior notes: `job-offline` counts as terminal for the
+  guard (timedout tagging declines on offline jobs whose redis key
+  survives), and a `ConnectionError` task-failed event for a worker that
+  already finalized no longer rewrites the job document.
+- `WorkerExecutionError`/`OrchestratorExecutionError` are picklable again, so
+  celery no longer reports `UnpickleableExceptionWrapper` in the result
+  backend and stored tracebacks (HC-638). MUST ship in the same release as
+  the HC-639 fix above: this change removes the traceback string operators
+  use to find documents damaged by HC-639.
 - Fixed `test_import` in `test_version.py` to use proper assertions
 - Resolved timezone-related `TypeError` exceptions in datetime operations
 

--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/event_processors.py
+++ b/hysds/event_processors.py
@@ -61,10 +61,7 @@ def _fail_job(event, uuid, exc, short_error):
     query = {"query": {"bool": {"must": [{"term": {"uuid": uuid}}]}}}
 
     result = mozart_es.search(index="job_status-current", body=query)
-    # TODO: Remove this after debugging
-    logger.info(f"job status from fail_job: {json.dumps(result, indent=2)}")
     total = result["hits"]["total"]["value"]
-    logger.info(f"total results back from fail_job function: {total}")
     if total == 0:
         msg = f"Failed to query for task UUID {uuid}"
         logger.error(msg)

--- a/hysds/event_processors.py
+++ b/hysds/event_processors.py
@@ -3,6 +3,7 @@ from future import standard_library
 standard_library.install_aliases()
 
 import json
+import re
 import socket
 import traceback
 
@@ -17,6 +18,7 @@ from hysds.log_utils import (
     backoff_max_tries,
     backoff_max_value,
     get_val_via_socket,
+    is_job_finalized,
     log_job_status,
     logger,
 )
@@ -26,10 +28,35 @@ from hysds.user_rules_job import queue_finished_job
 
 mozart_es = get_mozart_es()
 
+# task-failed patterns meaning "the worker had no chance to send an update".
+# A soft time limit is not one: the worker catches it, triages, and logs its
+# own job-failed doc. The lookbehind keeps SoftTimeLimitExceeded from
+# matching TimeLimitExceeded.
+TASK_FAILED_RE = re.compile(
+    r"(?<![A-Za-z])(WorkerLostError|TimeLimitExceeded|ConnectionError)"
+)
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=5, max_value=10)
+
 def fail_job(event, uuid, exc, short_error):
     """Set job status to job-failed."""
+
+    # log_job_status() is async on the ES side, so the ES read below can
+    # trail the worker's own terminal write; the redis key is authoritative
+    # (same re-check pattern as offline_jobs below). The guard sits OUTSIDE
+    # the retried body: _fail_job's own write sets the key to job-failed, so
+    # a retried guard would read its own write and drop the requeue.
+    if is_job_finalized(uuid):
+        logger.info(
+            f"fail_job - {uuid}: worker already finalized this job; "
+            f"not overwriting. exc={exc}, short_error={short_error}"
+        )
+        return
+    _fail_job(event, uuid, exc, short_error)
+
+
+@backoff.on_exception(backoff.expo, Exception, max_tries=5, max_value=10)
+def _fail_job(event, uuid, exc, short_error):
+    """Rewrite the job doc as job-failed and requeue rule evaluation."""
 
     query = {"query": {"bool": {"must": [{"term": {"uuid": uuid}}]}}}
 

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -574,7 +574,9 @@ def run_job(job, queue_when_finished=True):
                 message = f"Redelivered job for payload {payload_id} - lock held by {lock_holder_info}. Deduping this job."
                 logger.warning(message)
                 job_status_json = {
-                    "uuid": job["job_id"],
+                    # uuid = celery task id (as at every sibling call site);
+                    # job_id would key a redis entry nobody reads
+                    "uuid": job["task_id"],
                     "job_id": job["job_id"],
                     "payload_id": payload_id,
                     "payload_hash": payload_hash,

--- a/hysds/job_worker.py
+++ b/hysds/job_worker.py
@@ -360,13 +360,12 @@ def redelivered_job_dup(job):
 
 
 class WorkerExecutionError(Exception):
-    def __init__(self, message, job_status):
+    # celery rebuilds exceptions via cls(*exc.args); params outside args need
+    # defaults or the class degrades to UnpickleableExceptionWrapper
+    def __init__(self, message, job_status=None):
         self.message = message
         self.job_status = job_status
         super().__init__(message)
-
-    def job_status(self):
-        return self.job_status
 
 
 class JobDedupedError(Exception):
@@ -374,9 +373,6 @@ class JobDedupedError(Exception):
         self.message = message
         self.job_status = "job-deduped"
         super().__init__(message)
-
-    def job_status(self):
-        return self.job_status
 
 
 def shutdown_worker(celery_hostname):

--- a/hysds/log_utils.py
+++ b/hysds/log_utils.py
@@ -226,6 +226,35 @@ def get_job_status(task_id):
     return res.decode() if hasattr(res, "decode") else res
 
 
+# statuses after which an authoritative terminal doc has been logged.
+# job-offline is included: a job never leaves it on its own, so any
+# supervisory rewrite over it is destructive.
+TERMINAL_JOB_STATUSES = frozenset(
+    {"job-completed", "job-failed", "job-deduped", "job-offline", "job-revoked"}
+)
+
+
+def is_job_finalized(task_id):
+    """Return True if a terminal status was already logged for this task.
+
+    Reads the synchronous redis key set by log_job_status(), authoritative
+    while the ES doc is still in flight (redis list -> logstash -> ES).
+    Supervisory writers must check this before rewriting a job doc. Fails
+    open (False) on a missing key or redis error.
+    """
+    try:
+        status = get_job_status(task_id)
+    except Exception as e:
+        logger.warning(f"is_job_finalized({task_id}): redis check failed: {e}")
+        return False
+    if status is None:
+        logger.warning(
+            f"is_job_finalized({task_id}): no redis job-status key (missing or expired)"
+        )
+        return False
+    return status in TERMINAL_JOB_STATUSES
+
+
 @backoff.on_exception(
     backoff.expo, RedisError, max_tries=backoff_max_tries, max_value=backoff_max_value
 )
@@ -255,9 +284,16 @@ def log_job_status(job):
     # send update to redis
     r = StrictRedis(connection_pool=JOB_STATUS_POOL,
                     ssl_ciphers=app.conf.get("broker_use_ssl", {}).get("ciphers"))
+    # derive the key TTL from the job's own time_limit: a fixed TTL expires
+    # mid-run for any job that outlives it, silently disabling
+    # is_job_finalized() for exactly the jobs most likely to soft-limit
+    ttl = app.conf.HYSDS_JOB_STATUS_EXPIRES
+    time_limit = job.get("job", {}).get("job_info", {}).get("time_limit")
+    if isinstance(time_limit, int):
+        ttl = max(ttl, time_limit + 2 * hard_time_limit_gap())
     r.setex(
         JOB_STATUS_KEY_TMPL % job["uuid"],
-        app.conf.HYSDS_JOB_STATUS_EXPIRES,
+        ttl,
         job["status"],
     )
     r.rpush(app.conf.REDIS_JOB_STATUS_KEY, msgpack.dumps(job_for_indexing))  # for ES

--- a/hysds/log_utils.py
+++ b/hysds/log_utils.py
@@ -289,8 +289,11 @@ def log_job_status(job):
     # is_job_finalized() for exactly the jobs most likely to soft-limit
     ttl = app.conf.HYSDS_JOB_STATUS_EXPIRES
     time_limit = job.get("job", {}).get("job_info", {}).get("time_limit")
-    if isinstance(time_limit, int):
-        ttl = max(ttl, time_limit + 2 * hard_time_limit_gap())
+    # accept int or float, but not bool (an int subclass); mirrors the
+    # watchdog's check so a float time_limit never leaves the TTL unextended.
+    # int() the value so the setex TTL stays an integer number of seconds.
+    if isinstance(time_limit, (int, float)) and not isinstance(time_limit, bool):
+        ttl = max(ttl, int(time_limit) + 2 * hard_time_limit_gap())
     r.setex(
         JOB_STATUS_KEY_TMPL % job["uuid"],
         ttl,

--- a/hysds/orchestrator.py
+++ b/hysds/orchestrator.py
@@ -96,13 +96,12 @@ def get_job_id(job_name):
 
 
 class OrchestratorExecutionError(Exception):
-    def __init__(self, message, job_status):
+    # celery rebuilds exceptions via cls(*exc.args); params outside args need
+    # defaults or the class degrades to UnpickleableExceptionWrapper
+    def __init__(self, message, job_status=None):
         self.message = message
         self.job_status = job_status
         super().__init__(message)
-
-    def job_status(self):
-        return self.job_status
 
 
 @app.task

--- a/scripts/offline_orphaned_jobs.py
+++ b/scripts/offline_orphaned_jobs.py
@@ -21,7 +21,7 @@ from kombu.serialization import loads, prepare_accept_content, registry
 from redis import ConnectionPool, StrictRedis
 
 from hysds.celery import app
-from hysds.log_utils import log_job_status
+from hysds.log_utils import is_job_finalized, log_job_status
 from hysds.utils import datetime_iso_naive
 
 log_format = "[%(asctime)s: %(levelname)s/offline_orphaned_jobs] %(message)s"
@@ -123,6 +123,15 @@ def offline_orphaned_jobs(es_url, dry_run=False):
                     f"Cannot handle task status {task_info['_source']['status']} for {task_id}."
                 )
                 continue
+            # never rewrite a job the worker already finalized; checked
+            # before the dry-run branch so dry-run reports what a real run
+            # would actually write
+            if is_job_finalized(task_id):
+                logging.info(
+                    f"{'DRY RUN - ' if dry_run else ''}Job {id}: worker "
+                    f"already finalized; not overwriting."
+                )
+                continue
             if dry_run:
                 logging.info(
                     f"DRY RUN - Would update job {id} status to {updated_status} for task {task_id}"
@@ -149,6 +158,13 @@ def offline_orphaned_jobs(es_url, dry_run=False):
         )
         if task_meta is None:
             updated_status = "job-offline"
+            # guard before the dry-run branch, as above
+            if is_job_finalized(task_id):
+                logging.info(
+                    f"{'DRY RUN - ' if dry_run else ''}Job {id}: worker "
+                    f"already finalized; not overwriting."
+                )
+                continue
             if dry_run:
                 logging.info(
                     f"DRY RUN - Would update job {id} status to {updated_status} for task {task_id}"

--- a/scripts/process_events.py
+++ b/scripts/process_events.py
@@ -14,7 +14,7 @@ from redis import ConnectionPool, StrictRedis
 
 import hysds
 from hysds.celery import app
-from hysds.event_processors import queue_fail_job, queue_offline_jobs
+from hysds.event_processors import TASK_FAILED_RE, queue_fail_job, queue_offline_jobs
 from hysds.log_utils import (
     WORKER_STATUS_KEY_TMPL,
     backoff_max_tries,
@@ -36,9 +36,8 @@ POOL = None
 ORCH_HOST_RE = re.compile(r"^celery@orchestrator")
 ORCH_NAME_RE = re.compile(r"^hysds.orchestrator.submit_job")
 
-# regex for task-failed errors that won't be updated in ES because
-# worker had no chance to send update
-TASK_FAILED_RE = re.compile(r"(WorkerLostError|TimeLimitExceeded|ConnectionError)")
+# TASK_FAILED_RE now lives in hysds.event_processors so it is importable
+# and unit-testable
 
 # regex for extracting type and hostname from worker
 TYPE_RE = re.compile(r"'type': '(.+?)',")

--- a/scripts/watchdog_job_timeouts.py
+++ b/scripts/watchdog_job_timeouts.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 import job_utils
 
 from hysds.celery import app
-from hysds.log_utils import log_job_status
+from hysds.log_utils import get_job_status, is_job_finalized, log_job_status
 from hysds.utils import get_short_error, parse_iso8601
 
 log_format = "[%(asctime)s: %(levelname)s/watchdog_job_timeouts] %(message)s"
@@ -24,7 +24,7 @@ logging.basicConfig(format=log_format, level=logging.INFO)
 UNDETERMINED_BY_WATCHDOG = "undetermined by watchdog"
 
 
-def tag_timedout_jobs(url, timeout):
+def tag_timedout_jobs(url, timeout, grace_secs=300):
     """Tag jobs stuck in job-started or job-offline that have timed out."""
 
     status = ["job-started", "job-offline"]
@@ -47,18 +47,29 @@ def tag_timedout_jobs(url, timeout):
     )
 
     # tag each with timedout
+    divergence_count = 0
     for res in results:
         _id = res["_id"]
         _index = res["_index"]
         src = res.get("_source", {})
-        status = src["status"]
-        tags = src.get("tags", [])
-        task_id = src["uuid"]
-        celery_hostname = src["celery_hostname"]
+        try:
+            status = src["status"]
+            tags = src.get("tags", [])
+            task_id = src["uuid"]
+            celery_hostname = src["celery_hostname"]
 
-        # get job duration
-        time_limit = src["job"]["job_info"]["time_limit"]
-        time_start = parse_iso8601(src["job"]["job_info"]["time_start"])
+            # get job duration
+            time_limit = src["job"]["job_info"]["time_limit"]
+            if isinstance(time_limit, bool) or not isinstance(
+                time_limit, (int, float)
+            ):
+                raise TypeError(f"non-numeric time_limit: {time_limit!r}")
+            time_start = parse_iso8601(src["job"]["job_info"]["time_start"])
+        except (KeyError, TypeError, ValueError) as e:
+            # a partial doc must not abort the sweep: an escaped exception
+            # strands every job later in the scroll
+            logging.error(f"Job {_id}: skipping partial job_status doc ({e}).")
+            continue
         time_now = datetime.now(timezone.utc)
         duration = (time_now - time_start).total_seconds()
 
@@ -66,7 +77,9 @@ def tag_timedout_jobs(url, timeout):
             # get task info, sort by latest since we only look at the first hit
             task_query = {
                 "query": {"term": {"_id": task_id}},
-                "_source": ["status", "event"],
+                # @timestamp: the grace period is measured from the
+                # task-failed event
+                "_source": ["status", "event", "@timestamp"],
                 "sort": [{"@timestamp": {"order": "desc"}}],
             }
             task_res = job_utils.es_query(task_query, index="task_status-current")
@@ -106,6 +119,24 @@ def tag_timedout_jobs(url, timeout):
             if len(task_res["hits"]["hits"]) > 0:
                 task_info = task_res["hits"]["hits"][0]
                 if task_info["_source"]["status"] == "task-failed":
+                    # grace runs from the task-failed event (not job start)
+                    # so the worker's async job-failed doc can land in ES;
+                    # deferral writes nothing (a write would re-stamp
+                    # @timestamp and reset eligibility)
+                    task_ts = task_info["_source"].get("@timestamp")
+                    if task_ts is not None:
+                        try:
+                            age = (time_now - parse_iso8601(task_ts)).total_seconds()
+                        except (ValueError, TypeError):
+                            # malformed/non-string @timestamp: fail open to
+                            # the redis guard rather than abort the sweep
+                            age = None
+                        if age is not None and age < grace_secs:
+                            logging.info(
+                                f"Job {_id}: task-failed {age:.0f}s ago, within "
+                                f"{grace_secs}s grace; deferring to the worker."
+                            )
+                            continue
                     new_status = "job-failed"
                     error = (
                         task_info.get("_source", {})
@@ -132,6 +163,24 @@ def tag_timedout_jobs(url, timeout):
                     src["short_error"] = short_error
                     src["traceback"] = error_traceback
 
+                # guard immediately before the write (not loop top:
+                # job-offline docs must still reach the tag lane below)
+                if is_job_finalized(task_id):
+                    redis_status = get_job_status(task_id)
+                    if redis_status != status:
+                        # terminal in redis but the ES doc never converged:
+                        # the health signal for a lost terminal write
+                        divergence_count += 1
+                        logging.warning(
+                            f"Job {_id}: DIVERGENCE redis={redis_status} "
+                            f"es={status}; declining rewrite."
+                        )
+                    else:
+                        logging.info(
+                            f"Job {_id}: worker already finalized; not overwriting."
+                        )
+                    continue
+
                 # Use log_job_status() to ensure all required fields are populated
                 # and the update goes through the proper Redis->Logstash pipeline
                 try:
@@ -144,6 +193,22 @@ def tag_timedout_jobs(url, timeout):
 
         if "timedout" not in tags:
             if duration > time_limit:
+                # this path republishes the whole stale _source, status
+                # included; never over a finalized job
+                if is_job_finalized(task_id):
+                    redis_status = get_job_status(task_id)
+                    if redis_status != status:
+                        divergence_count += 1
+                        logging.warning(
+                            f"Job {_id}: DIVERGENCE redis={redis_status} "
+                            f"es={status}; declining tag write."
+                        )
+                    else:
+                        logging.info(
+                            f"Job {_id}: worker already finalized; not tagging "
+                            f"via stale doc."
+                        )
+                    continue
                 tags.append("timedout")
                 src["tags"] = tags
 
@@ -155,8 +220,16 @@ def tag_timedout_jobs(url, timeout):
                     logging.error(f"Failed to log job status for {_id}: {e}")
                     logging.error(traceback.format_exc())
 
+    if divergence_count:
+        # per-sweep health metric: alarm on this line to see strands that
+        # converge only when the redis key expires
+        logging.warning(
+            f"divergence_count={divergence_count} docs with a terminal redis "
+            f"status but a stale non-terminal ES doc this sweep"
+        )
 
-def daemon(interval, url, timeout):
+
+def daemon(interval, url, timeout, grace_secs=300):
     """Watch for jobs that have timed out in job-started or job-offline state."""
 
     interval_min = interval - int(interval / 4)
@@ -166,10 +239,11 @@ def daemon(interval, url, timeout):
     logging.info(f"interval max: {interval_max}")
     logging.info(f"url: {url}")
     logging.info(f"timeout threshold: {timeout}")
+    logging.info(f"task-failed grace period: {grace_secs}")
 
     while True:
         try:
-            tag_timedout_jobs(url, timeout)
+            tag_timedout_jobs(url, timeout, grace_secs)
         except Exception as e:
             logging.error(f"Got error: {e}")
             logging.error(traceback.format_exc())
@@ -193,5 +267,16 @@ if __name__ == "__main__":
     parser.add_argument(
         "-t", "--timeout", type=int, default=86400, help="timeout threshold"
     )
+    # a flag (not an env var) so deployments that override -t/-i on the
+    # supervisord command line can set it the same way
+    parser.add_argument(
+        "-g",
+        "--grace-secs",
+        type=int,
+        default=300,
+        help="seconds to wait after a task-failed event before rewriting the "
+        "job doc, giving the worker's own async job-failed doc time to land "
+        "in ES",
+    )
     args = parser.parse_args()
-    daemon(args.interval, args.url, args.timeout)
+    daemon(args.interval, args.url, args.timeout, args.grace_secs)

--- a/test/test_event_processors.py
+++ b/test/test_event_processors.py
@@ -1,0 +1,212 @@
+import importlib.util
+import pathlib
+import sys
+import unittest.mock as umock
+
+import pytest
+
+# hysds.celery reads configuration on import, so mock it before any hysds
+# import. event_processors also instantiates a mozart ES client at module
+# scope (get_mozart_es -> reads ~/.netrc-os), so hysds.es_util must be mocked
+# too. FORCE both (not setdefault): under CI's single-process collection an
+# earlier test file imports the real modules first, which would make setdefault
+# a no-op and let the netrc read escape. unsafe=True because user_rules_job
+# does `from hysds.es_util import assert_doc_settled` and a default MagicMock
+# raises AttributeError for attributes starting with "assert". Snapshot and
+# restore afterwards so this does not pollute later test files (test_user_rules,
+# test_triage) that need the real modules.
+# restore es_util and the two modules that bind it at import, so the mock does
+# not leak into later test files. celery stays mocked (test_job_worker does the
+# same). event_processors stays cached on purpose -- the regex-provenance test
+# below relies on `pe.TASK_FAILED_RE is ep.TASK_FAILED_RE`, which requires the
+# script to import this exact module object.
+_saved = {k: sys.modules.get(k) for k in
+          ("hysds.es_util", "hysds.user_rules_job", "hysds.task_worker")}
+sys.modules["hysds.celery"] = umock.MagicMock()
+sys.modules["hysds.es_util"] = umock.MagicMock(unsafe=True)
+
+import hysds.event_processors as ep  # noqa: E402
+
+for _k, _v in _saved.items():
+    if _v is not None:
+        sys.modules[_k] = _v
+    else:
+        sys.modules.pop(_k, None)
+
+# (exception string, should trigger the ES-overwrite path)
+CASES = [
+    ("WorkerExecutionError('SoftTimeLimitExceeded()')", False),
+    ("SoftTimeLimitExceeded()", False),
+    (
+        "UnpickleableExceptionWrapper: WorkerExecutionError('SoftTimeLimitExceeded()')",
+        False,
+    ),
+    ("TimeLimitExceeded(3600,)", True),
+    ("celery.exceptions.TimeLimitExceeded(3600,)", True),
+    ("WorkerLostError('Worker exited prematurely: signal 9 (SIGKILL).')", True),
+    ("ConnectionError('Error 111 connecting to redis')", True),
+]
+
+
+@pytest.mark.parametrize("exc,should_match", CASES)
+def test_task_failed_re_classification(exc, should_match):
+    """AC1: SoftTimeLimitExceeded must not false-match TimeLimitExceeded."""
+    assert bool(ep.TASK_FAILED_RE.search(exc)) is should_match
+
+
+def test_guard_reads_redis_not_es():
+    """Two functions named get_job_status exist with opposite staleness:
+    hysds.log_utils (redis, correct) and hysds.utils (ES, the lagging store
+    this guard exists to avoid). Pin the import provenance -- a wrong import
+    passes every behavioral test here and does nothing in production."""
+    import hysds.log_utils as lu
+
+    assert ep.is_job_finalized is lu.is_job_finalized
+
+
+def test_fail_job_skips_when_worker_finalized(monkeypatch):
+    """AC2: no ES read and no write when redis says the job is terminal."""
+    monkeypatch.setattr(ep, "is_job_finalized", lambda uuid: True)
+    mock_es = umock.MagicMock()
+    monkeypatch.setattr(ep, "mozart_es", mock_es)
+    mock_log = umock.MagicMock()
+    monkeypatch.setattr(ep, "log_job_status", mock_log)
+
+    ep.fail_job({"traceback": "tb"}, "uuid-1", "exc", "short")
+
+    mock_es.search.assert_not_called()
+    mock_log.assert_not_called()
+
+
+def test_fail_job_proceeds_when_worker_not_finalized(monkeypatch):
+    """AC5: a genuinely lost worker is still reaped."""
+    monkeypatch.setattr(ep, "is_job_finalized", lambda uuid: False)
+    mock_es = umock.MagicMock()
+    mock_es.search.return_value = {
+        "hits": {
+            "total": {"value": 1},
+            "hits": [
+                {
+                    "_index": "job_status-current",
+                    "_source": {
+                        "status": "job-started",
+                        "payload_id": "p1",
+                        "uuid": "uuid-1",
+                        "job": {"job_info": {}},
+                    },
+                }
+            ],
+        }
+    }
+    monkeypatch.setattr(ep, "mozart_es", mock_es)
+    mock_log = umock.MagicMock()
+    monkeypatch.setattr(ep, "log_job_status", mock_log)
+    mock_finished = umock.MagicMock()
+    monkeypatch.setattr(ep, "queue_finished_job", mock_finished)
+
+    ep.fail_job(
+        {"traceback": "tb"},
+        "uuid-1",
+        "WorkerLostError('Worker exited prematurely: signal 9 (SIGKILL).')",
+        "WorkerLostError",
+    )
+
+    mock_log.assert_called_once()
+    written = mock_log.call_args[0][0]
+    assert written["status"] == "job-failed"
+    assert written["short_error"] == "WorkerLostError"
+    assert written["job"]["job_info"]["time_end"].endswith("Z")
+    mock_finished.assert_called_once()
+
+
+def test_script_imports_the_package_regex():
+    """scripts/process_events.py must consume the shared regex, not a stale
+    local copy -- reverting only the script hunk brings the false-match back."""
+    sys.modules.setdefault("future", umock.MagicMock())
+    scripts = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+    spec = importlib.util.spec_from_file_location(
+        "process_events", scripts / "process_events.py"
+    )
+    pe = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(pe)
+    assert pe.TASK_FAILED_RE is ep.TASK_FAILED_RE
+
+
+def test_retry_does_not_self_arm_guard(monkeypatch):
+    """A transient queue_finished_job failure must not let the backoff retry
+    read the redis key the first attempt wrote and silently drop the requeue."""
+    state = {"finalized": False, "queue_calls": 0}
+    monkeypatch.setattr(ep, "is_job_finalized", lambda uuid: state["finalized"])
+    mock_es = umock.MagicMock()
+
+    def fresh_stale_response(*args, **kwargs):
+        # each retry re-queries ES, which is still serving the stale doc
+        return {
+            "hits": {
+                "total": {"value": 1},
+                "hits": [
+                    {
+                        "_index": "job_status-current",
+                        "_source": {
+                            "status": "job-started",
+                            "payload_id": "p1",
+                            "uuid": "uuid-1",
+                            "job": {"job_info": {}},
+                        },
+                    }
+                ],
+            }
+        }
+
+    mock_es.search.side_effect = fresh_stale_response
+    monkeypatch.setattr(ep, "mozart_es", mock_es)
+
+    def log_side_effect(job_status):
+        # the synchronous setex the real write performs
+        state["finalized"] = True
+
+    monkeypatch.setattr(
+        ep, "log_job_status", umock.MagicMock(side_effect=log_side_effect)
+    )
+
+    def queue_side_effect(payload_id, index=None):
+        state["queue_calls"] += 1
+        if state["queue_calls"] == 1:
+            raise ConnectionError("transient hiccup")
+
+    monkeypatch.setattr(
+        ep, "queue_finished_job", umock.MagicMock(side_effect=queue_side_effect)
+    )
+
+    ep.fail_job(
+        {"traceback": "tb"},
+        "uuid-1",
+        "WorkerLostError('Worker exited prematurely: signal 9 (SIGKILL).')",
+        "WorkerLostError",
+    )
+
+    assert state["queue_calls"] == 2
+
+
+def test_fail_job_leaves_terminal_es_doc_alone(monkeypatch):
+    """Second line of defence: the pre-existing ES-status else-branch."""
+    monkeypatch.setattr(ep, "is_job_finalized", lambda uuid: False)
+    mock_es = umock.MagicMock()
+    mock_es.search.return_value = {
+        "hits": {
+            "total": {"value": 1},
+            "hits": [
+                {
+                    "_index": "job_status-current",
+                    "_source": {"status": "job-failed", "payload_id": "p1"},
+                }
+            ],
+        }
+    }
+    monkeypatch.setattr(ep, "mozart_es", mock_es)
+    mock_log = umock.MagicMock()
+    monkeypatch.setattr(ep, "log_job_status", mock_log)
+
+    ep.fail_job({"traceback": "tb"}, "uuid-1", "exc", "short")
+
+    mock_log.assert_not_called()

--- a/test/test_event_processors.py
+++ b/test/test_event_processors.py
@@ -65,17 +65,23 @@ def test_guard_reads_redis_not_es():
 
 
 def test_fail_job_skips_when_worker_finalized(monkeypatch):
-    """AC2: no ES read and no write when redis says the job is terminal."""
+    """AC2: when redis says the job is terminal the guard declines -- no ES
+    read, no write, and no rule requeue. Skipping queue_finished_job here is
+    correct: the worker's own job-failed path already triggers rule
+    evaluation, so the supervisory path must not re-fire it."""
     monkeypatch.setattr(ep, "is_job_finalized", lambda uuid: True)
     mock_es = umock.MagicMock()
     monkeypatch.setattr(ep, "mozart_es", mock_es)
     mock_log = umock.MagicMock()
     monkeypatch.setattr(ep, "log_job_status", mock_log)
+    mock_finished = umock.MagicMock()
+    monkeypatch.setattr(ep, "queue_finished_job", mock_finished)
 
     ep.fail_job({"traceback": "tb"}, "uuid-1", "exc", "short")
 
     mock_es.search.assert_not_called()
     mock_log.assert_not_called()
+    mock_finished.assert_not_called()
 
 
 def test_fail_job_proceeds_when_worker_not_finalized(monkeypatch):

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -1,0 +1,74 @@
+import pickle
+import sys
+import unittest.mock as umock
+
+import pytest
+
+# hysds.celery searches for configuration on import, so mock it before any
+# hysds import. setdefault, not bare assignment: module-scope sys.modules
+# mutation is the cross-test-pollution pattern that forced test_lock.py into
+# its own pytest process in CI.
+sys.modules.setdefault("hysds.celery", umock.MagicMock())
+# hysds.orchestrator pulls hysds.es_util transitively, which imports
+# opensearchpy at module scope.
+sys.modules.setdefault("opensearchpy", umock.MagicMock())
+sys.modules.setdefault("opensearchpy.exceptions", umock.MagicMock())
+
+from celery.utils.serialization import get_pickleable_exception  # noqa: E402
+
+from hysds.job_worker import JobDedupedError, WorkerExecutionError  # noqa: E402
+from hysds.orchestrator import OrchestratorExecutionError  # noqa: E402
+
+EXC_CLASSES = [WorkerExecutionError, OrchestratorExecutionError]
+JOB_STATUS = {"status": "job-failed", "error": "SoftTimeLimitExceeded()"}
+
+
+@pytest.mark.parametrize("cls", EXC_CLASSES)
+def test_pickle_round_trip(cls):
+    """AC1: cls(*args) reconstruction must succeed."""
+    exc = cls("boom", JOB_STATUS)
+    restored = pickle.loads(pickle.dumps(exc))
+    assert type(restored) is cls
+    assert str(restored) == "boom"
+
+
+@pytest.mark.parametrize("cls", EXC_CLASSES)
+def test_args_carry_message_only(cls):
+    """AC2: args carries only the message (keeps tracebacks small)."""
+    exc = cls("boom", JOB_STATUS)
+    assert exc.args == ("boom",)
+    assert "job-failed" not in repr(exc)
+
+
+@pytest.mark.parametrize("cls", EXC_CLASSES)
+def test_job_status_optional_and_defaults_none(cls):
+    """AC1: single-arg construction is what pickle performs."""
+    exc = cls("boom")
+    assert exc.job_status is None
+    assert exc.message == "boom"
+
+
+@pytest.mark.parametrize("cls", EXC_CLASSES)
+def test_job_status_attribute_preserved(cls):
+    """AC3: attribute access still works after removing the dead method."""
+    exc = cls("boom", JOB_STATUS)
+    assert exc.job_status == JOB_STATUS
+    assert not callable(exc.job_status)
+
+
+@pytest.mark.parametrize("cls", EXC_CLASSES)
+def test_celery_does_not_wrap(cls):
+    """AC4: this is the regression test for the bug itself."""
+    exc = cls("boom", JOB_STATUS)
+    safe = get_pickleable_exception(exc)
+    assert type(safe) is cls
+    assert "UnpickleableExceptionWrapper" not in repr(safe)
+
+
+def test_job_deduped_error_attribute_not_callable():
+    """AC3: JobDedupedError shares the dead-method cleanup."""
+    exc = JobDedupedError("dup")
+    assert exc.job_status == "job-deduped"
+    assert not callable(exc.job_status)
+    restored = pickle.loads(pickle.dumps(exc))
+    assert type(restored) is JobDedupedError

--- a/test/test_log_utils.py
+++ b/test/test_log_utils.py
@@ -1,0 +1,89 @@
+import sys
+import unittest.mock as umock
+
+import pytest
+
+# hysds.celery searches for configuration on import, so mock it before any
+# hysds import. setdefault to avoid cross-test pollution.
+sys.modules.setdefault("hysds.celery", umock.MagicMock())
+
+import hysds.log_utils as lu  # noqa: E402
+
+TERMINAL = ["job-completed", "job-failed", "job-deduped", "job-offline", "job-revoked"]
+NON_TERMINAL = ["job-queued", "job-started"]
+
+
+@pytest.mark.parametrize("status", TERMINAL)
+def test_is_job_finalized_true_for_terminal(monkeypatch, status):
+    monkeypatch.setattr(lu, "get_job_status", lambda task_id: status)
+    assert lu.is_job_finalized("uuid-1") is True
+
+
+@pytest.mark.parametrize("status", NON_TERMINAL)
+def test_is_job_finalized_false_for_non_terminal(monkeypatch, status):
+    monkeypatch.setattr(lu, "get_job_status", lambda task_id: status)
+    assert lu.is_job_finalized("uuid-1") is False
+
+
+def test_is_job_finalized_false_on_missing_key(monkeypatch):
+    """Fail open: absence of evidence must not disable the backstop."""
+    monkeypatch.setattr(lu, "get_job_status", lambda task_id: None)
+    assert lu.is_job_finalized("uuid-1") is False
+
+
+def test_is_job_finalized_false_on_redis_error(monkeypatch):
+    def boom(task_id):
+        raise ConnectionError("redis down")
+
+    monkeypatch.setattr(lu, "get_job_status", boom)
+    assert lu.is_job_finalized("uuid-1") is False
+
+
+def _run_log_job_status(monkeypatch, job):
+    """Run log_job_status with redis mocked out; return the mock client."""
+    # monkeypatch (never plain assignment): lu.app is the session-shared
+    # hysds.celery mock, and stray conf values would leak into every
+    # later-collected test file
+    monkeypatch.setattr(lu.app.conf, "HYSDS_JOB_STATUS_EXPIRES", 86400, raising=False)
+    monkeypatch.setattr(lu.app.conf, "HARD_TIME_LIMIT_GAP", 300, raising=False)
+    monkeypatch.setattr(lu.app.conf, "REDIS_JOB_STATUS_KEY", "logstash", raising=False)
+    monkeypatch.setattr(lu, "set_redis_job_status_pool", lambda: None)
+    mock_redis = umock.MagicMock()
+    monkeypatch.setattr(lu, "StrictRedis", umock.MagicMock(return_value=mock_redis))
+    lu.log_job_status(job)
+    return mock_redis
+
+
+def _job(time_limit):
+    job = {
+        "uuid": "uuid-1",
+        "status": "job-started",
+        "job": {"type": "test", "job_info": {}},
+    }
+    if time_limit is not None:
+        job["job"]["job_info"]["time_limit"] = time_limit
+    return job
+
+
+def test_status_key_ttl_exceeds_long_time_limit(monkeypatch):
+    """The key must outlive an 86400s-limit job or the guard is disabled for
+    exactly the population most likely to soft-limit."""
+    r = _run_log_job_status(monkeypatch, _job(86700))
+    ttl = r.setex.call_args[0][1]
+    assert ttl == 86700 + 2 * 300
+    assert ttl > 86400
+
+
+def test_status_key_ttl_floors_at_configured_expires(monkeypatch):
+    r = _run_log_job_status(monkeypatch, _job(600))
+    assert r.setex.call_args[0][1] == 86400
+
+
+def test_status_key_ttl_defaults_without_time_limit(monkeypatch):
+    r = _run_log_job_status(monkeypatch, _job(None))
+    assert r.setex.call_args[0][1] == 86400
+
+
+def test_status_key_ttl_ignores_non_int_time_limit(monkeypatch):
+    r = _run_log_job_status(monkeypatch, _job("86700"))
+    assert r.setex.call_args[0][1] == 86400

--- a/test/test_log_utils.py
+++ b/test/test_log_utils.py
@@ -87,3 +87,12 @@ def test_status_key_ttl_defaults_without_time_limit(monkeypatch):
 def test_status_key_ttl_ignores_non_int_time_limit(monkeypatch):
     r = _run_log_job_status(monkeypatch, _job("86700"))
     assert r.setex.call_args[0][1] == 86400
+
+
+def test_status_key_ttl_extends_for_float_time_limit(monkeypatch):
+    """A float time_limit must extend the TTL like an int (the watchdog accepts
+    floats); the resulting TTL stays an integer for setex."""
+    r = _run_log_job_status(monkeypatch, _job(86700.5))
+    ttl = r.setex.call_args[0][1]
+    assert ttl == 86700 + 2 * 300
+    assert isinstance(ttl, int)

--- a/test/test_offline_orphaned_jobs.py
+++ b/test/test_offline_orphaned_jobs.py
@@ -1,0 +1,24 @@
+import importlib.util
+import pathlib
+import sys
+import unittest.mock as umock
+
+# hysds.celery searches for configuration on import, so mock it before any
+# hysds import; setdefault to avoid cross-test pollution.
+sys.modules.setdefault("hysds.celery", umock.MagicMock())
+sys.modules.setdefault("future", umock.MagicMock())
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "offline_orphaned_jobs", SCRIPTS / "offline_orphaned_jobs.py"
+)
+ooj = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ooj)
+
+
+def test_guard_reads_redis_not_es():
+    """Pin the guard's import provenance to hysds.log_utils (redis); the
+    identically-named hysds.utils.get_job_status reads lagging ES."""
+    import hysds.log_utils as lu
+
+    assert ooj.is_job_finalized is lu.is_job_finalized

--- a/test/test_watchdog_job_timeouts.py
+++ b/test/test_watchdog_job_timeouts.py
@@ -1,0 +1,240 @@
+import importlib.util
+import logging
+import pathlib
+import sys
+import unittest.mock as umock
+from datetime import datetime, timedelta, timezone
+
+# hysds.celery searches for configuration on import, so mock it before any
+# hysds import. scripts/ is not a package: the watchdog imports its sibling
+# job_utils and (on some platforms) the non-installed `future` package -- stub
+# both before loading it by path. setdefault to avoid cross-test pollution.
+sys.modules.setdefault("hysds.celery", umock.MagicMock())
+sys.modules.setdefault("future", umock.MagicMock())
+sys.modules.setdefault("job_utils", umock.MagicMock())
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "watchdog_job_timeouts", SCRIPTS / "watchdog_job_timeouts.py"
+)
+watchdog = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(watchdog)
+
+
+def _ts(dt):
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _job_doc(
+    status="job-started",
+    time_limit=100000,
+    started_secs_ago=3600,
+    uuid="task-1",
+    tags=None,
+):
+    now = datetime.now(timezone.utc)
+    return {
+        "_id": "payload-1",
+        "_index": "job_status-2026.07.20",
+        "_source": {
+            "status": status,
+            "tags": list(tags or []),
+            "uuid": uuid,
+            "celery_hostname": "worker-1",
+            "job": {
+                "job_info": {
+                    "time_limit": time_limit,
+                    "time_start": _ts(now - timedelta(seconds=started_secs_ago)),
+                }
+            },
+        },
+    }
+
+
+def _task_failed_hit(secs_ago, exception="WorkerLostError('signal 9 (SIGKILL).')"):
+    now = datetime.now(timezone.utc)
+    return [
+        {
+            "_source": {
+                "status": "task-failed",
+                "@timestamp": _ts(now - timedelta(seconds=secs_ago)),
+                "event": {"exception": exception, "traceback": "tb"},
+            }
+        }
+    ]
+
+
+def _wire(
+    monkeypatch,
+    docs,
+    task_hits=None,
+    worker_hits=None,
+    finalized=False,
+    redis_status=None,
+):
+    """Wire the watchdog's collaborators to mocks.
+
+    Returns (write mock, guard mock) -- the guard is a recording mock so
+    tests can assert it was not consulted on paths that must not reach it.
+    """
+    mock_ju = umock.MagicMock()
+    mock_ju.run_query_with_scroll.return_value = docs
+
+    def es_query(query, index=None):
+        if index == "task_status-current":
+            return {"hits": {"hits": task_hits or []}}
+        return {"hits": {"hits": worker_hits or []}}
+
+    mock_ju.es_query.side_effect = es_query
+    monkeypatch.setattr(watchdog, "job_utils", mock_ju)
+    guard = umock.MagicMock(return_value=finalized)
+    monkeypatch.setattr(watchdog, "is_job_finalized", guard)
+    if redis_status is None:
+        redis_status = "job-failed" if finalized else "job-started"
+    monkeypatch.setattr(watchdog, "get_job_status", lambda task_id: redis_status)
+    mock_log = umock.MagicMock()
+    monkeypatch.setattr(watchdog, "log_job_status", mock_log)
+    return mock_log, guard
+
+
+def test_guard_reads_redis_not_es():
+    """Pin the guard's import provenance to hysds.log_utils (redis); the
+    identically-named hysds.utils.get_job_status reads lagging ES."""
+    import hysds.log_utils as lu
+
+    assert watchdog.is_job_finalized is lu.is_job_finalized
+
+
+def test_within_grace_defers(monkeypatch):
+    """AC3: a fresh task-failed event defers to the worker, writes nothing,
+    and does not even consult the guard (a loop-top guard would)."""
+    mock_log, guard = _wire(
+        monkeypatch, [_job_doc()], task_hits=_task_failed_hit(secs_ago=30)
+    )
+    watchdog.tag_timedout_jobs("http://es", 300, grace_secs=300)
+    mock_log.assert_not_called()
+    guard.assert_not_called()
+
+
+def test_within_grace_defers_even_when_tag_eligible(monkeypatch):
+    """The deferral must skip the tag lane too: a doc past its time_limit
+    inside the grace window still gets NO write (any write re-stamps
+    @timestamp and re-arms the sweep clock)."""
+    mock_log, guard = _wire(
+        monkeypatch,
+        [_job_doc(time_limit=600, started_secs_ago=3600)],
+        task_hits=_task_failed_hit(secs_ago=30),
+    )
+    watchdog.tag_timedout_jobs("http://es", 300, grace_secs=300)
+    mock_log.assert_not_called()
+    guard.assert_not_called()
+
+
+def test_past_grace_reaps(monkeypatch):
+    """AC5: a genuinely lost worker is still reaped once the grace elapses."""
+    mock_log, guard = _wire(
+        monkeypatch, [_job_doc()], task_hits=_task_failed_hit(secs_ago=600)
+    )
+    watchdog.tag_timedout_jobs("http://es", 300, grace_secs=300)
+    mock_log.assert_called_once()
+    written = mock_log.call_args[0][0]
+    assert written["status"] == "job-failed"
+    assert "WorkerLostError" in written["error"]
+    assert written["traceback"] == "tb"
+
+
+def test_finalized_job_skipped(monkeypatch, caplog):
+    """AC2: past the grace, the redis guard declines a finalized job -- and
+    a stale non-terminal ES doc is surfaced as a DIVERGENCE health signal."""
+    mock_log, guard = _wire(
+        monkeypatch,
+        [_job_doc()],
+        task_hits=_task_failed_hit(secs_ago=600),
+        finalized=True,
+    )
+    with caplog.at_level(logging.INFO):
+        watchdog.tag_timedout_jobs("http://es", 300, grace_secs=300)
+    mock_log.assert_not_called()
+    assert "DIVERGENCE" in caplog.text
+    assert "divergence_count=1" in caplog.text
+
+
+def test_grace_configurable(monkeypatch):
+    """AC3: the grace period is honored from the CLI flag value."""
+    mock_log, guard = _wire(
+        monkeypatch, [_job_doc()], task_hits=_task_failed_hit(secs_ago=30)
+    )
+    watchdog.tag_timedout_jobs("http://es", 300, grace_secs=10)
+    mock_log.assert_called_once()
+
+
+def test_missing_task_timestamp_fails_open(monkeypatch):
+    """A task doc without @timestamp must not disable reaping (guard still
+    consulted)."""
+    hit = _task_failed_hit(secs_ago=600)
+    del hit[0]["_source"]["@timestamp"]
+    mock_log, guard = _wire(monkeypatch, [_job_doc()], task_hits=hit)
+    watchdog.tag_timedout_jobs("http://es", 300, grace_secs=300)
+    mock_log.assert_called_once()
+
+
+def test_malformed_task_timestamp_fails_open(monkeypatch):
+    """A non-string @timestamp must neither defer forever nor abort the
+    sweep -- it falls through to the redis guard."""
+    hit = _task_failed_hit(secs_ago=600)
+    hit[0]["_source"]["@timestamp"] = 12345
+    mock_log, guard = _wire(monkeypatch, [_job_doc()], task_hits=hit)
+    watchdog.tag_timedout_jobs("http://es", 300, grace_secs=300)
+    mock_log.assert_called_once()
+
+
+def test_timedout_tagging_guarded(monkeypatch, caplog):
+    """AC2: the tag-only path republishes the whole stale _source (including
+    status), so it must decline on a finalized job. A consistent decline
+    (redis and ES both job-offline) is NOT a divergence."""
+    mock_log, guard = _wire(
+        monkeypatch,
+        [_job_doc(status="job-offline", time_limit=600, started_secs_ago=3600)],
+        finalized=True,
+        redis_status="job-offline",
+    )
+    with caplog.at_level(logging.INFO):
+        watchdog.tag_timedout_jobs("http://es", 300, grace_secs=300)
+    mock_log.assert_not_called()
+    assert "DIVERGENCE" not in caplog.text
+
+
+def test_job_offline_docs_still_enter_the_loop(monkeypatch):
+    """Guard-placement regression: a top-of-loop guard would silently
+    disable the whole job-offline tagging lane."""
+    mock_log, guard = _wire(
+        monkeypatch,
+        [_job_doc(status="job-offline", time_limit=600, started_secs_ago=3600)],
+        finalized=False,
+    )
+    watchdog.tag_timedout_jobs("http://es", 300, grace_secs=300)
+    mock_log.assert_called_once()
+    written = mock_log.call_args[0][0]
+    assert "timedout" in written["tags"]
+    assert written["status"] == "job-offline"
+
+
+def test_partial_source_doc_does_not_abort_sweep(monkeypatch):
+    """One malformed document must not strand jobs later in the scroll."""
+    partial = {"_id": "payload-0", "_index": "job_status-2026.07.20", "_source": {}}
+    good = _job_doc(status="job-offline", time_limit=600, started_secs_ago=3600)
+    mock_log, guard = _wire(monkeypatch, [partial, good], finalized=False)
+    watchdog.tag_timedout_jobs("http://es", 300, grace_secs=300)
+    mock_log.assert_called_once()
+    assert "timedout" in mock_log.call_args[0][0]["tags"]
+
+
+def test_non_numeric_time_limit_does_not_abort_sweep(monkeypatch):
+    """A doc whose time_limit is null/string must be skipped like any other
+    partial doc instead of raising past the per-doc handler."""
+    bad = _job_doc(status="job-offline", time_limit=None, started_secs_ago=3600)
+    good = _job_doc(status="job-offline", time_limit=600, started_secs_ago=3600)
+    mock_log, guard = _wire(monkeypatch, [bad, good], finalized=False)
+    watchdog.tag_timedout_jobs("http://es", 300, grace_secs=300)
+    mock_log.assert_called_once()
+    assert "timedout" in mock_log.call_args[0][0]["tags"]


### PR DESCRIPTION
## Summary

- **Bug.** A failed job's authoritative `job-failed` document -- real error, exit code, `duration`, and the `products_staged` entry that points at the triage dataset -- gets silently overwritten by a *supervisory* process that rebuilt the document from a stale `job-started` snapshot it read straight from OpenSearch (OS). It is a read-side race against the worker's own in-flight write.
- **Impact** (measured on one NISAR OPS cluster, ~4 months): **1,356 damaged docs** (529 from `event_processors`, 827 from the watchdog); **none** kept their `duration`. The triage *products* were fine in GRQ/S3 -- only the pointer to them was destroyed, so failures render in Figaro with no triage link and no metrics.
- **Fix.** Before any supervisory write, consult the **synchronous redis status key** the worker already sets race-free (and that nothing read until now); give the watchdog a grace period timed from the failure event; and derive that redis key's TTL from the job's own `time_limit` so it can't expire mid-run.
- **Proven on a live cluster.** With the race forced deterministically, the buggy build clobbers and the fixed build stays healthy; a genuinely dead worker is still reaped within the specified bound; and the reviewer's 2-million-doc backlog concern was reproduced and answered. 50 new unit tests.
- **Ships with HC-638** (picklable exceptions) -- required, see the **Release coupling** section below.

## Two tickets, one PR

| Ticket | What it is |
|---|---|
| [HC-639] | Failed job docs lose their triage link and metrics when a supervisory writer overwrites them from a stale `job-started` source. **This is the fix.** |
| [HC-638] | `WorkerExecutionError` / `OrchestratorExecutionError` are unpicklable, so celery substitutes `UnpickleableExceptionWrapper` in the result, the event, and the traceback. Small change, but it **must ship in the same release** as HC-639 -- see the **Release coupling** section below. |

---

## The bug in one picture

A failed job has exactly **one** authoritative writer: the verdi worker -- the process that actually ran the job. It catches the failure, runs triage, and logs a complete `job-failed` document, which travels an **asynchronous** pipeline to OS (`redis list -> logstash -> OS`, ~1s).

The worker is not the only writer, though. Several **supervisory writers** run alongside it -- background daemons that never ran the job themselves, but monitor job state and write a status document *on the worker's behalf* when they decide a job has failed or gone missing. Two are in this hot path:

- **`event_processors.fail_job`** -- fires on a celery `task-failed` event, to record failures a genuinely lost worker never got to report;
- **`scripts/watchdog_job_timeouts.py`** -- periodically sweeps OpenSearch for jobs still marked running past their timeout, and reaps them.

(`scripts/offline_orphaned_jobs.py` is the same pattern, run manually.) Each reads job state **directly from OS** and writes a whole document back. If one reads before the worker's own document is searchable, it rebuilds the job from the stale `job-started` snapshot and overwrites everything the worker recorded.

```mermaid
sequenceDiagram
    participant W as verdi worker
    participant R as redis
    participant L as logstash
    participant OS as OpenSearch job_status
    participant P as process_events

    Note over W: PGE fails. Worker catches it,<br/>runs triage, builds complete<br/>job-failed doc with metrics
    W->>R: SETEX status key = job-failed (synchronous)
    W->>R: RPUSH good doc (asynchronous)
    W--)P: celery task-failed event
    Note over P: RC1 regex false-match routes this<br/>handled failure into the lost-worker lane
    P->>OS: read job doc by uuid
    OS-->>P: stale job-started _source
    R-->>L: drain list
    L->>OS: index good job-failed doc
    Note over P: RC3 rebuild whole doc<br/>from the stale _source
    P->>R: RPUSH bad doc
    R-->>L: drain list
    L->>OS: bad doc replaces good doc<br/>metrics and triage link gone
```

Two facts make this subtle:

1. **Only the read is contested.** Every writer enqueues through the same redis list, so the bad document always lands *after* the good one. Nothing races at write time -- what races is whether the supervisory OS *read* beats the good document becoming searchable. When it loses, the rewrite is total (it rebuilds the whole doc), so metrics that were never in the stale `_source` cannot survive.
2. **The race-free path already existed and nobody used it.** The same `log_job_status()` call that enqueues the OS document also does a synchronous `SETEX` of the status onto a redis *key*. That key is correct the instant the worker finalizes. Consulting it is the whole fix.

## Why it happens -- three root causes

None of the three is a recent regression -- they have been latent in the supervisory-write paths since early in the codebase, which is why the damage accrued slowly and went unnoticed.

**RC1 -- a regex false-match opens the racing lane.** `TASK_FAILED_RE` decides which task-failed events mean "the worker had no chance to report". With no word boundary, `SoftTimeLimitExceeded` (a failure the worker fully handles and triages) matches `TimeLimitExceeded` and is routed into `fail_job`, which then races the worker's own in-flight document.

| event `exception` string | should enter `fail_job` | old regex | new regex |
|---|---|---|---|
| `WorkerExecutionError('SoftTimeLimitExceeded()')` | no | **yes** | no |
| `SoftTimeLimitExceeded()` | no | **yes** | no |
| `TimeLimitExceeded(3600,)` | yes | yes | yes |
| `WorkerLostError('...signal 9 (SIGKILL).')` | yes | yes | yes |
| `ConnectionError('Error 111 connecting to redis')` | yes | yes | yes |

The pattern gains a `(?<![A-Za-z])` lookbehind and moves into `hysds.event_processors` so it is importable and unit-tested; `scripts/process_events.py` imports it. (HC-638 alone does **not** close this lane -- the fixed string still contains the substring `TimeLimitExceeded`.)

**RC2 -- the watchdog is always armed.** Its eligibility clock runs from the `job-started` document's `@timestamp` (job *start* time), so any job older than the threshold is permanently eligible and re-swept every interval -- with zero grace once a task-failed event appears.

```mermaid
flowchart LR
    A["job-started doc<br/>@timestamp = job START time"] -->|"older than threshold<br/>= eligible"| B["permanently eligible,<br/>re-swept every interval"]
    B --> C{"task-failed<br/>event exists?"}
    C -->|"yes: first sweep, zero grace"| D["rewrite from stale _source"]
    C -->|no| B
```

Fix: a grace period measured **from the task-failed event** (`-g/--grace-secs`, default 300), plus the RC3 guard.

**RC3 -- every supervisory write was an unguarded read-modify-write.** Five write sites rebuilt whole documents from a stale `_source` with no concurrency control: `event_processors.fail_job`; the watchdog's transition write; the watchdog's *tag-only* write (which republishes the entire stale doc -- `status: job-started` included -- just to append a `timedout` tag, silently reverting a finished job); and both writes in `scripts/offline_orphaned_jobs.py`.

## The fix -- a gate in front of every supervisory write

The fix adds two checks in front of every supervisory write. Two shorthands, used from here on and in the tables below:

- **guard** -- the new `hysds.log_utils.is_job_finalized(task_id)`. It reads the *synchronous* redis status key (the one the worker [`SETEX`s the instant it finalizes](https://github.com/hysds/hysds/blob/ca436500300e50f71b30cdcf525154344c1ba596/hysds/log_utils.py#L294-L298)) to answer one question: *has the worker already written a terminal status for this job?* Every supervisory write consults it immediately before writing (never at loop top).
- **grace** -- the watchdog's new `-g/--grace-secs` wait (default 300s), measured from the task-failed event. It gives the worker's own document time to travel the async pipeline before the watchdog even considers acting.

The watchdog applies **both** gates; the other supervisory writers apply **only the guard**. The flow below is the **watchdog's** -- the most complex case, since it is the only one with a grace period and a tag lane:

```mermaid
flowchart TD
    A["watchdog's periodic OpenSearch scan<br/>turns up a job past its timeout"] --> B{"job document<br/>well-formed?"}
    B -->|no| B1["skip it and keep sweeping<br/>(one bad doc no longer<br/>aborts the whole sweep)"]
    B -->|yes| C{"is there a task-failed<br/>event for this job?"}

    C -->|yes| D{"has the grace period elapsed<br/>since that failure event?"}
    D -->|"not yet"| D1["defer -- write nothing<br/>(any write re-stamps @timestamp<br/>and restarts the sweep clock)"]
    D -->|"yes"| E{"does redis say the worker<br/>already finished this job?"}
    E -->|"yes"| E1["decline -- the worker's doc wins<br/>(log DIVERGENCE + divergence_count)"]
    E -->|"no, or key missing<br/>(fail open)"| F["reap -- write job-failed"]

    C -->|no| G{"did the job run past<br/>its time_limit?"}
    G -->|"yes"| H{"does redis say the worker<br/>already finished this job?"}
    H -->|"yes"| H1["decline -- tagging would republish<br/>the whole stale document"]
    H -->|"no, or key missing"| I["append the timedout tag"]

    classDef added fill:#2da44e,stroke:#1a7f37,stroke-width:2px,color:#ffffff;
    class B,B1,D,D1,E,E1,H,H1 added;
```

*Green = **added** by this PR (the guard, the grace period, the parse-hardening). The new checks are inserted around unchanged pre-existing boxes (the scan, the task-failed-event routing, the `job-failed` transition, the time_limit check, and the `timedout` tag write), so nothing in the watchdog was modified in place.*

The **event-driven** writer is much simpler. When a `task-failed` event clears the RC1 regex, `process_events.py` calls `event_processors.fail_job`, which runs the guard alone -- the same `is_job_finalized` check: a terminal redis key -> decline, otherwise write `job-failed`. It has no grace gate and no tag lane, and needs neither: the regex ensures only genuine lost-worker events reach it, and a lost worker never wrote a terminal status, so there is nothing in flight to wait for. `scripts/offline_orphaned_jobs.py` likewise applies only the guard, before each of its writes.

```mermaid
flowchart TD
    A["celery task-failed event arrives"] --> B{"does the exception match<br/>TASK_FAILED_RE?<br/>(a genuine lost-worker signature)"}
    B -->|"no -- e.g. SoftTimeLimitExceeded,<br/>now correctly excluded"| B1["ignore -- the worker<br/>handles and logs this itself"]
    B -->|yes| C{"does redis say the worker<br/>already finished this job?"}
    C -->|"yes"| C1["decline -- the worker's doc wins<br/>(log, do not overwrite)"]
    C -->|"no, or key missing<br/>(fail open)"| D["reap -- write job-failed<br/>+ requeue rule evaluation"]

    classDef added fill:#2da44e,stroke:#1a7f37,stroke-width:2px,color:#ffffff;
    classDef modified fill:#0969da,stroke:#0a3069,stroke-width:2px,color:#ffffff;
    class C,C1 added;
    class B modified;
```

*Blue = **modified** -- the pre-existing RC1 regex gained a word boundary (B). Green = **added** -- `fail_job`'s guard and its decline (C, C1). The event trigger and the write are pre-existing.*

The guard **fails open**: a missing key or a redis error means "proceed", because the watchdog is the last backstop for genuinely lost workers -- absence of evidence must not disable it. One more hole is closed alongside: the redis key's `SETEX` TTL is now `max(HYSDS_JOB_STATUS_EXPIRES, time_limit + 2 x HARD_TIME_LIMIT_GAP)`, so for long job types (e.g. `time_limit` >= the 86400s default expiry) the key no longer expires mid-run and leaves the guard blind.

### Changes by file

**HC-638 -- picklable exceptions**
- `hysds/job_worker.py` (`WorkerExecutionError`) and `hysds/orchestrator.py` (`OrchestratorExecutionError`): `job_status` defaults to `None`. Celery rebuilds exceptions via `cls(*exc.args)`. HC-582 had moved `job_status` out of `args` to shrink oversized tracebacks (they were exceeding 700KB), but it stayed a required constructor parameter, so `cls(*args)` raised `TypeError` and celery substituted `UnpickleableExceptionWrapper`. Defaulting the parameter keeps HC-582's smaller `args` (traceback-size contract preserved and tested) while letting reconstruction succeed. Dead `job_status(self)` methods removed from both classes and from `JobDedupedError`.

**HC-639 -- close the races**
- `hysds/log_utils.py`: `TERMINAL_JOB_STATUSES` + `is_job_finalized()`; TTL derived from the job's `time_limit`.
- `hysds/event_processors.py`: bounded `TASK_FAILED_RE`; `is_job_finalized` early-return in `fail_job`.
- `scripts/process_events.py`: imports the shared regex.
- `scripts/watchdog_job_timeouts.py` -- the watchdog gets the grace period and the guard, plus two robustness fixes:
    - new `-g/--grace-secs` flag sets the grace period (default 300s);
    - the sweep's query now also pulls the task-failed event's `@timestamp`, which the grace check needs to know how long ago the failure happened;
    - the grace check and the guard both run immediately before each of the watchdog's two writes -- the one that transitions a job to `job-failed`, and the one that appends the `timedout` tag;
    - when redis says a job finished but OpenSearch still shows it running, the watchdog logs a `DIVERGENCE` warning and tallies these per sweep (`divergence_count`) instead of overwriting the job;
    - each candidate document is now parsed defensively, so a single malformed document is skipped instead of aborting the entire sweep.
- `scripts/offline_orphaned_jobs.py` -- the same guard added before both of its write sites. It runs *before* the `--dry_run` check, so a dry run reports the decision a real run would actually make (including "declined"), not a plan the guard would later veto.
- `hysds/job_worker.py` -- one-line fix in the dedup path for a redelivered job (under `ENABLE_JOB_LOCKING`): the redis status key is now written under `task_id` instead of `job_id`. Every reader, the guard included, looks the key up by `task_id`, so the old `job_id` key was one nobody ever read -- meaning the guard could never tell that these jobs had already finished.

<details>
<summary><b>Edge cases considered</b> (click)</summary>

*Reminder:* **guard** = the `is_job_finalized(task_id)` redis check; **grace** = the `--grace-secs` wait after the failure event (both defined in **The fix** section above).

| Edge case | Pre-fix | With this PR |
|---|---|---|
| Soft-limit failure, worker alive and finishing | RC1 mislabels it; `fail_job` races the in-flight doc | regex no longer matches; if the lane is reached anyway, the guard declines |
| Long job at the TTL boundary (`time_limit` >= `HYSDS_JOB_STATUS_EXPIRES`) | redis key expires mid-run -> guard would see "no key" and proceed | TTL now derived from `time_limit`; key outlives the job |
| Genuinely lost worker (SIGKILL, spot reclaim, hard limit) | reaped (correct) | still reaped: fail-open guard; grace delays reaping by at most grace + one interval |
| Finished job swept by the tag-only path | whole stale `_source` republished; terminal status reverts to `job-started` | guard immediately before the tag write |
| Grace-deferral bookkeeping | n/a | the deferral path writes nothing -- any `log_job_status()` would re-stamp `@timestamp` and reset the doc's own clock |
| Malformed / partial job doc in the sweep | one bad subscript aborts the whole sweep | per-doc parse hardened; doc skipped, sweep continues |
| redis terminal while OS stuck at `job-started` (dropped logstash write) | unguarded watchdog "repaired" it invisibly by rewriting | guard declines + logs `DIVERGENCE` + `divergence_count` (the detector; reconcile arm deferred, see below) |
| transient `queue_finished_job` failure inside `fail_job` | n/a | guard runs once, OUTSIDE the backoff-retried body -- a retried guard would read the key its own first attempt wrote and drop the requeue |
| `ConnectionError` event for a live, already-finalized worker | document rewritten | guard declines |

</details>

---

## Validation on a live cluster

Everything below ran on `nisar-gmanipon-1628` (post-RSO) on hysds **v6.4.0 = the unfixed build**, against a snapshot-restored, read-only copy of the OPS FWD corpus (`job_status-*` 4.9M docs, `job_failed` 73,837, `task_status-*` 6.45M). The fix is mozart-side, so each iteration was a file swap + `supervisorctl restart` -- seconds, no redeploy.

**How the race was made deterministic:** freeze the *reader*. `refresh_interval: -1` on the index the job names in `job_info.index` **and** on `job_failed` (logstash reroutes a `job-failed` doc into `job_failed`, so stalling only the dated index would leave the good doc visible and the clobber would never fire). Every iteration asserts the stall actually took, else it scores VOID -- never PASS.

### PRE/POST -- the headline result

Identical scenario, `stall_effective: true` in both, only the build differs:

| Run | Build | `duration` | `len(tags)` | `_version` | `products_staged` | Outcome |
|---|---|:--:|:--:|:--:|---|---|
| control (fast failure, no stall) | buggy | 222.03 | 1 | 2 | `[triaged_job-…]` | HEALTHY |
| **PRE** (`soft=120`, stalled) | buggy | **absent** | 3 | 8 | **`[]`** | **CLOBBERED** |
| **POST** (identical, stalled) | fixed | present | 1 | 2 | **`[triaged_job-…]`** | **HEALTHY** |

`short_error` also flipped from the celery-event elision `WorkerExecutionError.....ceeded()')` back to the worker's real `SoftTimeLimitExceeded()`, and the exit code (255) survived. The clobbered fingerprint (`_version` high, array `id`, `len(tags)` grown) is the same direction seen in production; it reads `_version 8` here because the stall was held across several 60s watchdog ticks.

### The watchdog, PRE vs POST (cleanest pair -- one log file)

Pre-fix the watchdog didn't clobber once -- it rewrote the doc on **every** 60s sweep, which is what drove that document to `_version 8`:

```
17:02:02  Set job ddd73b3f... to job-failed via log_job_status().
17:02:57  Set job ddd73b3f... to job-failed via log_job_status().
17:03:58 / 17:05:13 / 17:06:17   (five rewrites, one per tick)
```

Post-fix, the same situation **defers** (a positive log line, not a silent absence -- a guard that imported the wrong `get_job_status` would also produce "0 clobbers", so absence would prove nothing):

```
17:23:48  Job ea000018...: task-failed 32s ago, within 300s grace; deferring to the worker.
```

### AC5 -- the grace delays reaping, it does not strand

The most important regression risk: a guard *without* a grace would strand genuinely dead jobs forever, since the watchdog is the last backstop. A job whose worker was SIGKILLed mid-cleanup (task failed `17:23:17`):

```
17:23:48  task-failed  32s ago, within 300s grace; deferring to the worker.
17:25:02 / 17:25:48 / 17:26:35 / 17:27:46   (age counting up)
17:28:34  Set job ea000018... to job-failed via log_job_status().   <-- REAPED
```

Reaped **317s** after the failure = grace (300s) + one poll interval (60s) -- exactly the specified bound. Bounded and observable.

### Split arms -- neither fix is masking the other

With the regex in, `fail_job` never runs on this path, so a clean POST says nothing about the guard. Each arm ran with the *other* fix disabled, each with a positive assertion:

| Arm | Config | Outcome | Positive assertion |
|---|---|---|---|
| guard-only | regex reverted | HEALTHY | `fail_job` ran, then declined |
| regex-only | guard forced False | HEALTHY | `fail_job` ran **0** times |

`fail_job` was invoked exactly once in the whole campaign -- the guard-only decline:

```
fail_job - 879bf66c-...: worker already finalized this job; not overwriting.
exc=WorkerExecutionError('SoftTimeLimitExceeded()'), short_error=TimeLimitExceeded
```

That one line carries three facts: `short_error=TimeLimitExceeded` is **RC1 caught in the act** (`match.group(1)` pulling the token out of the soft-limit string); `fail_job` genuinely executed (guard on the live path); and it declined. It also **excludes the import trap**: the stall was active, so OS read `job-started` at that instant -- a guard wired to `hysds.utils.get_job_status` (the OS reader) would have clobbered. It declined, so it is provably reading the synchronous redis key under production conditions.

### Reviewer concern: does a timer survive a deep backlog?

> *"I'm concerned about a timer based solution here. What if there are a million docs in the redis-list -> logstash -> ES pipeline queue? We have hit 2 million on OPERA."* -- @stirlingalgermissen

Right concern, and a fixed timer alone would **not** survive it. It isn't alone: the grace timer is the *first* of two gates; the load-bearing one is the redis guard, which reads a synchronous **key** that never enters the pipeline. I reproduced the exact 2M scenario -- `logstash_indexer` stopped (an unbounded backlog, worse than 2M), 2,000,000 entries pushed onto the `logstash` list, then a probe soft-limited so its terminal doc's `RPUSH` sits behind the 2M while OS still serves `job-started`:

```json
{ "list_backlog_depth": 2004230,
  "redis_key_get_job_status": "job-failed",
  "guard_is_job_finalized": true,
  "ES_doc_status": "job-started" }
```

It holds because `log_job_status()` writes the status **twice** -- `SETEX` on a key, `RPUSH` on the list. The backlog is the *list*; the guard does a `GET` on the *key*. Different data structures; a `GET` is O(1) and cannot be delayed by `LLEN`. A deeper queue makes OS *more* stale, i.e. makes the guard *more* necessary and no less effective. With the grace deliberately expired (aged task-failed injected 600s back), the watchdog declined every sweep and emitted `divergence_count=1`; when the 2M drained, the worker's doc landed intact (`_version 2`, `duration 124.9`, triage link present). The one residual -- the key *expiring* mid-run -- is closed by the `time_limit`-derived TTL above. (The `sleep()` change mentioned is HC-633, already on develop and inherited here.)

<details>
<summary><b>Backlog experiment -- full writeup</b> (click)</summary>

**Setup.** `nisar-gmanipon-1628`, hysds fix installed. `logstash_indexer` STOPPED (pipeline frozen = the limiting case of an unbounded backlog), then 2,000,000 dummy entries LPUSHed onto the `logstash` list to match the exact number cited. A probe job was soft-limited so the worker wrote its terminal `job-failed` document -- whose RPUSH now sits behind the 2M-deep backlog, undrained, while its `job-started` document (indexed before the freeze) is what OS still serves.

**The measurement.**
```json
{ "list_backlog_depth": 2004230,
  "resolved_task_id": "d6d0a919-18ee-44d1-8b93-3699d71844bc",
  "redis_key_get_job_status": "job-failed",
  "guard_is_job_finalized": true,
  "ES_doc_status": "job-started",
  "ES_products_staged": [] }
```

**Why the backlog cannot reach the guard.** `log_job_status()` (`hysds/log_utils.py`):
```python
r.setex(JOB_STATUS_KEY_TMPL % job["uuid"], ttl, job["status"])  # KEY  hysds-job-status-<task_id>
r.rpush(app.conf.REDIS_JOB_STATUS_KEY, msgpack.dumps(...))       # LIST "logstash"
```
The guard (`is_job_finalized` -> `get_job_status`) does `GET` on the **key**. The backlog is the **list**. A `GET` on the key is O(1) and cannot be delayed by `LLEN`.

**End-to-end, grace expired, under the 2M backlog.** An aged (600s) `task-failed` was indexed so the watchdog's transition path ran with the grace **already expired** -- the purest form of the objection:
```
23:22:04 WARNING watchdog_job_timeouts: Job 00202dcb-...: DIVERGENCE redis=job-failed es=job-started; declining rewrite.
23:22:04 WARNING watchdog_job_timeouts: divergence_count=1 docs with a terminal redis status but a stale non-terminal ES doc this sweep
23:23:06 WARNING watchdog_job_timeouts: Job 00202dcb-...: DIVERGENCE redis=job-failed es=job-started; declining rewrite.
```

**After the pipeline drains.** The 2M dummies were removed by exact value (`LREM`; the 6,652 real entries untouched) and `logstash_indexer` restarted. The worker's terminal document landed intact:
```json
{ "_index": "job_failed", "_version": 2, "status": "job-failed",
  "short_error": "SoftTimeLimitExceeded()", "duration": 124.945009, "exit_status": 255,
  "products_staged": ["triaged_job-probe-soft120-sleep300-...-task-d6d0a919-..."],
  "len_tags": 1, "id_type": "scalar", "traceback_has_wrapper": false }
```
Clean worker-written fingerprint, no clobber, after a 2M-deep backlog that outlasted the grace entirely.

</details>

### HC-638 -- verdi-side (worker) pickling

The mozart hot-patch can't reach `job_worker.py`/`orchestrator.py` (they run on the worker), so this was validated separately against the **deployed** hysds via `get_pickleable_exception` -- exactly celery's own call when recording a task failure.

| exception | deployed v6.4.0 (PRE) | after HC-638 (POST) |
|---|---|---|
| `WorkerExecutionError` | `pickle.loads` fails (`TypeError`) -> `UnpickleableExceptionWrapper` | `pickle.loads` OK -> `WorkerExecutionError` |
| `OrchestratorExecutionError` | fails -> `UnpickleableExceptionWrapper` | OK -> `OrchestratorExecutionError` |

So the task-failed event and traceback now carry the real class instead of the wrapper. (Run on factotum's writable `hysdsops` tree; the container worker runs celery as root and can't be hot-patched.)

### Unit tests

**50 new tests** across `test_exceptions.py`, `test_log_utils.py`, `test_event_processors.py`, `test_watchdog_job_timeouts.py`, `test_offline_orphaned_jobs.py`, each proven to fail on the parent commit where it targets changed behavior. Hardened against an adversarial mutation pass: the within-grace deferral is tested with a *tag-eligible* doc (kills a "log the deferral by tagging" mutant); the guard is a recording mock asserted *not* consulted during deferral (kills a loop-top-guard mutant); the backoff self-arm is covered end-to-end; and import-provenance pins tie `is_job_finalized` to `hysds.log_utils` (redis, not the identically-named OS reader in `hysds.utils`) and `process_events.py` to the shared regex object.

<details>
<summary><b>Test output + corpus census + raw run records</b> (click)</summary>

**Suite** (green; two pre-existing macOS-only `test_disk_usage` failures unrelated to this diff, verified failing on the parent of commit 1):
```
--- lock tests (isolated, per CI) ---    20 passed in 16.34s
--- all other tests ---                  2 failed, 124 passed, 1 skipped   (the 2 = pre-existing macOS test_disk_usage)
--- new test files ---                   50 passed in 0.91s
```

**Corpus census that sized the problem** (`b1`):
```
job-failed total                                        73837
job-failed missing duration                             5762
wrapper docs (damaged, HC-638 handle)                   1356
wrapper AND has duration (expect 0)                     0
-- writer cross-tab (perfect partition, 0 crossover) --
wrapper + time_end (event_processors)                   529
wrapper + NO time_end (watchdog)                        827
CROSSOVER (expect 0 / 0)                                0 / 0
-- context: missing-duration outside the wrapper cohort (separate cause, not clobber) --
failed, no duration, NOT wrapper                        4406
-- fingerprint: damaged vs clean (n=60 each) --
damaged: _version=3 len(tags)=2 id=array
clean  : _version=2 len(tags)=1 id=scalar
```

**Per-run records** (`rc_results.jsonl`, 5 runs). `POST-rc1` is reported AMBIGUOUS, not dropped: its worker was replaced by the ASG mid-run so it never reached the scripted failure -- the harness refuses to count a run that didn't reproduce the conditions.
```json
{"label":"PRE-rc1","stall_effective":true,"final":{"index":"job_failed","version":8,"status":"job-failed","short_error":"WorkerExecutionError.....ceeded()')","has_duration":false,"exit_status":null,"products_staged":[],"len_tags":3,"id_array":true,"wrapper":true},"outcome":"CLOBBERED"}
{"label":"POST-rc1","stall_effective":true,"final":{"index":"job_status-2026.07.21","version":2,"status":"job-started","len_tags":1,"id_array":false,"wrapper":false},"outcome":"AMBIGUOUS"}
{"label":"POST-rc1b","stall_effective":true,"final":{"index":"job_failed","version":2,"status":"job-failed","short_error":"SoftTimeLimitExceeded()","has_duration":true,"exit_status":255,"products_staged":["triaged_job-...-task-fd582741-..."],"len_tags":1,"id_array":false,"wrapper":false},"outcome":"HEALTHY"}
{"label":"GUARDONLY","stall_effective":true,"final":{"index":"job_failed","version":2,"status":"job-failed","short_error":"SoftTimeLimitExceeded()","has_duration":true,"exit_status":255,"products_staged":["triaged_job-...-task-879bf66c-..."],"len_tags":1,"wrapper":false},"outcome":"HEALTHY"}
{"label":"REGEXONLY","stall_effective":true,"final":{"index":"job_failed","version":2,"status":"job-failed","short_error":"SoftTimeLimitExceeded()","has_duration":true,"exit_status":255,"products_staged":["triaged_job-...-task-8fe27bbc-..."],"len_tags":1,"wrapper":false},"outcome":"HEALTHY"}
```

**Watchdog decision log** (`p4_watchdog_decisions.log`) -- pre-fix clobbers, post-fix grace deferrals, the bounded reap:
```
17:02:02 .. 17:06:17   Set job ddd73b3f... to job-failed via log_job_status().   (x5, pre-fix clobbers)
17:23:48 .. 17:27:46   Job ea000018...: task-failed <n>s ago, within 300s grace; deferring to the worker.   (x5)
17:28:34               Set job ea000018... to job-failed via log_job_status().   (reaped at +317s)
```

</details>

---

## Release coupling

**HC-638 and HC-639 must ship in the same release.** HC-638 removes the `UnpickleableExceptionWrapper` string -- which is the only search handle operators use to find already-damaged documents. That handle exists only because the HC-582 change caused the wrapper substitution in the first place, so the same behavior that produced HC-638 is what gives HC-639's damage its one fingerprint. Shipping HC-638 first would erase that fingerprint while leaving the data loss in place. The CHANGELOG records this. Merged together, reverted together, tested as the one configuration that ships.

This PR cuts **hysds 3.3.1** (`hysds/__init__.py` + the `[3.3.1]` CHANGELOG section).

## Deferred: the auto-reconcile arm (decided, not pending)

This PR ships the divergence **detector** (the watchdog warning + `divergence_count`). It does **not** ship an automatic reconcile that rewrites a diverged doc, and that is a deliberate decision:

- On the restored OPS corpus the OS-side strand proxy (a job doc non-terminal while its `task_status` is terminal) returned **1 doc in 4.9M**. But that number is weak on purpose: it's an instantaneous *stock* taken with the unguarded watchdog's clobber-repair still warm, and the OS-only proxy is biased *toward* "no strand". The true population (redis-terminal + OS-non-terminal) can't be measured on a dev corpus with an empty redis -- which is exactly what the shipped **detector** now measures live.
- A lost `job-failed` write **self-heals**: once the redis key expires the guard fails open and the watchdog reaps normally -- a delay, not a correctness loss. A lost `job-completed` write does **not** self-heal (the watchdog only ever transitions to failed/offline), but the only component with a completed arm (`scripts/offline_orphaned_jobs.py`) is manual and in no supervisord template.
- **Revisit trigger:** a non-zero `divergence_count` in production, or any observed lost `job-completed`, makes the reconcile arm required.

## Still outstanding before merge

- [ ] HC-638's `job_worker.py`/`orchestrator.py` hunks are verdi-side and were validated via the deployed pickling path, not a full worker job run -- confirm on a factotum-queued (host-celery) job type if desired.
- [ ] Reviewers: two approvals, one explicitly signing off on AC5.

[HC-639]: https://hysds-core.atlassian.net/browse/HC-639
[HC-638]: https://hysds-core.atlassian.net/browse/HC-638



