### PR TITLE
HC-641: Properly expand env vars in runtime_options for podman

### DIFF
--- a/hysds/__init__.py
+++ b/hysds/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "3.3.1"
+__version__ = "3.3.2"
 __url__ = "https://github.com/hysds/hysds"
 __description__ = "HySDS (Hybrid Cloud Science Data System)"

--- a/hysds/containers/podman.py
+++ b/hysds/containers/podman.py
@@ -121,6 +121,8 @@ class Podman(Base):
 
         # add runtime options
         for k, v in params["runtime_options"].items():
+            if isinstance(v, str):
+                v = os.path.expandvars(v)
             podman_cmd_base.extend([f"--{k}", v])
 
         # add volumes


### PR DESCRIPTION
This PR updates the podman container implementation such that it properly expands environmental variables specified in the runtime_options. Here's an example of what could be specified in a HySDS job spec:
```
  "runtime_options": {
    "env": "HYSDS_ROOT_WORK_DIR=$HYSDS_ROOT_WORK_DIR"
  },
```

In testing with SWOT and the HECC environment, which uses podman, I can see that with this update, the $HYSDS_ROOT_WORK is being properly expanded now in the `--env` setting:

```
podman --remote --url unix:/run/user/246851314/podman/podman.sock run --init --rm -e HOST_VERDI_HOME=/nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9 -e HOST_USER=mcayanan -e HOST_UID=246851314 -e HYSDS_ROOT_WORK_DIR=/nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/data/work_0 --passwd-entry=mcayanan:*:246851314:0::/root:/bin/bash --security-opt label=disable --env HYSDS_ROOT_WORK_DIR=/nobackupnfs1/swot/mcayanan/pbs_workspace/w
orkspace/r211c3t7n4-f9d6dea9/data/work_0 -v /run/user/246851314/podman/podman.sock:/run/user/246851314/podman/podman.sock -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/data/work_0/jobs:/nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/data/work_0/jobs -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/data/work_0/tasks:/nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/data/work
_0/tasks -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/data/work_0/workers:/nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/data/work_0/workers -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/data/work_0/cache:/nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/data/work_0/cache:ro -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/verdi/etc/rc_tmpl/:/
home/ops/verdi/ops/swot-pcm/conf/rc_tmpl/:ro -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/verdi/etc/datasets.json:/nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/data/work_0/jobs/2026/07/31/21/18/SCIFLO_L1B_HR_SLC__release-r0.0.0-20260728-L1B_HR_SLC_001_152_169_R-state-config-20260729T173209.45723Z/datasets.json:ro -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/verdi/etc/pge_outputs.yaml:/hom
e/ops/verdi/ops/swot-pcm/conf/pge_outputs.yaml:ro -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/.aws:/home/ops/.aws:ro -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/verdi/etc/pge_configs/:/home/ops/verdi/ops/swot-pcm/swot_chimera/configs/pge_configs/:ro -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/.netrc:/home/ops/.netrc:ro -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7
n4-f9d6dea9/verdi/etc/schema/:/home/ops/verdi/ops/swot-pcm/conf/schema/:ro -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/.netrc-os:/home/ops/.netrc-os:ro -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/verdi/etc/celeryconfig.py:/nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/data/work_0/jobs/2026/07/31/21/18/SCIFLO_L1B_HR_SLC__release-r0.0.0-20260728-L1B_HR_SLC_001_152_169_R-state-config-202607
29T173209.45723Z/celeryconfig.py:ro -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/verdi/etc/settings.yaml:/home/ops/verdi/ops/swot-pcm/conf/settings.yaml:ro -v /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/data/work/s3_cache:/data/work/s3_cache:rw -w /nobackupnfs1/swot/mcayanan/pbs_workspace/workspace/r211c3t7n4-f9d6dea9/data/work_0/jobs/2026/07/31/21/18/SCIFLO_L1B_HR_SLC__release-r0.0.0-20260728-L1B_HR_SLC_001_152_169
_R-state-config-20260729T173209.45723Z container-iems-sds_swot-pcm:release-r0.0.0-20260728 /home/ops/verdi/ops/swot-pcm/swot_chimera/run_sciflo.sh L1B_HR_SLC
```